### PR TITLE
DS 232 Frontend

### DIFF
--- a/etna/home/templates/home/home_page.html
+++ b/etna/home/templates/home/home_page.html
@@ -9,6 +9,38 @@
 
 {% block content %}
 
-<h1>{{ self.title }}</h1>
+{% include 'includes/generic-intro--dark.html' %}
+
+<div class="container pt-4">
+    <h2 class="sr-only">A subheading for the cards (for accessibility purposes)</h2>
+    <ul class="row card-group">
+        {% with children=page.get_children %}
+            {% if children %}
+                {% for child in children %}
+                    {% include 'includes/card-group-secondary-nav.html' %}
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+    </ul>
+    <div class="row">
+        <div class="col-md-12">
+            <h2>Thank you for taking part in this Beta program</h2>
+            <p>A few things to remember before you get started: 
+                <ul>
+                    <li>
+                        You will be viewing an early Beta version of our new website. While we hope everything works you may find some things don't. <a href="#">Tell us</a> if you find a broken link or error page.
+                    </li>
+                    <li>
+                        Please provide regular feedback via the survey links at the top of the page.
+                    </li>
+                    <li>
+                        For any other issues, incuding login problems, please <a href="#">contact us</a> directly.
+                    </li>
+                </ul>
+            </p>
+        </div>
+    </div>
+</div>
+
 
 {% endblock content %}

--- a/etna/home/templates/home/home_page.html
+++ b/etna/home/templates/home/home_page.html
@@ -14,7 +14,7 @@
 <div class="container pt-4">
     <h2 class="sr-only">A subheading for the cards (for accessibility purposes)</h2>
     <ul class="row card-group">
-        {% with children=page.get_children %}
+        {% with children=page.get_children.specific %}
             {% if children %}
                 {% for child in children %}
                     {% include 'includes/card-group-secondary-nav.html' %}

--- a/templates/collections/category_page.html
+++ b/templates/collections/category_page.html
@@ -10,7 +10,7 @@
                 <p>From the well-known to the unusual, browse highlights from The National Archives arts and culture
                     collections.</p>
                 <ul class="row card-group">
-                    {% with children=page.get_children %}
+                    {% with children=page.get_children.specific %}
                         {% if children %}
                             {% for child in children %}
                                 {% include 'includes/card-group-secondary-nav.html' %}
@@ -24,7 +24,7 @@
                 <h2>More Arts and Culture</h2>
                 <p>Find out more about Arts and culture at The National Archives..</p>
                 <ul class="row card-group">
-                    {% with children=page.get_children %}
+                    {% with children=page.get_children.specific %}
                         {% if children %}
                             {% for child in children %}
                                 {% include 'includes/card-group-secondary-nav.html' %}

--- a/templates/collections/explorer_page.html
+++ b/templates/collections/explorer_page.html
@@ -9,7 +9,7 @@
                 <h2>Explore by topic</h2>
                 <p>Discover highlights of The National Archives’ collections.</p>
                     <ul class="row card-group">
-                        {% with children=page.get_children %}
+                        {% with children=page.get_children.specific %}
                             {% if children %}
                                 {% for child in children %}
                                     {% include 'includes/card-group-secondary-nav.html' %}
@@ -22,7 +22,7 @@
                 <p>The National Archives contains over 1,000 years of British historical records. Select a time period
                     to start exploring.</p>
                 <ul class="row card-group">
-                    {% with children=page.get_children %}
+                    {% with children=page.get_children.specific %}
                         {% if children %}
                             {% for child in children %}
                                 {% include 'includes/card-group-secondary-nav-time-period.html' %}

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -8,7 +8,7 @@
                     {# Available to assistive technology #}
                     <span class="sr-only">{{ child.title }}. Covering years <time datetime="974">974</time> to <time datetime="2010">2010</time>.</span>
                 </h3>
-                <p>Description</p>
+                <p>{{child.introduction}}</p>
             </div>
             <div class="card-group-secondary-nav__image">
                 <picture>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -3,7 +3,7 @@
         <a href='{{ child.url }}' class="card-group-secondary-nav__link">
             <div class="card-group-secondary-nav__body">
                 <h3 class="tna-card__heading">{{ child.title }}</h3>
-                <p>Description</p>
+                <p>{{ child.introduction }}</p>
             </div>
             <div class="card-group-secondary-nav__image">
                 <picture>


### PR DESCRIPTION
Hi @gtvj,

Would you be able to look at this PR?

It adds some HTML includes/static content to the homepage to match the UXPin Mockup in 
https://national-archives.atlassian.net/browse/DS-232

I have also changed the  card loops to use `page.get_children.specific`  instead of `page.get_children`, as Dan B let me know that without the `.specific`, you can only access fields on the default Wagtail Page class, instead of the extra fields that have been added to the Page via  the `models.py` file. So in this case,  I have made it so that `{{child.introduction}}` is accessible in the cards, so that their description texts are dynamic.

Here's a screenshot of the homepage with the same  cards as the UXPin:

![image](https://user-images.githubusercontent.com/8880610/123783541-5e300500-d8ce-11eb-810b-a0198b0655ab.png)

Note that in the UXPin, the cards have a "NEW" label next  to them, however we decided this was a nice to  have, so this doesn't need to be accounted for.


Thanks. :+1:
