### PR TITLE
Replace settings access with init params in client

### DIFF
--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -68,14 +68,16 @@ def mock_response_from_file(filename, **kwargs):
 
 
 class KongClient:
-    def __init__(self, base_url, api_key):
+    def __init__(self, base_url, api_key, test_mode=False, test_file_path=None):
         self.base_url = base_url
         self.session = requests.Session()
         self.session.headers.update({'apikey': api_key})
+        self.test_mode = test_mode
+        self.test_file_path = test_file_path
 
     def fetch(self, **kwargs):
-        if settings.KONG_CLIENT_TEST_MODE:
-            return mock_response_from_file(settings.KONG_CLIENT_TEST_FILENAME, **kwargs)
+        if self.test_mode:
+            return mock_response_from_file(self.test_file_path, **kwargs)
 
         kwargs["ref"] = kwargs.pop("reference_number", None)
         kwargs["from"] = kwargs.pop("start", 0)
@@ -109,8 +111,8 @@ class KongClient:
         ):
             kwargs["term"] = term
 
-        if settings.KONG_CLIENT_TEST_MODE:
-            return mock_response_from_file(settings.KONG_CLIENT_TEST_FILENAME, **kwargs)
+        if self.test_mode:
+            return mock_response_from_file(self.test_file_path, **kwargs)
 
         # from isn'ca valid kwargs
         kwargs["from"] = kwargs.pop("start", 0)

--- a/etna/ciim/models.py
+++ b/etna/ciim/models.py
@@ -42,7 +42,12 @@ class SearchManager:
     @property
     def client(self):
         """Lazy-load client to allow tests to overwrite base url."""
-        return KongClient(settings.KONG_CLIENT_BASE_URL, api_key=settings.KONG_CLIENT_KEY)
+        return KongClient(
+            settings.KONG_CLIENT_BASE_URL,
+            api_key=settings.KONG_CLIENT_KEY,
+            test_mode=settings.KONG_CLIENT_TEST_MODE,
+            test_file_path=settings.KONG_CLIENT_TEST_FILENAME,
+        )
 
     def filter(self, **kwargs):
         self._query = kwargs

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -219,13 +219,14 @@ class ClientReponseTest(TestCase):
         self.client = KongClient("", api_key="")
 
 
-@override_settings(
-    KONG_CLIENT_TEST_MODE=True,
-    KONG_CLIENT_TEST_FILENAME=Path(Path(__file__).parent, "fixtures/record.json"),
-)
 class TestClientTestMode(TestCase):
     def setUp(self):
-        self.client = KongClient("", api_key='')
+        self.client = KongClient(
+            "",
+            api_key="",
+            test_mode=True,
+            test_file_path=Path(Path(__file__).parent, "fixtures/record.json"),
+        )
 
     def test_empty_search(self):
         self.client.search()
@@ -256,8 +257,10 @@ class TestClientTestMode(TestCase):
 
         self.assertEqual(response["hits"]["total"]["value"], 1)
 
-    @override_settings(KONG_CLIENT_TEST_FILENAME="missing.json")
     def test_missing_test_file(self):
+
+        self.client.test_file_path = "missing.json"
+
         with self.assertRaises(FileNotFoundError):
             self.client.search()
 
@@ -265,7 +268,7 @@ class TestClientTestMode(TestCase):
 @override_settings(KONG_CLIENT_TEST_MODE=False)
 class TestClientSearchReponse(TestCase):
     def setUp(self):
-        self.client = KongClient("https://kong.test", api_key='')
+        self.client = KongClient("https://kong.test", api_key="")
 
     @responses.activate
     def test_test_mode_doesnt_use_requests(self):


### PR DESCRIPTION
Small tidy to the Kong client.

I've replaced code where `KongClient` directly accesses `django.conf.settings` in favour of `__init__` params