### PR TITLE
Feature/explorer frontend updates

### DIFF
--- a/etna/home/static/images/tna-blk-logo-beta.svg
+++ b/etna/home/static/images/tna-blk-logo-beta.svg
@@ -4,7 +4,6 @@
 	 viewBox="0 0 253 159.9" style="enable-background:new 0 0 253 159.9;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}
-	.st1{font-family:'PTSans-Bold';}
 	.st2{font-size:30px;}
 </style>
 <path d="M1.9,107.2h156.3V158H1.9V107.2z M1.9,54.5h79.1h77.2v50.8H1.9V54.5z M1.9,1.9h77.2v50.8H1.9V1.9z M80.9,1.9h77.2v50.8H80.9
@@ -45,5 +44,5 @@
 	c0-1.7-0.6-3.2-3-3.2c-2.1,0-3,1.2-3,2.8c0,1.7,0.9,2.5,2.2,2.9l3.5,1.3c2.6,1,4.3,2.6,4.3,5.8c0,3.6-2.4,6.1-7,6.1
 	c-5.9,0-6.8-3.9-6.8-6.5c0-0.3,0-0.6,0.1-1L130.4,136z"/>
 <rect x="172.2" y="122.6" class="st0" width="93" height="48"/>
-<text transform="matrix(1 0 0 1 172.22 143.58)" class="st1 st2">BETA</text>
+<text transform="matrix(1 0 0 1 172.22 143.58)" class="st1 st2" style="font-family: 'Open Sans', sans-serif;">BETA</text>
 </svg>

--- a/etna/home/templates/home/home_page.html
+++ b/etna/home/templates/home/home_page.html
@@ -13,11 +13,13 @@
 
 <div class="container pt-4">
     <h2 class="sr-only">A subheading for the cards (for accessibility purposes)</h2>
-    <ul class="row card-group--list-style-none">
-            {% for page in etna_index_pages %}
-                {% include 'includes/card-group-secondary-nav.html' %}
-            {% endfor %}
-    </ul>
+    <div class="row">
+        <ul class="card-group--list-style-none">
+                {% for page in etna_index_pages %}
+                    {% include 'includes/card-group-secondary-nav.html' %}
+                {% endfor %}
+        </ul>
+    </div>
     <div class="row">
         <div class="col-md-12">
             <h2>Thank you for taking part in this Beta program</h2>

--- a/etna/home/templates/home/home_page.html
+++ b/etna/home/templates/home/home_page.html
@@ -13,7 +13,7 @@
 
 <div class="container pt-4">
     <h2 class="sr-only">A subheading for the cards (for accessibility purposes)</h2>
-    <ul class="row card-group">
+    <ul class="row card-group--list-style-none">
             {% for page in etna_index_pages %}
                 {% include 'includes/card-group-secondary-nav.html' %}
             {% endfor %}

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -63,13 +63,20 @@
       @extend .tna-card__link;
       @include explorer-link;
 
-      text-decoration: underline;
+      text-decoration: none;
     }
 
     &__body {
       padding-left: 0.3rem;
       padding-right: 0.3rem;
       margin-top: 1rem;
+      text-decoration: underline;
+    }
+
+    &__heading {
+      padding-left: 0.3rem;
+      padding-right: 0.3rem;
+      text-decoration: underline;
     }
   }
 

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -1,10 +1,12 @@
 .card-group {
   padding-left: 0;
-  li {
+
+  &--list-style-none {
+    @extend .card-group;
     list-style: none;
   }
-  &-secondary-nav {
 
+  &-secondary-nav {
     display: inline-block;
 
     &__link {
@@ -37,7 +39,7 @@
   }
 
   &-record-summary {
-
+    list-style: none;
     display: inline-block;
 
     &__image {
@@ -63,9 +65,10 @@
   }
 
   &-promo {
+    list-style: none;
     padding: 1rem;
     margin-bottom: 1rem;
-
+    width: 100%;
     &--green {
       @extend .card-group-promo;
       background-color: $color__green;
@@ -108,6 +111,7 @@
 
       &-list {
         padding-left: 1rem;
+        margin-bottom: 1rem;
         &-item {
             list-style-type: '- ';
         }

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -1,14 +1,23 @@
 .card-group {
   padding-left: 0;
-
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  
   &--list-style-none {
     @extend .card-group;
     list-style: none;
   }
 
+  &--no-flex {
+    @extend .card-group;
+    display: block;
+    flex-wrap: unset;
+  }
+
   &-secondary-nav {
     display: inline-block;
-
+    width: 100%;
     &__link {
       @extend .tna-card__link;
       @include explorer-link;

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -24,6 +24,9 @@
 
     &__body {
       display: table-footer-group;
+    }
+
+    &__heading, &__paragraph {
       padding-left: 0.3rem;
       padding-right: 0.3rem;
     }

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -50,7 +50,7 @@
   &-record-summary {
     list-style: none;
     display: inline-block;
-
+    width: 100%;
     &__image {
       @extend .tna-card__image;
       border: 0.0625rem solid $color__black;

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -24,6 +24,8 @@
 
     &__body {
       display: table-footer-group;
+      padding-left: 0.3rem;
+      padding-right: 0.3rem;
     }
 
     @media only screen and (min-width: $screen__lg) {
@@ -51,6 +53,8 @@
     }
 
     &__body {
+      padding-left: 0.3rem;
+      padding-right: 0.3rem;
       margin-top: 1rem;
     }
   }
@@ -58,6 +62,18 @@
   &-promo {
     padding: 1rem;
     margin-bottom: 1rem;
+
+    &--green {
+      @extend .card-group-promo;
+      background-color: $color__green;
+      color: $color__black;
+      padding: 1rem 2rem;
+
+      a, hr {
+        color: $color__black;
+      }
+
+    }
 
     &--dark {
       @extend .card-group-promo;
@@ -79,8 +95,23 @@
       }
 
       &-heading {
-        font-weight: 400;
+        font-weight: 800;
         font-size: 1.5rem;
+      }
+
+      &-paragraph {
+        margin-bottom: 1rem;
+      }
+
+      &-list {
+        padding-left: 1rem;
+        &-item {
+            list-style-type: '- ';
+        }
+      }
+
+      &-link {
+        display: block;
       }
     }
 

--- a/sass/includes/_header.scss
+++ b/sass/includes/_header.scss
@@ -1,5 +1,5 @@
 .tna-header {
-  padding: 1rem 3rem 0rem 3rem;
+  padding: 1rem 3rem 0 3rem;
 
   @media only screen and (max-width: $screen__md) {
   padding: 1rem 1rem 1rem 1rem;
@@ -19,7 +19,7 @@
   }
 
   &__description {
-    font-size: 1.2em;
+    font-size: 1.2rem;
     margin-left: auto;
     margin-top: auto;
     margin-bottom: 0;
@@ -37,8 +37,8 @@
 
     &__description {
       padding-top: 0;
-      padding-left: 5em;
-      max-width: 600px;
+      padding-left: 5rem;
+      max-width: 37.5rem;
       text-align: right;
       &-heading {
         text-align: right;

--- a/sass/includes/_header.scss
+++ b/sass/includes/_header.scss
@@ -1,9 +1,48 @@
 .tna-header {
+  padding: 1rem 3rem 0rem 3rem;
+
+  @media only screen and (max-width: $screen__md) {
+  padding: 1rem 1rem 1rem 1rem;
+
+  }
+
+  &__home-link {
+    width: 100%;
+    max-width: 8.938rem;
+  }
 
   &__logo {
 
     &--beta {
       max-width: 8.938rem;
+    }
+  }
+
+  &__description {
+    font-size: 1.2em;
+    margin-left: auto;
+    margin-top: auto;
+    margin-bottom: 0;
+    padding-top: 1rem;
+    
+    &-heading {
+      font-weight: bold;
+    }
+  }
+
+  @media only screen and (min-width: $screen__md) {
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 1rem;
+
+    &__description {
+      padding-top: 0;
+      padding-left: 5em;
+      max-width: 600px;
+      text-align: right;
+      &-heading {
+        text-align: right;
+      }
     }
   }
 }

--- a/sass/includes/_results-options.scss
+++ b/sass/includes/_results-options.scss
@@ -1,6 +1,6 @@
 .results-options {
   background-color: $color__green;
-  padding: 1em;
+  padding: 1rem;
 
   &__count {
     margin-bottom: 0;
@@ -17,7 +17,7 @@
     border-radius: 0;
 
     @media only screen and (max-width: $screen__sm) {
-      margin-top: 1em;
+      margin-top: 1rem;
     }
 
     &:focus {

--- a/sass/includes/_results-options.scss
+++ b/sass/includes/_results-options.scss
@@ -33,7 +33,7 @@
       outline: 0.313rem solid $color__focus-blue-outline-light-bg;
     }
     padding: 0.5rem;
-    margin-left: 0rem;
+    margin-left: 0;
     @media only screen and (max-width: $screen__md) {
       margin-left: 0.3rem;
     }

--- a/sass/includes/_results-options.scss
+++ b/sass/includes/_results-options.scss
@@ -6,6 +6,10 @@
     margin-bottom: 0;
   }
 
+  &__sort {
+    text-align: right;
+  }
+
   &__select {
     padding: 0.2rem;
     border-radius: 0;
@@ -20,11 +24,15 @@
   }
 
   &__submit {
-    @extend .tna-button;
+    @extend .tna-button--dark;
+    border: none;
     cursor: pointer;
     &:focus {
       outline: 0.313rem solid $color__focus-blue-outline-light-bg;
     }
+    padding: 0.5rem;
+    margin-left: 0rem;
+    margin-top: 0.5rem;
   }
 
   &__loading-message {

--- a/sass/includes/_results-options.scss
+++ b/sass/includes/_results-options.scss
@@ -7,7 +7,7 @@
   }
 
   &__sort {
-    @media only screen and (min-width: 575px) {
+    @media only screen and (min-width: $screen__sm) {
      text-align: right;
     }
   }
@@ -16,7 +16,7 @@
     padding: 0.2rem;
     border-radius: 0;
 
-    @media only screen and (max-width: 575px) {
+    @media only screen and (max-width: $screen__sm) {
       margin-top: 1em;
     }
 
@@ -34,6 +34,9 @@
     }
     padding: 0.5rem;
     margin-left: 0rem;
+    @media only screen and (max-width: $screen__md) {
+      margin-left: 0.3rem;
+    }
     margin-top: 0.5rem;
   }
 

--- a/sass/includes/_results-options.scss
+++ b/sass/includes/_results-options.scss
@@ -7,7 +7,9 @@
   }
 
   &__sort {
-    text-align: right;
+    @media only screen and (min-width: 575px) {
+     text-align: right;
+    }
   }
 
   &__select {

--- a/sass/includes/_results-options.scss
+++ b/sass/includes/_results-options.scss
@@ -1,10 +1,18 @@
 .results-options {
-  text-align: right;
+  background-color: $color__green;
+  padding: 1em;
+
+  &__count {
+    margin-bottom: 0;
+  }
 
   &__select {
     padding: 0.2rem;
     border-radius: 0;
-    margin-left: .3rem;
+
+    @media only screen and (max-width: 575px) {
+      margin-top: 1em;
+    }
 
     &:focus {
       outline: 0.313rem solid $color__focus-blue-outline-light-bg;

--- a/templates/collections/blocks/collection_highlights.html
+++ b/templates/collections/blocks/collection_highlights.html
@@ -1,8 +1,11 @@
 <h2>Collection highlights</h2>
 <p>{{ page.introduction }}</p>
 
-<ul class="row card-group--list-style-none">
-    {% for child in page.results_pages %}
-        {% include 'includes/card-group-secondary-nav.html' with page=child %}
-    {% endfor %}
-</ul>
+<div class="row">
+    <ul class="card-group--list-style-none">
+        {% for child in page.results_pages %}
+            {% include 'includes/card-group-secondary-nav.html' with page=child %}
+        {% endfor %}
+    </ul>
+</div>
+

--- a/templates/collections/blocks/collection_highlights.html
+++ b/templates/collections/blocks/collection_highlights.html
@@ -1,7 +1,7 @@
 <h2>Collection highlights</h2>
 <p>{{ page.introduction }}</p>
 
-<ul class="row card-group">
+<ul class="row card-group--list-style-none">
     {% for child in page.results_pages %}
         {% include 'includes/card-group-secondary-nav.html' with page=child %}
     {% endfor %}

--- a/templates/collections/blocks/featured_page.html
+++ b/templates/collections/blocks/featured_page.html
@@ -1,3 +1,5 @@
-<ul class="row card-group">
-    {% include 'includes/card-group-promo--dark.html' with page=value.page.specific heading=value.heading only %}
-</ul>
+<div class="row">
+    <ul class="card-group">
+        {% include 'includes/card-group-promo--dark.html' with page=value.page.specific heading=value.heading only %}
+    </ul>
+</div>

--- a/templates/collections/blocks/featured_page.html
+++ b/templates/collections/blocks/featured_page.html
@@ -1,3 +1,3 @@
-<ul class="card-group">
+<ul class="row card-group">
     {% include 'includes/card-group-promo--dark.html' with page=value.page.specific heading=value.heading only %}
 </ul>

--- a/templates/collections/blocks/promoted_pages.html
+++ b/templates/collections/blocks/promoted_pages.html
@@ -9,7 +9,7 @@
         {% image promoted_item.teaser_image fill-288x172 as teaser_image_small %}
         {% image promoted_item.teaser_image fill-328x196 as teaser_image_medium %}
         {% image promoted_item.teaser_image fill-348x208 as teaser_image_large %}
-        {% image promoted_item.teaser_image fill-543x325 as teaser_image_extra_large %}
+        {% image promoted_item.teaser_image fill-508x304 as teaser_image_extra_large %}
 
         {% comment %}
         Source copied from templates/includes/card-group-secondary-nav.html

--- a/templates/collections/blocks/promoted_pages.html
+++ b/templates/collections/blocks/promoted_pages.html
@@ -3,7 +3,7 @@
 <h2>{{ value.heading }}</h2>
 <p>{{ value.sub_heading }}</p>
 
-<ul class="row card-group">
+<ul class="row card-group--list-style-none">
     {% for promoted_item in value.promoted_items %}
 
         {% image promoted_item.teaser_image fill-288x172 as teaser_image_small %}

--- a/templates/collections/blocks/promoted_pages.html
+++ b/templates/collections/blocks/promoted_pages.html
@@ -2,43 +2,44 @@
 
 <h2>{{ value.heading }}</h2>
 <p>{{ value.sub_heading }}</p>
+<div class="row">
+    <ul class="card-group--list-style-none">
+        {% for promoted_item in value.promoted_items %}
 
-<ul class="row card-group--list-style-none">
-    {% for promoted_item in value.promoted_items %}
+            {% image promoted_item.teaser_image fill-288x172 as teaser_image_small %}
+            {% image promoted_item.teaser_image fill-328x196 as teaser_image_medium %}
+            {% image promoted_item.teaser_image fill-348x208 as teaser_image_large %}
+            {% image promoted_item.teaser_image fill-508x304 as teaser_image_extra_large %}
 
-        {% image promoted_item.teaser_image fill-288x172 as teaser_image_small %}
-        {% image promoted_item.teaser_image fill-328x196 as teaser_image_medium %}
-        {% image promoted_item.teaser_image fill-348x208 as teaser_image_large %}
-        {% image promoted_item.teaser_image fill-508x304 as teaser_image_extra_large %}
+            {% comment %}
+            Source copied from templates/includes/card-group-secondary-nav.html
 
-        {% comment %}
-        Source copied from templates/includes/card-group-secondary-nav.html
+            Modified slightly to support data from a streamfield.
 
-        Modified slightly to support data from a streamfield.
+            This is not intended to be production-ready code.
 
-        This is not intended to be production-ready code.
+            To discuss an approach to allow for reusability going forward.
+            {% endcomment %}
 
-        To discuss an approach to allow for reusability going forward.
-        {% endcomment %}
-
-        <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
-            <div class="card-group-secondary-nav">
-                <a href="{{ promoted_item.promoted_item.url }}" class="card-group-secondary-nav__link">
-                    <div class="card-group-secondary-nav__body">
-                        <h3 class="card-group-secondary-nav__heading">{{ promoted_item.title }}</h3>
-                        <p class="card-group-secondary-nav__paragraph">{{ promoted_item.description }}</p>
-                    </div>
-                    <div class="card-group-secondary-nav__image">
-                        <picture>
-                            <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
-                            <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
-                            <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
-                            <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                            <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
-                        </picture>
-                    </div>
-                </a>
-            </div>
-        </li>
-    {% endfor %}
-</ul>
+            <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
+                <div class="card-group-secondary-nav">
+                    <a href="{{ promoted_item.promoted_item.url }}" class="card-group-secondary-nav__link">
+                        <div class="card-group-secondary-nav__body">
+                            <h3 class="card-group-secondary-nav__heading">{{ promoted_item.title }}</h3>
+                            <p class="card-group-secondary-nav__paragraph">{{ promoted_item.description }}</p>
+                        </div>
+                        <div class="card-group-secondary-nav__image">
+                            <picture>
+                                <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
+                                <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
+                                <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
+                                <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                                <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
+                            </picture>
+                        </div>
+                    </a>
+                </div>
+            </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/templates/collections/blocks/promoted_pages.html
+++ b/templates/collections/blocks/promoted_pages.html
@@ -25,8 +25,8 @@
             <div class="card-group-secondary-nav">
                 <a href="{{ promoted_item.promoted_item.url }}" class="card-group-secondary-nav__link">
                     <div class="card-group-secondary-nav__body">
-                        <h3 class="tna-card__heading">{{ promoted_item.title }}</h3>
-                        <p>{{ promoted_item.description }}</p>
+                        <h3 class="card-group-secondary-nav__heading">{{ promoted_item.title }}</h3>
+                        <p class="card-group-secondary-nav__paragraph">{{ promoted_item.description }}</p>
                     </div>
                     <div class="card-group-secondary-nav__image">
                         <picture>

--- a/templates/collections/blocks/time_period_explorer.html
+++ b/templates/collections/blocks/time_period_explorer.html
@@ -9,7 +9,7 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ value.page.url }}" class="card-group-promo__card-link">
+                <a href="{{ value.page.url }}" class="card-group-promo__card-link" tabindex="-1">
                     <picture class="mt-auto">
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">

--- a/templates/collections/blocks/time_period_explorer.html
+++ b/templates/collections/blocks/time_period_explorer.html
@@ -5,7 +5,7 @@
 {% image value.page.specific.teaser_image fill-508x311 as teaser_image_large %}
 {% image value.page.specific.teaser_image fill-626x383 as teaser_image_extra_large %}
 
-<div class="card-group-promo--green">
+<li class="card-group-promo--green">
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
@@ -34,4 +34,4 @@
             </div>
         </div>
     </div>
-</div>
+</li>

--- a/templates/collections/blocks/time_period_explorer.html
+++ b/templates/collections/blocks/time_period_explorer.html
@@ -10,7 +10,7 @@
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
                 <a href="{{ value.page.url }}" class="card-group-promo__card-link" tabindex="-1">
-                    <picture class="mt-auto">
+                    <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/collections/blocks/topic_explorer.html
+++ b/templates/collections/blocks/topic_explorer.html
@@ -10,7 +10,7 @@
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
                 <a href="{{ value.page.url }}" class="card-group-promo__card-link">
-                    <picture class="mt-auto">
+                    <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/collections/blocks/topic_explorer.html
+++ b/templates/collections/blocks/topic_explorer.html
@@ -9,7 +9,7 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ value.page.url }}" class="card-group-promo__card-link">
+                <a href="{{ value.page.url }}" class="card-group-promo__card-link" tabindex="-1">
                     <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">

--- a/templates/collections/blocks/topic_explorer.html
+++ b/templates/collections/blocks/topic_explorer.html
@@ -5,7 +5,7 @@
 {% image value.page.specific.teaser_image fill-508x311 as teaser_image_large %}
 {% image value.page.specific.teaser_image fill-626x383 as teaser_image_extra_large %}
 
-<div class="card-group-promo--green">
+<li class="card-group-promo--green">
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
@@ -34,4 +34,4 @@
             </div>
         </div>
     </div>
-</div>
+</li>

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -6,7 +6,7 @@
     {% include 'includes/generic-intro--dark.html' %}
 
     <div class="container">
-        <div class="row">
+        <div class="row mt-4">
             <div class="col-md-12" id="content">
                 <h2 class="sr-only">Select a way to explore</h2>
                 {% for block in page.body %}

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -8,6 +8,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12" id="content">
+                <h2 class="sr-only">Select a way to explore</h2>
                 {% for block in page.body %}
                     {% include_block block %}
                 {% endfor %}

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -7,8 +7,8 @@
 
     <div class="container mt-4">
        <div class="row">
+        <h2 class="sr-only">Select a way to explore</h2>
             <ul class="card-group--no-flex">
-                <h2 class="sr-only">Select a way to explore</h2>
                 {% for block in page.body %}
                     {% include_block block %}
                 {% endfor %}

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -6,11 +6,13 @@
     {% include 'includes/generic-intro--dark.html' %}
 
     <div class="container mt-4">
-       <ul class="row card-group">
-        <h2 class="sr-only">Select a way to explore</h2>
-        {% for block in page.body %}
-            {% include_block block %}
-        {% endfor %}
-       </ul>
+       <div class="row">
+            <ul class="card-group--no-flex">
+                <h2 class="sr-only">Select a way to explore</h2>
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
+            </ul>
+       </div>
     </div>
 {% endblock %}

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -5,14 +5,12 @@
 {% block content %}
     {% include 'includes/generic-intro--dark.html' %}
 
-    <div class="container">
-        <div class="row mt-4">
-            <div class="col-md-12" id="content">
-                <h2 class="sr-only">Select a way to explore</h2>
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
-            </div>
-        </div>
+    <div class="container mt-4">
+       <ul class="row card-group">
+        <h2 class="sr-only">Select a way to explore</h2>
+        {% for block in page.body %}
+            {% include_block block %}
+        {% endfor %}
+       </ul>
     </div>
 {% endblock %}

--- a/templates/collections/results_page.html
+++ b/templates/collections/results_page.html
@@ -15,8 +15,8 @@
                     <h3 class="sr-only">Options</h3>
                     {% include 'includes/results-options.html' %}
                     <div class="row">
+                        <h3 class="sr-only">Items</h3>
                         <ul class="card-group--list-style-none">
-                            <h3 class="sr-only">Items</h3>
                             {% for record_page_result in page.records.all %}
                                 {% include 'includes/card-group-record-summary.html' with record_page=record_page_result.record_page teaser_image=record_page_result.teaser_image description_override=record_page_result.description only %}
                             {% endfor %}

--- a/templates/collections/results_page.html
+++ b/templates/collections/results_page.html
@@ -14,7 +14,7 @@
                     <h2 class="sr-only">Results</h2>
                     <h3 class="sr-only">Options</h3>
                     {% include 'includes/results-options.html' %}
-                    <ul class="row card-group">
+                    <ul class="row card-group--list-style-none">
                         <h3 class="sr-only">Items</h3>
                         {% for record_page_result in page.records.all %}
                             {% include 'includes/card-group-record-summary.html' with record_page=record_page_result.record_page teaser_image=record_page_result.teaser_image description_override=record_page_result.description only %}

--- a/templates/collections/results_page.html
+++ b/templates/collections/results_page.html
@@ -14,12 +14,14 @@
                     <h2 class="sr-only">Results</h2>
                     <h3 class="sr-only">Options</h3>
                     {% include 'includes/results-options.html' %}
-                    <ul class="row card-group--list-style-none">
-                        <h3 class="sr-only">Items</h3>
-                        {% for record_page_result in page.records.all %}
-                            {% include 'includes/card-group-record-summary.html' with record_page=record_page_result.record_page teaser_image=record_page_result.teaser_image description_override=record_page_result.description only %}
-                        {% endfor %}
-                    </ul>
+                    <div class="row">
+                        <ul class="card-group--list-style-none">
+                            <h3 class="sr-only">Items</h3>
+                            {% for record_page_result in page.records.all %}
+                                {% include 'includes/card-group-record-summary.html' with record_page=record_page_result.record_page teaser_image=record_page_result.teaser_image description_override=record_page_result.description only %}
+                            {% endfor %}
+                        </ul>
+                    </div>
                     {% comment %}
                         <h3 class="sr-only">Pagination</h3>
                         {% include 'includes/pagination.html' %}

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -5,15 +5,13 @@
 {% block content %}
     {% include 'includes/generic-intro--dark.html' %}
 
-    <div class="container">
-        <div class="row">
+    <div class="container mt-4">
             <h2 class="sr-only">Select a time period</h2>
             <ul class="row card-group">
                 {% for child in page.time_period_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
                 {% endfor %}
             </ul>
-        </div>
         <div class="row">
             <div class="col-md-12" id="content">
                 <h2>More ways to explore</h2>

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -6,14 +6,14 @@
     {% include 'includes/generic-intro--dark.html' %}
 
     <div class="container mt-4">
+        <div class="row">
             <h2 class="sr-only">Select a time period</h2>
-            <div class="row">
-                <ul class="card-group--list-style-none">
-                    {% for child in page.time_period_explorer_pages %}
-                        {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
-                    {% endfor %}
-                </ul>
-            </div>
+            <ul class="card-group--list-style-none">
+                {% for child in page.time_period_explorer_pages %}
+                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
+                {% endfor %}
+            </ul>
+        </div>
         <div class="row">
             <div class="col-md-12" id="content">
                 <h2>More ways to explore</h2>

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -7,6 +7,7 @@
 
     <div class="container">
         <div class="row">
+            <h2 class="sr-only">Select a time period</h2>
             <ul class="row card-group">
                 {% for child in page.time_period_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
@@ -15,6 +16,7 @@
         </div>
         <div class="row">
             <div class="col-md-12" id="content">
+                <h2>More ways to explore</h2>
                 {% for block in page.body %}
                     {% include_block block %}
                 {% endfor %}

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -7,17 +7,21 @@
 
     <div class="container mt-4">
             <h2 class="sr-only">Select a time period</h2>
-            <ul class="row card-group--list-style-none">
-                {% for child in page.time_period_explorer_pages %}
-                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
-                {% endfor %}
-            </ul>
+            <div class="row">
+                <ul class="card-group--list-style-none">
+                    {% for child in page.time_period_explorer_pages %}
+                        {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
+                    {% endfor %}
+                </ul>
+            </div>
         <div class="row">
             <div class="col-md-12" id="content">
                 <h2>More ways to explore</h2>
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
+                <ul class="card-group--no-flex">
+                    {% for block in page.body %}
+                        {% include_block block %}
+                    {% endfor %}
+                </ul>
             </div>
         </div>
     </div>

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -7,7 +7,7 @@
 
     <div class="container mt-4">
             <h2 class="sr-only">Select a time period</h2>
-            <ul class="row card-group">
+            <ul class="row card-group--list-style-none">
                 {% for child in page.time_period_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
                 {% endfor %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -6,18 +6,22 @@
     {% include 'includes/generic-intro--dark.html' %}
 
     <div class="container mt-4">
-            <ul class="row card-group--list-style-none">
-                <h2 class="sr-only">Select a topic</h2>
-                {% for child in page.topic_explorer_pages %}
-                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
-                {% endfor %}
-            </ul>
+        <div class="row">
+            <ul class="card-group--list-style-none">
+                    <h2 class="sr-only">Select a topic</h2>
+                    {% for child in page.topic_explorer_pages %}
+                        {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
+                    {% endfor %}
+                </ul>
+            </div>
         <div class="row">
             <div class="col-md-12" id="content">
                 <h2>More ways to explore</h2>
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
+                <ul class="card-group--no-flex">
+                    {% for block in page.body %}
+                        {% include_block block %}
+                    {% endfor %}
+                </ul>
             </div>
         </div>
     </div>

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -8,6 +8,7 @@
     <div class="container">
         <div class="row">
             <ul class="row card-group">
+                <h2 class="sr-only">Select a topic</h2>
                 {% for child in page.topic_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
                 {% endfor %}
@@ -15,6 +16,7 @@
         </div>
         <div class="row">
             <div class="col-md-12" id="content">
+                <h2>More ways to explore</h2>
                 {% for block in page.body %}
                     {% include_block block %}
                 {% endfor %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -6,7 +6,7 @@
     {% include 'includes/generic-intro--dark.html' %}
 
     <div class="container mt-4">
-            <ul class="row card-group">
+            <ul class="row card-group--list-style-none">
                 <h2 class="sr-only">Select a topic</h2>
                 {% for child in page.topic_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -5,15 +5,13 @@
 {% block content %}
     {% include 'includes/generic-intro--dark.html' %}
 
-    <div class="container">
-        <div class="row">
+    <div class="container mt-4">
             <ul class="row card-group">
                 <h2 class="sr-only">Select a topic</h2>
                 {% for child in page.topic_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
                 {% endfor %}
             </ul>
-        </div>
         <div class="row">
             <div class="col-md-12" id="content">
                 <h2>More ways to explore</h2>

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -7,8 +7,8 @@
 
     <div class="container mt-4">
         <div class="row">
+            <h2 class="sr-only">Select a topic</h2>
             <ul class="card-group--list-style-none">
-                    <h2 class="sr-only">Select a topic</h2>
                     {% for child in page.topic_explorer_pages %}
                         {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
                     {% endfor %}

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -27,7 +27,7 @@
             </div>
             <div class="col-md-6 col-lg-7 col-xl-8">
                 <h3 class="card-group-promo__card-heading"><a href="{{ page.url }}">{{ page.title }}</a></h3>
-                <p>{{ page.introduction }}</p>
+                <p class="card-group-promo__card-paragraph">{{ page.introduction }}</p>
             </div>
         </div>
     </div>

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -11,7 +11,7 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link">
+                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link" tabindex="-1">
                     <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -12,7 +12,7 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-6 col-lg-5 col-xl-4">
-                <a href="{{ page.url }}" tabindex="-1">
+                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link">
                     <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_extra_large.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_large.url }}">

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -12,7 +12,7 @@
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
                 <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link">
-                    <picture class="mt-auto">
+                    <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -11,7 +11,7 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link">
+                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link" tabindex="-1">
                     <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -5,7 +5,7 @@
 {% image page.teaser_image fill-508x311 as teaser_image_large %}
 {% image page.teaser_image fill-626x383 as teaser_image_extra_large %}
 
-<li class="card-group-promo--dark">
+<li class="card-group-promo--green">
     <h2 class="card-group-promo__heading">{{ heading }}</h2>
 
     <div class="card-group-promo__card">

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -12,7 +12,7 @@
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
                 <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link">
-                    <picture class="mt-auto">
+                    <picture>
                         <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -16,7 +16,7 @@
                         <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                         <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_small.url }}" alt="Record Alt" class="card-group-record-summary__image-fallback">
+                        <img src="{{ teaser_image_extra_large.url }}" alt="Record Alt" class="card-group-record-summary__image-fallback">
                     </picture>
                 </div>
                 <div class="card-group-record-summary__body">

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -8,7 +8,7 @@
 <div class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link">
-            <h4>{{ record_page.title }}</h4>
+            <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
             <figure>
                 <div class="card-group-record-summary__image">
                     <picture>

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -3,7 +3,7 @@
 {% image page.teaser_image fill-288x172 as teaser_image_small %}
 {% image page.teaser_image fill-328x196 as teaser_image_medium %}
 {% image page.teaser_image fill-348x208 as teaser_image_large %}
-{% image page.teaser_image fill-543x325 as teaser_image_extra_large %}
+{% image page.teaser_image fill-508x304 as teaser_image_extra_large %}
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -23,7 +23,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -9,13 +9,13 @@
     <div class="card-group-secondary-nav">
         <a href='{{ child.url }}' class="card-group-secondary-nav__link">
             <div class="card-group-secondary-nav__body">
-                <h3 class="tna-card__heading">
+                <h3 class="card-group-secondary-nav__heading">
                     {# Visible on screen but hidden from assistive technology #}
                     <span aria-hidden="true">{{ page.title }} ({{ page.start_year }} - {{ page.end_year }})</span>
                     {# Available to assistive technology #}
                     <span class="sr-only">{{ child.title }}. Covering years <time datetime="{{ page.start_year }}">{{ page.start_year }}</time> to <time datetime="{{ page.end_year }}">{{ page.end_year }}</time>.</span>
                 </h3>
-                <p>{{child.sub_heading}}</p>
+                <p class="card-group-secondary-nav__paragraph">{{child.sub_heading}}</p>
             </div>
             <div class="card-group-secondary-nav__image">
                 <picture>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -3,7 +3,7 @@
 {% image page.teaser_image fill-288x172 as teaser_image_small %}
 {% image page.teaser_image fill-328x196 as teaser_image_medium %}
 {% image page.teaser_image fill-348x208 as teaser_image_large %}
-{% image page.teaser_image fill-543x325 as teaser_image_extra_large %}
+{% image page.teaser_image fill-508x304 as teaser_image_extra_large %}
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -9,8 +9,8 @@
     <div class="card-group-secondary-nav">
         <a href='{{ page.url }}' class="card-group-secondary-nav__link">
             <div class="card-group-secondary-nav__body">
-                <h3 class="tna-card__heading">{{ page.title }}</h3>
-                <p>{{ page.sub_heading }}</p>
+                <h3 class="card-group-secondary-nav__heading">{{ page.title }}</h3>
+                <p class="card-group-secondary-nav__paragraph">{{ page.sub_heading }}</p>
             </div>
             <div class="card-group-secondary-nav__image">
                 <picture>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -18,7 +18,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -1,14 +1,12 @@
 {% load static %}
 <a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable">Skip to main content</a>
 <header class="tna-header">
-    <div class="container">
-        <div class="row">
-            <div class="col-3">
-                <a href="/">
-                    <img src="{% static 'images/tna-blk-logo-beta.svg' %}" class="img-fluid tna-header__logo--beta"
-                         alt="The National Archives" width="143" height="90.375">
-                </a>
-            </div>
-        </div>
-    </div>
+    <a href="/" class="tna-header__home-link">
+        <img src="{% static 'images/tna-blk-logo-beta.svg' %}" class="img-fluid tna-header__logo--beta"
+        alt="The National Archives" width="143" height="90.375">
+    </a>
+    <p class="tna-header__description">
+    <span class="tna-header__description-heading">Welcome to The National Archives</span><br/>
+    We are the guardians of over 1,000 years of iconic documents and UK government records.
+</p>
 </header>

--- a/templates/includes/related-content.html
+++ b/templates/includes/related-content.html
@@ -1,4 +1,4 @@
-<div class="col-sm-12 col-md-6 col-lg-4">
+<li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
         <a href="/" class="card-group-secondary-nav__link">
             <h3 class="sr-only">Event - ‘Before Shakespeare’ at The National Archives</h3>
@@ -21,4 +21,4 @@
             </div>
         </a>
     </div>
-</div>
+</li>

--- a/templates/includes/related-content.html
+++ b/templates/includes/related-content.html
@@ -12,8 +12,8 @@
                 </picture>
             </div>
             <div class="card-group-secondary-nav__body">
-                <h3 class="tna-card__heading" aria-hidden="true">Event - ‘Before Shakespeare’ at The National Archives</h3>
-                <p><time datetime="2018-08-01">Wednesday 1 August 2018</time></p>
+                <h3 class="card-group-secondary-nav__heading" aria-hidden="true">Event - ‘Before Shakespeare’ at The National Archives</h3>
+                <p class="card-group-secondary-nav__paragraph"><time datetime="2018-08-01">Wednesday 1 August 2018</time></p>
                 <p>In this talk, the project team will ask the fundamental question, ‘what is a playhouse?’, and explore surviving documents that tell us what we know about these spaces, and rethink the builders, managers, and audiences who brought them into being.</p>
 
                 <!-- Price will be conditionally rendered if it's needed e.g. for an event ticket price -->

--- a/templates/includes/results-options.html
+++ b/templates/includes/results-options.html
@@ -1,12 +1,21 @@
 <div class="results-options" aria-live="polite">
-    <div class="results-options__sort">
-        <form action="">
-            <label for="sort">Sort by:</label>
-            <select class="results-options__select" name="sort" id="sort">
-                <option value="importance">Importance</option>
-                <option value="else">Something else</option>
-            </select>
-            <input class="results-options__submit" type="submit">
-        </form>
+    <div class="row">
+        <div class="col-xl-9 col-lg-8 col-md-7 col-sm-6 ">
+                <p class="results-options__count">
+                    100 items
+                </p>
+        </div>
+        <div class="col-xl-3 col-lg-4 col-md-5 col-sm-6">
+            <div class="results-options__sort">
+                    <form action="">
+                        <label for="sort">Sort by:</label>
+                        <select class="results-options__select" name="sort" id="sort">
+                            <option value="importance">Publication date</option>
+                            <option value="else">Something else</option>
+                        </select>
+                        <input class="results-options__submit" type="submit">
+                    </form>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Hi @gtvj & @danbentley 

Here is the PR for the Explorer frontend updates in Wagtail.

I've had to tweak the SASS/HTML a bit more than expected to make everything work, as the HTML has become out of sync with `ds-wagtail-frontend` (which I'll try and resynchronise at some point).

The changes include:

- An updated header with some descriptive text. The logo has been fixed too (the "BETA" text was serif outside of Chrome)
- Updates to the `card-group-promo` component styles, to allow for the new index page card styles
- Padding fixes on the `card-group-secondary-nav` and `card-group-record-summary` cards
- Adding the amount of items returned on the results page, which also involved some styling changes to the `results_options` component. 

I've hard coded some H2 elements into a couple of the blocks/templates. They're needed for accessibility - they'll probably need to be added to the pages model.

Below I've pasted a screenshot of the `results_options` component on `results_page.html`. The model validation prevents you from creating a `results_page` currently, so I used the `urls.py` to check that page. It's also slightly different from `ds-wagtail-frontend` as in that repo I forgot to account for the non-JS submit button!

#### Results options on Desktop
![image](https://user-images.githubusercontent.com/8880610/125757959-519e8328-27a0-45d6-8002-b46c8b8b14b2.png)
#### Results options on Mobile (320px)
![image](https://user-images.githubusercontent.com/8880610/125758545-d20ab2d8-c41c-4ae9-bdd8-3f9ae02cc1dc.png)


Would you be able to approve the changes if all is OK? Thanks :+1: