### PR TITLE
Feature/sync generic intro

### DIFF
--- a/sass/includes/_generic_intro.scss
+++ b/sass/includes/_generic_intro.scss
@@ -18,5 +18,16 @@
     @media (max-width: $screen__md) {
       font-size: 2.5rem;
     }
+
+    &-prefix {
+      display: block;
+      @media (max-width: $screen__md) {
+        font-size: 1.25rem;
+        line-height: 1.3em;
+      }
+      font-size: 2rem;
+      line-height: 0.3em;
+      margin-top: 1em;
+    }
   }
 }

--- a/templates/includes/generic-intro--dark.html
+++ b/templates/includes/generic-intro--dark.html
@@ -2,7 +2,10 @@
     <div class="container">
         <div class="row">
             <div class="col-12">
-                <h1 class="generic-intro__title">{{ self.title }}</h1>
+                <h1 class="generic-intro__title">
+                    <span class="generic-intro__title-prefix">{{self.title_prefix}}</span>
+                    {{ self.title }}
+                </h1>
                 <p>{{ page.sub_heading }}</p>
             </div>
         </div>

--- a/templates/includes/generic-intro--dark.html
+++ b/templates/includes/generic-intro--dark.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-12">
                 <h1 class="generic-intro__title">
-                    <span class="generic-intro__title-prefix">{{self.title_prefix}}</span>
+                    <span class="generic-intro__title-prefix">[Optional Prefix]</span>
                     {{ self.title }}
                 </h1>
                 <p>{{ page.sub_heading }}</p>


### PR DESCRIPTION
Hi,

Would someone be able to merge this?

I forgot to port over the updated `generic-intro` in the explorer branch. This allows a smaller prefix to be added to the page `<h1>` allowing you to do like the below:

![image](https://user-images.githubusercontent.com/8880610/125939000-e0000548-ad0b-400b-8907-b0ce0780d29c.png)

Thanks :+1: