### PR TITLE
Feature/remove duplicated h3s

### DIFF
--- a/templates/collections/blocks/time_period_explorer.html
+++ b/templates/collections/blocks/time_period_explorer.html
@@ -9,16 +9,14 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ value.page.url }}" class="card-group-promo__card-link" tabindex="-1">
-                    <picture>
-                        <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
-                        <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
-                        <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-promo__card-image">
-                    </picture>
-                </a>
+                <picture>
+                    <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
+                    <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
+                    <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                    <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-promo__card-image">
+                </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">
                 <h3 class="card-group-promo__card-heading"><a href="{{ value.page.url }}">{{ value.heading }}</a></h3>

--- a/templates/collections/blocks/time_period_explorer.html
+++ b/templates/collections/blocks/time_period_explorer.html
@@ -15,7 +15,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-promo__card-image">
+                    <img src="{{ teaser_image_small.url }}" alt="" role="presentation" class="card-group-promo__card-image">
                 </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">

--- a/templates/collections/blocks/topic_explorer.html
+++ b/templates/collections/blocks/topic_explorer.html
@@ -9,16 +9,14 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ value.page.url }}" class="card-group-promo__card-link" tabindex="-1">
-                    <picture>
-                        <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
-                        <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
-                        <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-promo__card-image">
-                    </picture>
-                </a>
+                <picture>
+                    <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
+                    <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
+                    <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                    <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-promo__card-image">
+                </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">
                 <h3 class="card-group-promo__card-heading"><a href="{{ value.page.url }}">{{ value.heading }}</a></h3>

--- a/templates/collections/blocks/topic_explorer.html
+++ b/templates/collections/blocks/topic_explorer.html
@@ -15,7 +15,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_small.url }}" alt="{{ image.title }}" class="card-group-promo__card-image">
+                    <img src="{{ teaser_image_small.url }}" alt="" role="presentation" class="card-group-promo__card-image">
                 </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -19,7 +19,7 @@
                         <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                         <img src="{{ teaser_image_extra_large.url }}"
-                             alt="{{ page.teaser_image.title }}"
+                             alt=""
                              class="card-group-promo__card-image">
                     </picture>
                 </a>

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -11,19 +11,17 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link" tabindex="-1">
-                    <picture>
-                        <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
-                        <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
-                        <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_extra_large.url }}"
-                             alt=""
-                             role="presentation"
-                             class="card-group-promo__card-image">
-                    </picture>
-                </a>
+                <picture>
+                    <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
+                    <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
+                    <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                    <img src="{{ teaser_image_extra_large.url }}"
+                         alt=""
+                         role="presentation"
+                         class="card-group-promo__card-image">
+                </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">
                 <h3 class="card-group-promo__card-heading"><a href="{{ page.url }}">{{ page.title }}</a></h3>

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -20,6 +20,7 @@
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                         <img src="{{ teaser_image_extra_large.url }}"
                              alt=""
+                             role="presentation"
                              class="card-group-promo__card-image">
                     </picture>
                 </a>

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -19,7 +19,7 @@
                         <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                         <img src="{{ teaser_image_extra_large.url }}"
-                             alt="{{ page.teaser_image.title }}"
+                             alt=""
                              class="card-group-promo__card-image">
                     </picture>
                 </a>

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -11,19 +11,17 @@
     <div class="card-group-promo__card">
         <div class="row">
             <div class="col-md-12 col-lg-7 col-xl-6">
-                <a href="{{ page.url }}" tabindex="-1" class="card-group-promo__card-link" tabindex="-1">
-                    <picture>
-                        <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
-                        <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
-                        <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_extra_large.url }}"
-                             alt=""
-                             role="presentation"
-                             class="card-group-promo__card-image">
-                    </picture>
-                </a>
+                <picture>
+                    <source media="(max-width: 576px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 768px)" srcset="{{ teaser_image_small.url }}">
+                    <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
+                    <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
+                    <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                    <img src="{{ teaser_image_extra_large.url }}"
+                         alt=""
+                         role="presentation"
+                         class="card-group-promo__card-image">
+                </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">
                 <h3 class="card-group-promo__card-heading"><a href="{{ page.url }}">{{ page.title }}</a></h3>

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -20,6 +20,7 @@
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                         <img src="{{ teaser_image_extra_large.url }}"
                              alt=""
+                             role="presentation"
                              class="card-group-promo__card-image">
                     </picture>
                 </a>

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -5,7 +5,7 @@
 {% image teaser_image fill-348x352 as teaser_image_large %}
 {% image teaser_image fill-543x549 as teaser_image_extra_large %}
 
-<div class="col-sm-12 col-md-6 col-lg-4">
+<li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link">
             <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
@@ -25,4 +25,4 @@
             </figure>
         </a>
     </div>
-</div>
+</li>

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -23,7 +23,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -23,7 +23,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -18,7 +18,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -18,7 +18,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="{{ image.title }}" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/related-content.html
+++ b/templates/includes/related-content.html
@@ -7,7 +7,7 @@
                     <source media="(max-width: 991px)" srcset="/images/collection-explorer/topics_cards/328/design-registers.png">
                     <source media="(max-width: 1199px)" srcset="/images/collection-explorer/topics_cards/288/design-registers.png">
                     <source media="(min-width: 1200px)" srcset="/images/collection-explorer/topics_cards/348/design-registers.png">
-                    <img src="/images/collection-explorer/topics_cards/543/design-registers.png" alt="" class="card-group-secondary-nav__image-fallback">
+                    <img src="/images/collection-explorer/topics_cards/543/design-registers.png" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
             <div class="card-group-secondary-nav__body">

--- a/templates/includes/related-content.html
+++ b/templates/includes/related-content.html
@@ -1,18 +1,17 @@
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
         <a href="/" class="card-group-secondary-nav__link">
-            <h3 class="sr-only">Event - ‘Before Shakespeare’ at The National Archives</h3>
             <div class="card-group-secondary-nav__image">
                 <picture>
                     <source media="(max-width: 768px)" srcset="/images/collection-explorer/topics_cards/543/design-registers.png">
                     <source media="(max-width: 991px)" srcset="/images/collection-explorer/topics_cards/328/design-registers.png">
                     <source media="(max-width: 1199px)" srcset="/images/collection-explorer/topics_cards/288/design-registers.png">
                     <source media="(min-width: 1200px)" srcset="/images/collection-explorer/topics_cards/348/design-registers.png">
-                    <img src="/images/collection-explorer/topics_cards/543/design-registers.png" alt="Decorative pattern from the design registers" class="card-group-secondary-nav__image-fallback">
+                    <img src="/images/collection-explorer/topics_cards/543/design-registers.png" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
             <div class="card-group-secondary-nav__body">
-                <h3 class="card-group-secondary-nav__heading" aria-hidden="true">Event - ‘Before Shakespeare’ at The National Archives</h3>
+                <h3 class="card-group-secondary-nav__heading">Event - ‘Before Shakespeare’ at The National Archives</h3>
                 <p class="card-group-secondary-nav__paragraph"><time datetime="2018-08-01">Wednesday 1 August 2018</time></p>
                 <p>In this talk, the project team will ask the fundamental question, ‘what is a playhouse?’, and explore surviving documents that tell us what we know about these spaces, and rethink the builders, managers, and audiences who brought them into being.</p>
 


### PR DESCRIPTION
Hi @AshTNA,

Would it be possible to look at this PR? It removes a duplicated `<h3>` heading from the related-content component, removes the `<a>` tag wrapping images on the promo/time periods/topic explorer cards, and removes `alt` text/adds `role="presentation"` to decorative images. Thank you 👍   