### PR TITLE
Insights styling fixes

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -55,7 +55,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/specifics';
 @import 'includes/content-block';
 @import 'includes/quote';
-@import 'includes/callout';
+@import 'includes/box-out';
 @import 'includes/media-embed';
 @import 'includes/record-embed';
 @import 'includes/record-embed__no-image';

--- a/sass/includes/_blog-embed.scss
+++ b/sass/includes/_blog-embed.scss
@@ -8,6 +8,12 @@
     border-radius: 50%;
     margin-bottom: 1rem;
     padding: 1rem;
+    width: 5rem;
+    height: 5rem;
+    margin: auto;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 3rem;
   }
 
   &__icon-label {

--- a/sass/includes/_box-out.scss
+++ b/sass/includes/_box-out.scss
@@ -1,9 +1,6 @@
-.callout {
+.box-out {
   background-color: $color__blue_3;
   padding: 2rem 0;
-  width: 100vw;
-  position: relative;
-  left: calc(-50vw + 50%);
 
   &__standfirst {
     color: $color__white;

--- a/sass/includes/_content-block.scss
+++ b/sass/includes/_content-block.scss
@@ -19,8 +19,5 @@
     border-top: 0.3125rem solid $color__grey-4;
     border-bottom: 0.3125rem solid $color__grey-4;
     padding: 2rem 0;
-    width: 100vw;
-    position: relative;
-    left: calc(-50vw + 50%);
   }
 }

--- a/sass/includes/_global.scss
+++ b/sass/includes/_global.scss
@@ -11,6 +11,8 @@
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
+  background-color: black !important;
+  color: white !important;
 }
 
 // Use in conjunction with .sr-only to only display content when it's focused.

--- a/sass/includes/_key-facts__author.scss
+++ b/sass/includes/_key-facts__author.scss
@@ -1,9 +1,6 @@
 .key-facts__author {
   background-color: $color__grey_4;
   padding: 2rem 0;
-  width: 100vw;
-  position: relative;
-  left: calc(-50vw + 50%);
 
   &-image-container {
     text-align: center;

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -1,9 +1,7 @@
 .media-embed {
   background-size: cover;
   min-height: 37.5rem;
-  width: 100vw;
   position: relative;
-  left: calc(-50vw + 50%);
 
   &__overlay {
     background-color: $color__black;

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -23,6 +23,12 @@
     border-radius: 50%;
     margin-bottom: 1rem;
     padding: 1rem;
+    width: 5rem;
+    height: 5rem;
+    margin: auto;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 3rem;
   }
 
   &__icon-label {

--- a/sass/includes/_record-embed.scss
+++ b/sass/includes/_record-embed.scss
@@ -1,7 +1,4 @@
 .record-embed {
-  width: 100vw;
-  position: relative;
-  left: calc(-50vw + 50%);
 
   &__image-container {
     background-color: $color__black;

--- a/sass/includes/_record-embed__no-image.scss
+++ b/sass/includes/_record-embed__no-image.scss
@@ -8,6 +8,12 @@
     border-radius: 50%;
     margin-bottom: 1rem;
     padding: 1rem;
+    width: 5rem;
+    height: 5rem;
+    margin: auto;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 3rem;
   }
 
   &__icon-label {

--- a/sass/includes/_research-resources.scss
+++ b/sass/includes/_research-resources.scss
@@ -8,6 +8,12 @@
     border-radius: 50%;
     margin-bottom: 1rem;
     padding: 1rem;
+    width: 5rem;
+    height: 5rem;
+    margin: auto;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 3rem;
   }
 
   &__icon-label {

--- a/sass/includes/_section-separator.scss
+++ b/sass/includes/_section-separator.scss
@@ -1,7 +1,4 @@
 .section-separator {
-  width: 100vw;
-  position: relative;
-  left: calc(-50vw + 50%);
 
   &__heading {
     font-size: 2.5rem;

--- a/templates/includes/blog-embed.html
+++ b/templates/includes/blog-embed.html
@@ -1,6 +1,6 @@
 <div class="blog-embed">
     <div class="container">
-        <img class="blog-embed__icon" src="/static/images/fontawesome-svgs/comment-white.svg" alt="">
+        <div class="blog-embed__icon"style="background-image: url('/static/images/fontawesome-svgs/comment-white.svg');"></div>
         <p class="blog-embed__icon-label" role="presentation" aria-hidden="true">
             Blog
         </p>

--- a/templates/includes/blog-embed.html
+++ b/templates/includes/blog-embed.html
@@ -1,26 +1,28 @@
 <div class="blog-embed">
-    <img class="blog-embed__icon" src="/static/images/fontawesome-svgs/comment-white.svg" alt="">
-    <p class="blog-embed__icon-label" role="presentation" aria-hidden="true">
-        Blog
-    </p>
+    <div class="container">
+        <img class="blog-embed__icon" src="/static/images/fontawesome-svgs/comment-white.svg" alt="">
+        <p class="blog-embed__icon-label" role="presentation" aria-hidden="true">
+            Blog
+        </p>
 
-    <h3 class="blog-embed__heading">
-        <span class="sr-only">Blog.</span>
-        Paying for the privilege: a new Shakespeare discovery
-    </h3>
+        <h3 class="blog-embed__heading">
+            <span class="sr-only">Blog.</span>
+            Paying for the privilege: a new Shakespeare discovery
+        </h3>
 
-    <p class="blog-embed__date">
-        Published on <time datetime="2016-04-23">Saturday 23 April 2016</time>
-    </p>
+        <p class="blog-embed__date">
+            Published on <time datetime="2016-04-23">Saturday 23 April 2016</time>
+        </p>
 
-    <div class="blog-embed__image-container">
-        <img class="blog-embed__image" src="https://via.placeholder.com/690x260" alt="Summary in Signet Office Docquet Book of licence to the Lord Chamberlain’s Men (including Shakespeare) and fee charged (catalogue reference: SO 3/2)">
+        <div class="blog-embed__image-container">
+            <img class="blog-embed__image" src="https://via.placeholder.com/690x260" alt="Summary in Signet Office Docquet Book of licence to the Lord Chamberlain’s Men (including Shakespeare) and fee charged (catalogue reference: SO 3/2)">
+        </div>
+
+        <!--  Paragraphs to be placed in a for loop  -->
+        <p class="blog-embed__text">
+            One third of a pound does not go far today – it’s not even a small child’s pocket money. But in 1603, it helped Shakespeare secure his future.
+        </p>
+
+        <a class="tna-button--dark" href="https://blog.nationalarchives.gov.uk/paying-privilege-new-shakespeare-discovery/">Read the full blog</a>
     </div>
-
-    <!--  Paragraphs to be placed in a for loop  -->
-    <p class="blog-embed__text">
-        One third of a pound does not go far today – it’s not even a small child’s pocket money. But in 1603, it helped Shakespeare secure his future.
-    </p>
-
-    <a class="tna-button--dark" href="https://blog.nationalarchives.gov.uk/paying-privilege-new-shakespeare-discovery/">Read the full blog</a>
 </div>

--- a/templates/includes/box-out.html
+++ b/templates/includes/box-out.html
@@ -1,44 +1,44 @@
-<div class="callout">
+<div class="box-out">
     <div class="container">
         <h3 class="sr-only">Legal cases relating to Shakespeare</h3>
-        <p class="callout__standfirst">
+        <p class="box-out__standfirst">
             Whilst the registry record of Shakespeare’s birth is held in Stratford-upon-Avon and his November 28th 1582 marriage bond to Anne Hathaway is now in Worcestershire Record Office, a series of important records of his life are held at The National Archives, including pleadings and depositions in three lawsuits in the Court of Requests involving Shakespeare.
         </p>
 
         <!-- Links to be conditionally rendered -->
-        <dl class="callout__list">
-            <div class="callout__list-item">
+        <dl class="box-out__list">
+            <div class="box-out__list-item">
                 <dt>
-                    <h4 class="callout__link-heading">
-                        <a class="callout__link" href="http://discovery.nationalarchives.gov.uk/details/r/C5904894">
+                    <h4 class="box-out__link-heading">
+                        <a class="box-out__link" href="http://discovery.nationalarchives.gov.uk/details/r/C5904894">
                             The case of Belott versus Mountjoy
                         </a>
                     </h4>
                 </dt>
-                <dd class="callout__link-text">
+                <dd class="box-out__link-text">
                     This concerns a marriage dowry and contains Shakespeare’s signed deposition. The documents pinpoint his residence in 1604.                            </dd>
             </div>
-            <div class="callout__list-item">
+            <div class="box-out__list-item">
                 <dt>
-                    <h4 class="callout__link-heading">
-                        <a class="callout__link" href="http://discovery.nationalarchives.gov.uk/details/r/C2677795">
+                    <h4 class="box-out__link-heading">
+                        <a class="box-out__link" href="http://discovery.nationalarchives.gov.uk/details/r/C2677795">
                             The case of Keysar versus Burbage and others
                         </a>
                     </h4>
                 </dt>
-                <dd class="callout__link-text">
+                <dd class="box-out__link-text">
                     This describes the King’s Men acting company’s involvement in the Blackfriars Playhouse.
                 </dd>
             </div>
-            <div class="callout__list-item">
+            <div class="box-out__list-item">
                 <dt>
-                    <h4 class="callout__link-heading">
-                        <a class="callout__link" href="http://discovery.nationalarchives.gov.uk/details/r/C5904893">
+                    <h4 class="box-out__link-heading">
+                        <a class="box-out__link" href="http://discovery.nationalarchives.gov.uk/details/r/C5904893">
                             The case of Witter versus Heminges and Condell
                         </a>
                     </h4>
                 </dt>
-                <dd class="callout__link-text">
+                <dd class="box-out__link-text">
                     This describes the way in which the shares in the syndicate that leased the Globe playhouse were distributed.                            </dd>
             </div>
         </dl>

--- a/templates/includes/content-block.html
+++ b/templates/includes/content-block.html
@@ -1,14 +1,16 @@
 <div class="content-block">
-    <h3 class="content-block__heading">
-        Shakespeare's career
-    </h3>
-    <div class="content-block__text">
-        <p>
-            William Shakespeare, also known as the ‘Bard’, was born in Stratford-upon-Avon on April 23rd 1564. It is thought he married his wife, Anne Hathaway, in 1582, although we have no specific marriage certificate. He pursued a career as an actor, poet and dramatist in London.                    </p>
-        <p>
-            His now famous plays were performed widely during his lifetime, often at the purpose-built Globe Theatre in London on the south bank of the Thames. The first folio was published in 1623, with 154 sonnets, 37 plays, and 2 long poems. It is suggested that his friends put it together in case others tried to copy Shakespeare’s work and claim it as their own.                    </p>
-        <p>
-            Since then, he has become internationally renowned as the world’s greatest ever playwright.
-        </p>
+    <div class="container">
+        <h3 class="content-block__heading">
+            Shakespeare's career
+        </h3>
+        <div class="content-block__text">
+            <p>
+                William Shakespeare, also known as the ‘Bard’, was born in Stratford-upon-Avon on April 23rd 1564. It is thought he married his wife, Anne Hathaway, in 1582, although we have no specific marriage certificate. He pursued a career as an actor, poet and dramatist in London.                    </p>
+            <p>
+                His now famous plays were performed widely during his lifetime, often at the purpose-built Globe Theatre in London on the south bank of the Thames. The first folio was published in 1623, with 154 sonnets, 37 plays, and 2 long poems. It is suggested that his friends put it together in case others tried to copy Shakespeare’s work and claim it as their own.                    </p>
+            <p>
+                Since then, he has become internationally renowned as the world’s greatest ever playwright.
+            </p>
+        </div>
     </div>
 </div>

--- a/templates/includes/media-embed--audio.html
+++ b/templates/includes/media-embed--audio.html
@@ -1,7 +1,7 @@
 <div class="media-embed" style="background: url(/static/images/media-embed-bg.png)">
     <div class="media-embed__overlay"></div>
     <div class="media-embed__content-panel">
-        <img class="media-embed__icon" src="/static/images/fontawesomesvgs/headphones-white.svg" alt="">
+        <div class="media-embed__icon" style="background-image: url('/static/images/fontawesome-svgs/headphones-white.svg');"></div>
         <p class="media-embed__icon-label" role="presentation" aria-hidden="true">
             Podcast
         </p>

--- a/templates/includes/media-embed--video.html
+++ b/templates/includes/media-embed--video.html
@@ -1,7 +1,7 @@
 <div class="media-embed" style="background: url(/static/images/media-embed-bg.png)">
     <div class="media-embed__overlay"></div>
     <div class="media-embed__content-panel">
-        <img class="media-embed__icon" src="/static/images/fontawesomesvgs/video-white.svg" alt="">
+        <div class="media-embed__icon" style="background-image: url('/static/images/fontawesome-svgs/video-white.svg');"></div>
         <p class="media-embed__icon-label" role="presentation" aria-hidden="true">
             Video
         </p>

--- a/templates/includes/record-embed--no-image.html
+++ b/templates/includes/record-embed--no-image.html
@@ -1,6 +1,6 @@
 <div class="record-embed-no-image">
     <div class="container">
-        <img class="record-embed-no-image__icon" src="/static/images/fontawesomesvgs/search-white.svg" alt="">
+        <div class="record-embed-no-image__icon" style="background-image: url('/static/images/fontawesome-svgs/search-white.svg');"></div>
         <p class="record-embed-no-image__icon-label" role="presentation" aria-hidden="true">
             Discover our records
         </p>

--- a/templates/includes/record-embed--no-image.html
+++ b/templates/includes/record-embed--no-image.html
@@ -1,25 +1,23 @@
 <div class="record-embed-no-image">
-    <img class="record-embed-no-image__icon" src="/static/images/fontawesomesvgs/search-white.svg" alt="">
-    <p class="record-embed-no-image__icon-label" role="presentation" aria-hidden="true">
-        Discover our records
-    </p>
+    <div class="container">
+        <img class="record-embed-no-image__icon" src="/static/images/fontawesomesvgs/search-white.svg" alt="">
+        <p class="record-embed-no-image__icon-label" role="presentation" aria-hidden="true">
+            Discover our records
+        </p>
+        <h3 class="record-embed-no-image__heading">
+            <span class="sr-only">Discover our records.</span>
+            Shakespeare and James I
+        </h3>
+        <p class="record-embed-no-image__text--inline">
+            Reference: LC 2/4/5    </p>
+        <p class="record-embed-no-image__text--inline">
+            Date created: <time datetime="1958">1958</time>
+        </p>
+        <p class="record-embed-no-image__text">
+            Other documents at The National Archives reveal the growing status and prestige of Shakespeare, as, for example, the 1604 Progress of James I through the city of London, which mentions a grant of cloth to Shakespeare.
+        </p>
+        <!-- Buttons to be placed in a for loop in case there are more than one e.g. view in the catalogue and read more in our blog -->
+        <a class="tna-button--dark" href="http://discovery.nationalarchives.gov.uk/details/r/C213527">View in the catalogue</a>
 
-    <h3 class="record-embed-no-image__heading">
-        <span class="sr-only">Discover our records.</span>
-        Shakespeare and James I
-    </h3>
-
-    <p class="record-embed-no-image__text--inline">
-        Reference: LC 2/4/5    </p>
-
-    <p class="record-embed-no-image__text--inline">
-        Date created: <time datetime="1958">1958</time>
-    </p>
-
-    <p class="record-embed-no-image__text">
-        Other documents at The National Archives reveal the growing status and prestige of Shakespeare, as, for example, the 1604 Progress of James I through the city of London, which mentions a grant of cloth to Shakespeare.
-    </p>
-
-    <!-- Buttons to be placed in a for loop in case there are more than one e.g. view in the catalogue and read more in our blog -->
-    <a class="tna-button--dark" href="http://discovery.nationalarchives.gov.uk/details/r/C213527">View in the catalogue</a>
+    </div>
 </div>

--- a/templates/includes/related-content.html
+++ b/templates/includes/related-content.html
@@ -13,10 +13,10 @@
             <div class="card-group-secondary-nav__body">
                 <h3 class="card-group-secondary-nav__heading">Event - ‘Before Shakespeare’ at The National Archives</h3>
                 <p class="card-group-secondary-nav__paragraph"><time datetime="2018-08-01">Wednesday 1 August 2018</time></p>
-                <p>In this talk, the project team will ask the fundamental question, ‘what is a playhouse?’, and explore surviving documents that tell us what we know about these spaces, and rethink the builders, managers, and audiences who brought them into being.</p>
+                <p class="card-group-secondary-nav__paragraph">In this talk, the project team will ask the fundamental question, ‘what is a playhouse?’, and explore surviving documents that tell us what we know about these spaces, and rethink the builders, managers, and audiences who brought them into being.</p>
 
                 <!-- Price will be conditionally rendered if it's needed e.g. for an event ticket price -->
-                <p>Price - £4</p>
+                <p class="card-group-secondary-nav__paragraph">Price - £4</p>
             </div>
         </a>
     </div>

--- a/templates/includes/research-resources.html
+++ b/templates/includes/research-resources.html
@@ -1,42 +1,44 @@
 <div class="research-resources">
-    <img class="research-resources__icon" src="/static/images/fontawesomesvgs/book-open-white.svg" alt="">
-    <p class="research-resources__icon-label" role="presentation" aria-hidden="true">
-        Research
-    </p>
+    <div class="container">
+        <img class="research-resources__icon" src="/static/images/fontawesomesvgs/book-open-white.svg" alt="">
+        <p class="research-resources__icon-label" role="presentation" aria-hidden="true">
+            Research
+        </p>
 
-    <h3 class="research-resources__heading">
-        Research resources
-        <span class="sr-only">Research</span>
-    </h3>
+        <h3 class="research-resources__heading">
+            Research resources
+            <span class="sr-only">Research</span>
+        </h3>
 
-    <p class="research-resources__description">
-        These research resources may be a helpful way to continue your exploration of Shakespeare.
-    </p>
+        <p class="research-resources__description">
+            These research resources may be a helpful way to continue your exploration of Shakespeare.
+        </p>
 
-    <dl class="research-resources__list">
-        <div class="research-resources__list-item">
-            <dt>
-                <h4 class="research-resources__link-heading">
-                    <a class="research-resources__link" href="https://www.nationalarchives.gov.uk/education/resources/tudor-entertainment/">
-                        Tudor Entertainment
-                    </a>
-                </h4>
-            </dt>
-            <dd class="research-resources__link-text">
-                What was the effect of the early playhouses?
-            </dd>
-        </div>
-        <div class="research-resources__list-item">
-            <dt>
-                <h4 class="research-resources__link-heading">
-                    <a class="research-resources__link" href="https://www.nationalarchives.gov.uk/education/resources/james-i/">
-                        James I
-                    </a>
-                </h4>
-            </dt>
-            <dd class="research-resources__link-text">
-                What were the key areas of dispute?
-            </dd>
-        </div>
-    </dl>
+        <dl class="research-resources__list">
+            <div class="research-resources__list-item">
+                <dt>
+                    <h4 class="research-resources__link-heading">
+                        <a class="research-resources__link" href="https://www.nationalarchives.gov.uk/education/resources/tudor-entertainment/">
+                            Tudor Entertainment
+                        </a>
+                    </h4>
+                </dt>
+                <dd class="research-resources__link-text">
+                    What was the effect of the early playhouses?
+                </dd>
+            </div>
+            <div class="research-resources__list-item">
+                <dt>
+                    <h4 class="research-resources__link-heading">
+                        <a class="research-resources__link" href="https://www.nationalarchives.gov.uk/education/resources/james-i/">
+                            James I
+                        </a>
+                    </h4>
+                </dt>
+                <dd class="research-resources__link-text">
+                    What were the key areas of dispute?
+                </dd>
+            </div>
+        </dl>
+    </div>
 </div>

--- a/templates/includes/research-resources.html
+++ b/templates/includes/research-resources.html
@@ -1,6 +1,6 @@
 <div class="research-resources">
     <div class="container">
-        <img class="research-resources__icon" src="/static/images/fontawesomesvgs/book-open-white.svg" alt="">
+        <div class="research-resources__icon" style="background-image: url('/static/images/fontawesome-svgs/book-open-white.svg');"></div>
         <p class="research-resources__icon-label" role="presentation" aria-hidden="true">
             Research
         </p>

--- a/templates/insights/insights_page.html
+++ b/templates/insights/insights_page.html
@@ -8,7 +8,6 @@
     {% include 'includes/hero-img.html' %}
     {% include 'includes/jumplinks.html' %}
 
-    <div class="container">
         {% include 'includes/section-separator.html' %}
         {% include 'includes/content-block.html' %}
         {% include 'includes/content-block--bordered.html' %}
@@ -18,7 +17,7 @@
             {% include_block block %}
         {% endfor %}
 
-        {% include 'includes/callout.html' %}
+        {% include 'includes/box-out.html' %}
         {% include 'includes/section-separator.html' %}
         {% include 'includes/record-embed--no-image.html' %}
         {% include 'includes/media-embed--audio.html' %}
@@ -27,11 +26,14 @@
         {% include 'includes/section-separator.html' %}
         {% include 'includes/blog-embed.html' %}
         {% include 'includes/media-embed--video.html' %}
-
+        <div class="container">
         <h3 class="related-content__heading">Explore our other content about Shakespeare</h3>
         <p>Find out more about Shakespeare at The National Archives.</p>
-        {% include 'includes/related-content.html' %}
+            <ul class="card-group--list-style-none">
+                {% include 'includes/related-content.html' %}
+            </ul>
+        </div>
         {% include 'includes/key-facts--author.html' %}
 
-    </div>
+
 {% endblock %}

--- a/templates/quotes/blocks/quote.html
+++ b/templates/quotes/blocks/quote.html
@@ -1,20 +1,21 @@
 <div class="quote">
-    <img class="quote__icon" src="/static/images/fontawesome-svgs/quote-icon.svg" alt="" />
-    <h3 class="sr-only">{{ value.heading }}</h3>
+    <div class="container">
+        <img class="quote__icon" src="/static/images/fontawesome-svgs/quote-icon.svg" alt="" />
+        <h3 class="sr-only">{{ value.heading }}</h3>
 
-    {% if value.attribution %}
-        <figure>
+        {% if value.attribution %}
+            <figure>
+                <blockquote class="quote__container">
+                    <p class="quote__text">{{ value.quote }}</p>
+                </blockquote>
+                <figcaption class="quote__citation">
+                    <cite>{{ value.attribution }}</cite>
+                </figcaption>
+            </figure>
+        {% else %}
             <blockquote class="quote__container">
                 <p class="quote__text">{{ value.quote }}</p>
             </blockquote>
-            <figcaption class="quote__citation">
-                <cite>{{ value.attribution }}</cite>
-            </figcaption>
-        </figure>
-    {% else %}
-        <blockquote class="quote__container">
-            <p class="quote__text">{{ value.quote }}</p>
-        </blockquote>
-    {% endif %}
-
+        {% endif %}
+    </div>
 </div>


### PR DESCRIPTION
Hi @JamesWChan 

Would you be able to merge this branch?

This contains the following fixes:

- The `100vw` fix
- Renaming `callout` to `box-out`
- Fixing some issues with the icons. The URLs were incorrect. Also, as the `border-radius` was applied directly to the `<img>` tag, the images were being cut off by this `border-radius`. Therefore I've changed them to `<div>` elements with `background-image` which doesn't get affected by `border-radius`. Hopefully this is OK.
- Preventing `sr-only` elements appearing as contrast issues (by giving them a `background-color` and `color` even though they're never visible) This is just so they don't pollute the WAVE/Lighthouse issues across the whole application.

Would you be able to merge if this is OK?

Thanks :+1: