### PR TITLE
Only show evidential records in record chooser DS-256

### DIFF
--- a/etna/collections/tests/test_views.py
+++ b/etna/collections/tests/test_views.py
@@ -70,6 +70,16 @@ class TestRecordChooseView(WagtailPageTests):
             content["html"],
         )
 
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/search?stream=evidential&term=law&from=0&pretty=false",
+        )
+        self.assertEqual(
+            responses.calls[1].request.url,
+            "https://kong.test/search?stream=evidential&size=1&term=law&from=0&pretty=false",
+        )
+
     @responses.activate
     def test_select(self):
         response = self.client.get("/admin/record-chooser/C10297/")

--- a/etna/records/views.py
+++ b/etna/records/views.py
@@ -75,7 +75,9 @@ class KongModelChooserMixinIn(ModelChooserMixin):
         object_list = self.get_unfiltered_object_list()
 
         if search_term:
-            object_list = self.model.search.filter(term=search_term)
+            object_list = self.model.search.filter(
+                term=search_term, stream="evidential"
+            )
 
         return object_list
 


### PR DESCRIPTION
Update call to Kong to only present evidential data in `RecordChooser`