### PR TITLE
Remove line that says toolkit CSS is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,5 @@ And then **import**:
 
 - Ensure you have NodeJS & NPM installed.
 - Install SASS globally by running `npm install -g sass`.
-- Download `tna-toolkit.0.0.1.css` into `/templates/static/css/libraries/`. [Download link is here.](https://raw.githubusercontent.com/nationalarchives/tna-frontend-design-toolkit/main/dist/css/tna-toolkit.0.0.1.css)
 - To watch and build the SASS, run `sass --watch sass/etna.scss:templates/static/css/dist/etna.css`
 - To modify styles, navigate to the `sass` folder in your editor.


### PR DESCRIPTION
This is no longer relevant since we are using the SASS directly within the repo.