### PR TITLE
Fix migration conflict in insights

### DIFF
--- a/etna/insights/migrations/0008_add_teaser_image.py
+++ b/etna/insights/migrations/0008_add_teaser_image.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtailimages', '0023_add_choose_permissions'),
-        ('insights', '0006_record_embed_blocks'),
+        ('insights', '0007_add_section_block'),
     ]
 
     operations = [


### PR DESCRIPTION
CommandError: Conflicting migrations detected;
multiple leaf nodes in the migration graph:
(0007_add_section_block, 0007_add_teaser_image in insights).