### PR TITLE
Remove generic-intro from results page intro text

### DIFF
--- a/templates/collections/results_page.html
+++ b/templates/collections/results_page.html
@@ -7,7 +7,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12" id="content">
-                <div class="generic-intro">
+                <div class="mt-4">
                     <p>{{ page.introduction }}</p>
                 </div>
                 <div class="results">


### PR DESCRIPTION
Hi @JamesWChan 

Would you be able to merge this?

It fixes a styling issue on the explorer results page - if you don't have the Kong environment variables you can only see this page on the live environment at https://www.main-bvxea6i-rasrzs7pi6sd4.uk-1.platformsh.site/explore-the-collection/explore-by-topic/arts-and-culture/the-design-registers/ 



![image](https://user-images.githubusercontent.com/8880610/127324612-7df31fa5-00c0-4f1e-b02e-5279e912a14e.png)


I changed it to this:

![image](https://user-images.githubusercontent.com/8880610/127324642-3c3d9c7a-3d18-464c-a639-b27992ef13bf.png)


Would you be able to merge this?

Thanks :+1: