### PR TITLE
Update all 'src' paths to use 'static'

### DIFF
--- a/templates/quotes/blocks/quote.html
+++ b/templates/quotes/blocks/quote.html
@@ -2,7 +2,7 @@
 
 <div class="quote">
     <div class="container">
-        <img class="quote__icon" src="/static/images/fontawesome-svgs/quote-left.svg" alt="" />
+        <img class="quote__icon" src="{% static 'images/fontawesome-svgs/quote-left.svg' %}" alt="" />
         <h3 class="sr-only">{{ value.heading }}</h3>
 
         {% if value.attribution %}


### PR DESCRIPTION
Hi @danbentley - I hadn't realised that _not_ using `static` within the path would cause an error (my previous PR had updated the code to ensure that where `static` was used it had been loaded). I've done quite a thorough search through the code and I think this is the only instance of a local `src` attribute that doesn't use `static`.