### PR TITLE
Feature/fix component names

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -55,7 +55,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/specifics';
 @import 'includes/content-block';
 @import 'includes/quote';
-@import 'includes/box-out';
+@import 'includes/featured-records';
 @import 'includes/media-embed';
 @import 'includes/record-embed';
 @import 'includes/record-embed__no-image';

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -59,7 +59,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/media-embed';
 @import 'includes/record-embed';
 @import 'includes/record-embed__no-image';
-@import 'includes/research-resources';
+@import 'includes/related-resources';
 @import 'includes/blog-embed';
 @import 'includes/related-content';
 @import 'includes/key-facts__author';

--- a/sass/includes/_featured-records.scss
+++ b/sass/includes/_featured-records.scss
@@ -42,8 +42,16 @@
  }
 
  &__link-text {
-   color: $color__grey-4;
+   color: $color__white;
    margin-bottom: 0;
+
+   a {
+     color: $color__white;
+
+     &:focus {
+       outline: 0.313rem solid $color__blue_5;
+     }
+   }
  }
 
   p:last-child {

--- a/sass/includes/_featured-records.scss
+++ b/sass/includes/_featured-records.scss
@@ -1,4 +1,4 @@
-.box-out {
+.featured-records {
   background-color: $color__blue_3;
   padding: 2rem 0;
 

--- a/sass/includes/_related-resources.scss
+++ b/sass/includes/_related-resources.scss
@@ -1,4 +1,4 @@
-.research-resources {
+.related-resources {
   text-align: center;
   margin: 0 0 2rem 0;
   padding: 2rem 0;

--- a/templates/insights/blocks/featured_record.html
+++ b/templates/insights/blocks/featured_record.html
@@ -19,13 +19,6 @@
             </p>
         {% endif %}
 
-        {% comment %}
-        {# Images not yet returned by kong #}
-        <div class="blog-embed__image-container">
-            {% image value.teaser_image min-690x260 alt=value.teaser_alt_text class="blog-embed__image" %}
-        </div>
-        {% endcomment %}
-
         <p class="record-embed-no-image__text">{{ value.record.description|safe }}</p>
         <!-- Buttons to be placed in a for loop in case there are more than one e.g. view in the catalogue and read more in our blog -->
         {% if value.record.reference_number %}

--- a/templates/insights/blocks/featured_records.html
+++ b/templates/insights/blocks/featured_records.html
@@ -1,24 +1,24 @@
-<div class="box-out">
+<div class="featured-records">
     <div class="container">
         <h3 class="sr-only">{{ value.heading }}</h3>
-        <p class="box-out__standfirst">
+        <p class="featured-records__standfirst">
             {{ value.introduction }}
         </p>
 
-        <dl class="box-out__list" data-container-name="featured-records" id="analytics-featured-records">
+        <dl class="featured-records__list" data-container-name="featured-records" id="analytics-featured-records">
             {% for record in value.records %}
-                <div class="box-out__list-item">
+                <div class="featured-records__list-item">
                     <dt>
-                        <h4 class="box-out__link-heading">
+                        <h4 class="featured-records__link-heading">
                             {% if record.reference_number %}
-                                <a class="box-out__link" href="{% url 'details-page-human-readable' record.reference_number %}" data-link="{{ record.title }}">{{ record.title }}</a>
+                                <a class="featured-records__link" href="{% url 'details-page-human-readable' record.reference_number %}" data-link="{{ record.title }}">{{ record.title }}</a>
                             {% elif record.iaid %}
-                                <a class="box-out__link" href="{% url 'details-page-machine-readable' record.iaid %}" data-link="{{ record.title }}">{{ record.title }}</a>
+                                <a class="featured-records__link" href="{% url 'details-page-machine-readable' record.iaid %}" data-link="{{ record.title }}">{{ record.title }}</a>
                             {% endif %}
                         </h4>
                     </dt>
                     {% if record.description %}
-                        <dd class="box-out__link-text">{{ record.description|safe }}</dd>
+                        <dd class="featured-records__link-text">{{ record.description|safe }}</dd>
                     {% endif %}
                 </div>
             {% endfor %}

--- a/templates/insights/blocks/promoted_list_block.html
+++ b/templates/insights/blocks/promoted_list_block.html
@@ -8,34 +8,34 @@
         {% static value.category.icon_static_path as bg_image %}
         <div class="blog-embed__icon" style="background-image: url('{{ bg_image }}');"></div>
         {% endif %}
-        <p class="research-resources__icon-label" role="presentation" aria-hidden="true">
+        <p class="related-resources__icon-label" role="presentation" aria-hidden="true">
             {{ value.category.name }}
         </p>
 
-        <h3 class="research-resources__heading">
+        <h3 class="related-resources__heading">
             {{ value.heading }}
             <span class="sr-only">{{ value.heading }}</span>
         </h3>
 
         {% if value.summary %}
-        <p class="research-resources__description">
+        <p class="related-resources__description">
             {{ value.summary|richtext }}
         </p>
         {% endif %}
 
         {% if value.promoted_items %}
-        <dl class="research-resources__list">
+        <dl class="related-resources__list">
             {% for item in value.promoted_items %}
-            <div class="research-resources__list-item">
+            <div class="related-resources__list-item">
                 <dt>
-                    <h4 class="research-resources__link-heading">
-                        <a class="research-resources__link" href="{{ item.url }}" data-link="{{ item.title }}">
+                    <h4 class="related-resources__link-heading">
+                        <a class="related-resources__link" href="{{ item.url }}" data-link="{{ item.title }}">
                             {{ item.title }}
                         </a>
                     </h4>
                 </dt>
                 {% if item.description %}
-                <dd class="research-resources__link-text">
+                <dd class="related-resources__link-text">
                     {{ item.description }}
                 </dd>
                 {% endif %}


### PR DESCRIPTION
Hi @gtvj,

This PR replaces instances of `box-out` with `featured-records` and instances of `research-resources` with `related-resources` in the HTML and SASS. It also removes a comment referring to a `blog-embed` element in the featured-record.html file (I'm not too sure why it was there but I can reinstate it if it's needed).

Everything looks okay locally, would it be possible to merge if you are happy? Thank you 👍 