### PR TITLE
Amend promoted item teaser image implementation

### DIFF
--- a/templates/insights/blocks/promoted_item.html
+++ b/templates/insights/blocks/promoted_item.html
@@ -31,7 +31,22 @@
         </p>
 
         <div class="blog-embed__image-container">
-            {% image value.teaser_image min-690x260 alt=value.teaser_alt_text class="blog-embed__image" %}
+            <picture>
+                {% image value.teaser_image fill-800x500 as teaser %}
+                <source media="(max-width: 480px)" srcset="{{ teaser.url }}">
+                {% image value.teaser_image fill-800x500 as teaser %}
+                <source media="(max-width: 640px)" srcset="{{ teaser.url }}">
+                {% image value.teaser_image fill-800x450 as teaser %}
+                <source media="(max-width: 768px)" srcset="{{ teaser.url }}">
+                {% image value.teaser_image fill-800x350 as teaser %}
+                <source media="(max-width: 991px)" srcset="{{ teaser.url }}">
+                {% image value.teaser_image fill-800x350 as teaser %}
+                <source media="(max-width: 1199px)" srcset="{{ teaser.url }}">
+                {% image value.teaser_image fill-800x300 as teaser %}
+                <source media="(max-width: 1200px)" srcset="{{ teaser.url }}">
+                {% image value.teaser_image fill-800x300 as teaser %}
+                <img src="{{ teaser.url }}" alt="{{ teaser.alt }}" class="blog-embed__image" />
+            </picture>
         </div>
 
         <div class="blog-embed__text">


### PR DESCRIPTION
Hi @gtvj,

Would it be possible to have a look at this PR? It implements the teaser image for promoted items (e.g. a blog embed) in the same fashion as the hero image so that the image isn't distorted as the screen is resized. Thank you 👍 