### PR TITLE
Feature/fix details page

### DIFF
--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from django.db import models
 
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 
 from ..ciim.models import SearchManager, MediaManager
 from .transforms import transform_record_page_result, transform_image_result
@@ -51,6 +51,13 @@ class RecordPage(Page):
         self._debug_kong_result = kwargs.pop("_debug_kong_result", None)
 
         super().__init__(*args, **kwargs)
+
+    def get_site(self):
+        """Override to return the Site instance despite this page not belonging to the CMS.
+
+        Site is used by base.html to add the site name to the page's <title>
+        """
+        return Site.objects.first()
 
     def __str__(self):
         return f"{self.title} ({self.iaid})"

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,10 +9,10 @@
             {% if form.errors %}Error: {% endif %}
 
             {% block title %}
-                {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}
+                {% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}
             {% endblock %}
             {% block title_suffix %}
-                {% with self.get_site.site_name as site_name %}
+                {% with page.get_site.site_name as site_name %}
                     {% if site_name %}- {{ site_name }}{% endif %}
                 {% endwith %}
             {% endblock %}

--- a/templates/includes/records/key-facts.html
+++ b/templates/includes/records/key-facts.html
@@ -10,5 +10,5 @@
             <li><span>Record now held at:</span><b>{{ page.held_by }}</b></li>
         {% endif %}
     </ul>
-    <p class="key-facts__link"><a href="#" data-link="See the full description">See the full description</a></p>
+    <p class="key-facts__link"><a href="#record-description" data-link="See the full description">See the full description</a></p>
 </div>

--- a/templates/includes/records/key-facts.html
+++ b/templates/includes/records/key-facts.html
@@ -10,5 +10,5 @@
             <li><span>Record now held at:</span><b>{{ page.held_by }}</b></li>
         {% endif %}
     </ul>
-    <p class="key-facts__link"><a href="#record-description" data-link="See the full description">See the full description</a></p>
+    <p class="key-facts__link"><a href="#record-details-heading" data-link="See the full description">See the full description</a></p>
 </div>

--- a/templates/records/record_page.html
+++ b/templates/records/record_page.html
@@ -36,7 +36,7 @@
                 {% endif %}
                 {% include "includes/records/record-access-options.html" %}
 
-                <h2>Description and record details</h2>
+                <h2 id="record-description">Description and record details</h2>
 
                 {% include "includes/records/record-details.html" %}
 

--- a/templates/records/record_page.html
+++ b/templates/records/record_page.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 
 {% load static %}
+{% load i18n %}
 {% load datalayer_tags %}
+
+{% block title %}
+    {{ page.title }} - {% trans 'The National Archives' %}
+{% endblock %}
 
 {% block extra_gtm_js %}
 {{ page | datalayer:request | json_script:"datalayer" }}

--- a/templates/records/record_page.html
+++ b/templates/records/record_page.html
@@ -1,12 +1,7 @@
 {% extends "base.html" %}
 
 {% load static %}
-{% load i18n %}
 {% load datalayer_tags %}
-
-{% block title %}
-    {{ page.title }} - {% trans 'The National Archives' %}
-{% endblock %}
 
 {% block extra_gtm_js %}
 {{ page | datalayer:request | json_script:"datalayer" }}

--- a/templates/records/record_page.html
+++ b/templates/records/record_page.html
@@ -36,7 +36,7 @@
                 {% endif %}
                 {% include "includes/records/record-access-options.html" %}
 
-                <h2 id="record-description">Description and record details</h2>
+                <h2 id="record-details-heading">Description and record details</h2>
 
                 {% include "includes/records/record-details.html" %}
 


### PR DESCRIPTION
Hi @gtvj, @danbentley, 

Would it be possible to merge this if you're happy? It adds an `id` to the record details `h2` so that the "See full description" jumplink works and it also fixes the details page title (previously it displayed the url and now it displays the record title e.g. "9 Battalion Royal Irish Rifles - The National Archives"). Thank you 👍 