### PR TITLE
Fix disambiguation page

### DIFF
--- a/etna/ciim/tests/factories.py
+++ b/etna/ciim/tests/factories.py
@@ -10,7 +10,11 @@ def create_record(
     latest="2100",
     is_digitised=False,
     media_reference_id="0f183772-6fa7-4fb4-b608-412cf6fa8204",
+    hierarchy=None,
 ):
+    if not hierarchy:
+        hierarchy = []
+
     """Return a sample response for a record.
 
     Useful for tidying up tests where response needs to be mocked
@@ -34,6 +38,7 @@ def create_record(
                 },
             },
             "digitised": is_digitised,
+            "hierarchy" : [hierarchy],
             "@summary": {
                 "title": title,
             },

--- a/etna/ciim/tests/test_models.py
+++ b/etna/ciim/tests/test_models.py
@@ -487,9 +487,9 @@ class ModelTranslationTest(TestCase):
             ],
         )
 
-    def test_taxonomy(self):
+    def test_topics(self):
         self.assertEqual(
-            self.record_page.taxonomy,
+            self.record_page.topics,
             [
                 {
                     "title": "Taxonomy One",

--- a/etna/ciim/tests/test_models.py
+++ b/etna/ciim/tests/test_models.py
@@ -502,3 +502,53 @@ class ModelTranslationTest(TestCase):
                 },
             ],
         )
+
+
+@override_settings(
+    KONG_CLIENT_BASE_URL="https://kong.test", KONG_CLIENT_TEST_MODE=False
+)
+class UnexpectedParsingIssueTest(TestCase):
+    """A collection of tests verifying fixes for real-world (but unexpected)
+    issues with data returned by Kong"""
+
+    @responses.activate
+    def test_hierarchy_with_no_identifier_is_skipped(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/fetch",
+            json=create_response(
+                records=[
+                    create_record(
+                        iaid="C123456",
+                        hierarchy=[
+                            {
+                                "@summary": {
+                                    "title": "Foreign and Commonwealth Office and predecessors: Cultural Relations Departments:..."
+                                },
+                            },
+                        ],
+                    ),
+                ]
+            ),
+        )
+
+        record_page = RecordPage.search.get(iaid="C123456")
+
+        self.assertEqual(record_page.hierarchy, [])
+
+    @responses.activate
+    def test_record_with_origination_but_no_date(self):
+        record = create_record(
+            iaid="C123456",
+        )
+        del record['_source']['@origination']['date']
+
+        responses.add(
+            responses.GET,
+            "https://kong.test/fetch",
+            json=create_response(records=[record]),
+        )
+
+        record_page = RecordPage.search.get(iaid="C123456")
+
+        self.assertEqual(record_page.origination_date, None)

--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -61,6 +61,23 @@ class TestResolveLinks(SimpleTestCase):
             stripped_markup,
         )
 
+    def test_invalid_link(self):
+        # C3829405 contains an span.extref with no href
+        markup = (
+            "<span>"
+            '<span class="extref">Invalid link</span>'
+            "</span>"
+        )
+
+        stripped_markup = format_description_markup(markup)
+
+        self.assertEquals(
+            (
+                '<span></span>'
+            ),
+            stripped_markup,
+        )
+
 
 class TestPluck(SimpleTestCase):
     def test_pluck_from_dict_in_list(self):

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -116,7 +116,7 @@ def resolve_links(markup):
         if link := pq(span).attr("href"):
             return pq(f'<a href="{link}">{pq(span).text()}</a>')
 
-        return ''
+        return ""
 
     document(".extref").each(lambda _, e: pq(e).replace_with(link_from_span(e)))
 

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -116,6 +116,8 @@ def resolve_links(markup):
         if link := pq(span).attr("href"):
             return pq(f'<a href="{link}">{pq(span).text()}</a>')
 
+        return ''
+
     document(".extref").each(lambda _, e: pq(e).replace_with(link_from_span(e)))
 
     return str(document)

--- a/etna/records/converters.py
+++ b/etna/records/converters.py
@@ -37,4 +37,4 @@ class IAIDConverter(StringConverter):
     https://beta.nationalarchives.gov.uk/C11285946/
     """
 
-    regex = r"(\w\d+)"
+    regex = r"(\w\d+)|([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})"

--- a/etna/records/tests/test_urls.py
+++ b/etna/records/tests/test_urls.py
@@ -171,9 +171,22 @@ class TestMachineReadableDetailsRouteResolution(TestCase):
         self.assertEquals(resolver.view_name, "details-page-machine-readable")
         self.assertEqual(resolver.kwargs["iaid"], "d123456")
 
+    def test_resolves_uuid(self):
+        # Some IAIDs are UUIDs. Tested IAID is a real example
+        resolver = resolve("/catalogue/43f766a9-e968-4b82-93dc-8cf11a841d41/")
+
+        self.assertEquals(resolver.func, views.record_page_view)
+        self.assertEqual(resolver.view_name, "details-page-machine-readable")
+        self.assertEqual(resolver.kwargs["iaid"], "43f766a9-e968-4b82-93dc-8cf11a841d41")
+
 
 class TestMachineReadableDetailsURL(TestCase):
-    def test_reverse_reference_number_lettercode(self):
+    def test_reverse_iaid(self):
         url = reverse("details-page-machine-readable", kwargs={"iaid": "C7810139"})
 
         self.assertEqual(url, "/catalogue/C7810139/")
+
+    def test_reverse_uuid(self):
+        url = reverse("details-page-machine-readable", kwargs={"iaid": "43f766a9-e968-4b82-93dc-8cf11a841d41"})
+
+        self.assertEqual(url, "/catalogue/43f766a9-e968-4b82-93dc-8cf11a841d41/")

--- a/etna/records/transforms.py
+++ b/etna/records/transforms.py
@@ -23,7 +23,9 @@ def transform_record_page_result(result):
         data["created_by"] = pluck(
             origination, accessor=lambda i: i["creator"][0]["name"][0]["value"]
         )
-        data["origination_date"] = origination["date"]["value"]
+        data["origination_date"] = pluck(
+            origination, accessor=lambda i: i["date"]["value"]
+        )
 
     if description := source.get("description"):
         data["description"] = format_description_markup(description[0]["value"])
@@ -55,7 +57,7 @@ def transform_record_page_result(result):
                 "reference_number": i["identifier"][0]["reference_number"],
                 "title": i["@summary"]["title"],
             }
-            for i in hierarchy[0]
+            for i in hierarchy[0] if 'identifier' in i
         ]
 
     if availability := source.get("availability"):

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -10,7 +10,7 @@
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record_page.title }}">
             <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
             <div class="card-group-record-summary__body">
-                <p>{{ description_override|default:record_page.description|safe }}</p>
+                <p>{{ description_override|default:record_page.description|striptags }}</p>
             </div>
         </a>
     </div>

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -3,15 +3,6 @@
 {% load static %}
 {% load datalayer_tags %}
 
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
-
 {% block content %}
     {% include 'includes/generic-intro.html'  with self="Several records share this reference" only %}
 


### PR DESCRIPTION
Some disambiguation pages returned data that couldn't be parsed into a `RecordPage`.

Additionally, the `datalayer` template tag raised an error because there's no page object to query. 