### PR TITLE
Move GTM script below the dataLayer push

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -5,6 +5,15 @@
     <title>Internal server error</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+            "contentGroup1": "Error pages",
+            "customDimension1": "offsite",
+            "customDimension3": "500 server error page"
+        });
+    </script>
+
     <!-- Google Tag Manager -->
     <script>(function (w, d, s, l, i) {
         w[l] = w[l] || [];
@@ -19,15 +28,6 @@
         f.parentNode.insertBefore(j, f);
     })(window, document, 'script', 'dataLayer', 'GTM-TQLPKH2');</script>
     <!-- End Google Tag Manager -->
-
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push({
-            "contentGroup1": "Error pages",
-            "customDimension1": "offsite",
-            "customDimension3": "500 server error page"
-        });
-    </script>
 
 </head>
 <body>


### PR DESCRIPTION
Hi @JamesWChan - could you have a look at this PR. It's just moving the `dataLayer.push()` above the GTM script.