### PR TITLE
Feature/details page image link

### DIFF
--- a/sass/includes/_image-viewer-panel.scss
+++ b/sass/includes/_image-viewer-panel.scss
@@ -13,17 +13,31 @@
       display: block;
       margin: 0 auto;
     }
+  }
 
-    a {
-      padding: 2rem 1rem 2rem 2.5rem;
-      display: inline-block;
+  &__text-link {
+    padding: 2rem 1rem 2rem 2.5rem;
+    display: inline-block;
+    color: $color__white;
+    background: url($fa_search_plus) no-repeat center left;
+    background-size: 1.75rem;
+    text-align: center;
+    font-weight: bold;
+    vertical-align: top;
+    font-size: 1.1rem;
+
+    &:visited {
       color: $color__white;
-      background: url($fa_search_plus) no-repeat center left;
-      background-size: 1.75rem;
-      text-align: center;
-      font-weight: bold;
-      vertical-align: top;
-      font-size: 1.1rem;
+    }
+
+    &:focus {
+      outline: 0.313rem solid $color__blue_5;
+    }
+  }
+
+  &__image-link:hover, &__image-link:focus {
+    img {
+      outline: 0.313rem solid $color__blue_5;
     }
   }
 }

--- a/templates/includes/records/image-viewer-panel.html
+++ b/templates/includes/records/image-viewer-panel.html
@@ -1,9 +1,11 @@
 <div class="image-viewer-panel" data-container-name="image-viewer-panel" id="analytics-image-viewer-panel">
     <div class="container">
         <figure>
-            <img src="{% url 'image-serve' location=image.location %}" alt="">
+            <a class="image-viewer-panel__image-link" href="{% url 'image-browse' iaid=page.iaid %}">
+                <img src="{% url 'image-serve' location=image.location %}" alt="">
+            </a>
             <figcaption>
-                <a href="{% url 'image-browse' iaid=page.iaid %}" title="#">Open in our image viewer</a>
+                <a class="image-viewer-panel__text-link" href="{% url 'image-browse' iaid=page.iaid %}" title="#">Open in our image viewer</a>
             </figcaption>
         </figure>
     </div>


### PR DESCRIPTION
Hi @gtvj,

Would it be possible to have a look at this PR? It wraps the image in the image viewer within a link and adds the appropriate focus and hover styles (the image browse page uses light blue for hover and focus for images on a black background and so that's why it was chosen here). I also updated the text link focus style to light blue for consistency.

I added a BEM class to the image link because it seemed like the best way to isolate it. I added a BEM class to the text link for consistency in the HTML.

Thank you 👍 