### PR TITLE
Style disambiguation pagination and trucate item descriptions

### DIFF
--- a/sass/includes/_pagination.scss
+++ b/sass/includes/_pagination.scss
@@ -16,6 +16,7 @@
 
             ol {
                 padding: 0;
+                list-style-type: none;
             }
         }
 

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -10,7 +10,7 @@
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record_page.title }}">
             <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
             <div class="card-group-record-summary__body">
-                <p>{{ description_override|default:record_page.description|striptags }}</p>
+                <p>{{ description_override|default:record_page.description|striptags|truncatewords:40 }}</p>
             </div>
         </a>
     </div>

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -8,8 +8,11 @@
 
     <div class="disambiguation-explanation">
         <div class="container">
-            <h2 class="disambiguation-explanation__subheading">Several records share the reference {{ queried_reference_number }}. </h2>
-            <p>Very occasionally (less than 1% of the time) a record shares its catalogue reference with other records in the catalogue, usually with its own sub-records. This is the case with reference {{ queried_reference_number }}.</p>
+            <h2 class="disambiguation-explanation__subheading">Several records share the
+                reference {{ queried_reference_number }}. </h2>
+            <p>Very occasionally (less than 1% of the time) a record shares its catalogue reference with other records
+                in the catalogue, usually with its own sub-records. This is the case with
+                reference {{ queried_reference_number }}.</p>
             <p class="mb-0">Its associated records are listed below.</p>
         </div>
     </div>
@@ -18,7 +21,8 @@
         <div class="row">
             <h3 class="sr-only">Associated records</h3>
 
-            <ul class="card-group--list-style-none" data-container-name="associated-records" id="analytics-associated-records">
+            <ul class="card-group--list-style-none" data-container-name="associated-records"
+                id="analytics-associated-records">
 
                 {% for page in pages %}
                     {% include 'includes/card-group-record-summary-no-image.html' with record_page=page %}
@@ -28,26 +32,52 @@
         </div>
     </div>
 
-    {% if pages.has_other_pages %}
-        <ul class="pagination">
-            {% if pages.has_previous %}
-                <li><a href="?page={{ pages.previous_page_number }}">&laquo;</a></li>
-            {% else %}
-                <li class="disabled"><span>&laquo;</span></li>
-            {% endif %}
-            {% for i in pages.paginator.page_range %}
-                {% if pages.number == i %}
-                    <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+    <nav class="pagination" role="navigation" aria-label="Records pagination" data-container-name="Pagination"
+         id="analytics-disambiguation-pagination">
+        {% if pages.has_other_pages %}
+            <ul class="pagination__list">
+                {% if pages.has_previous %}
+                    <li class="pagination__list-item">
+                        <a class="pagination__page-chevron-previous" href="?page={{ pages.previous_page_number }}"><span
+                                class="sr-only" data-link="Previous page">Previous page</span></a>
+                    </li>
                 {% else %}
-                    <li><a href="?page={{ i }}">{{ i }}</a></li>
+                    <li class="pagination__list-item">
+                        <span class="pagination__page-chevron-previous--disabled"></span>
+                    </li>
                 {% endif %}
-            {% endfor %}
-            {% if pages.has_next %}
-                    <li><a href="?page={{ pages.next_page_number }}">&raquo;</a></li>
-            {% else %}
-                <li class="disabled"><span>&raquo;</span></li>
-            {% endif %}
-        </ul>
-    {% endif %}
+                <li class="pagination__list-pages" aria-label="Page numbers">
+                    <ol>
+                        {% for i in pages.paginator.page_range %}
+                            {% if pages.number == i %}
+                                <li class="pagination__list-item">
+                                    <a class="pagination__page-link-current" href="?page={{ i }}"
+                                       aria-label="Current page, Page {{ i }}"
+                                       aria-current="true" data-link="{{ i }}"><span
+                                            class="sr-only">Current page </span>{{ i }}</a>
+                                </li>
+                            {% else %}
+                                <li class="pagination__list-item"><a class="pagination__page-link" href="?page={{ i }}"
+                                                                     aria-label="Go to page {{ i }}"
+                                                                     data-link="{{ i }}"><span
+                                        class="sr-only">Page </span>{{ i }}</a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ol>
+                </li>
+                {% if pages.has_next %}
+                    <li class="pagination__list-item">
+                        <a class="pagination__page-chevron-next" href="?page={{ pages.next_page_number }}"
+                           data-link="Next page"><span class="sr-only">Next page</span></a>
+                    </li>
+                {% else %}
+                    <li class="pagination__list-item">
+                        <span class="pagination__page-chevron-next--disabled"></span>
+                    </li>
+                {% endif %}
+            </ul>
+        {% endif %}
+    </nav>
 
 {% endblock content %}


### PR DESCRIPTION
This introduces:

1. the same component pattern HTML for pagination as is used in other places (directly in the view)
2. uses the `truncatewords` Django [built-in filter](https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#truncatewords) to truncate descriptions within `card-group-record-summary-no-image.html` 