### PR TITLE
Add condition to prevent page.subheading being rendered empty

### DIFF
--- a/templates/includes/generic-intro-with-prefix.html
+++ b/templates/includes/generic-intro-with-prefix.html
@@ -6,7 +6,9 @@
                     <span class="generic-intro__title-prefix">[Optional Prefix]</span>
                     {{ self.title }}
                 </h1>
-                <p>{{ page.sub_heading }}</p>
+                {% if page.sub_heading %}
+                    <p>{{ page.sub_heading }}</p>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/templates/includes/generic-intro.html
+++ b/templates/includes/generic-intro.html
@@ -5,7 +5,9 @@
                 <h1 class="generic-intro__title">
                     {{ self.title }}
                 </h1>
-                <p>{{ page.sub_heading }}</p>
+                {% if page.sub_heading %}
+                    <p>{{ page.sub_heading }}</p>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
This is just a quick change to prevent an issue which is currently present on the record disambiguation page (that I've just spotted). I've just added a condition to prevent a `<p>` being rendered empty.