### PR TITLE
Ensure the edit page is still accessible even if a record isn't available in Kong

### DIFF
--- a/etna/records/tests/test_blocks.py
+++ b/etna/records/tests/test_blocks.py
@@ -361,6 +361,33 @@ class TestFeaturedRecordsBlockIntegration(WagtailPageTests):
         )
 
     @responses.activate
+    def test_view_edit_page_with_featured_record_not_in_kong(self):
+        """Ensure that even if a record associated with this page doesn't
+        exist, we're still able to render its edit page."""
+
+        responses.add(responses.GET, "https://kong.test/fetch", json=create_response())
+
+        self.insights_page.body = json.dumps(
+            [
+                {
+                    "type": "featured_records",
+                    "value": {
+                        "heading": "This is a heading",
+                        "introduction": "This is some text",
+                        "records": ["C123456"],
+                    },
+                }
+            ]
+        )
+        self.insights_page.save()
+
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=(self.insights_page.id,))
+        )
+
+        self.assertEquals(response.status_code, 200)
+
+    @responses.activate
     def test_view_page_with_featured_record(self):
         self.insights_page.body = json.dumps(
             [

--- a/etna/records/widgets.py
+++ b/etna/records/widgets.py
@@ -1,7 +1,7 @@
 from generic_chooser.widgets import AdminChooser
 
 from .models import RecordPage
-from ..ciim.exceptions import KongError
+from ..ciim.exceptions import KongException
 
 
 class RecordChooser(AdminChooser):
@@ -15,7 +15,7 @@ class RecordChooser(AdminChooser):
         """Fetch related instance on edit form."""
         try:
             return self.model.search.get(iaid=pk)
-        except KongError:
+        except KongException:
             # If there's a connection issue with Kong, return a stub RecordPage
             # so we have something to render on the ResultsPage edit form.
             return RecordPage(iaid=pk)


### PR DESCRIPTION
It's possible that a referenced record on an insights or results page isn't available in Kong, this fix ensure the edit page is still accessible.