### PR TITLE
Remove author component from insights page

### DIFF
--- a/templates/insights/insights_page.html
+++ b/templates/insights/insights_page.html
@@ -22,7 +22,6 @@
         {% include_block block %}
     {% endfor %}
 
-    {% include 'includes/key-facts--author.html' %}
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Hi @gtvj,

Would it be possible to have a quick look at this PR? It just removes the currently hardcoded author component from the Insights page as per Piriya's request. Thank you 👍 