### PR TITLE
Fix issue where record doesn't have a teaser image

### DIFF
--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -1,24 +1,27 @@
 {% load wagtailimages_tags %}
 
-{% image teaser_image fill-288x292 as teaser_image_small %}
-{% image teaser_image fill-328x322 as teaser_image_medium %}
-{% image teaser_image fill-348x352 as teaser_image_large %}
-{% image teaser_image fill-543x549 as teaser_image_extra_large %}
-
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record_page.title }}">
             <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
             <figure>
-                <div class="card-group-record-summary__image">
-                    <picture>
-                        <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
-                        <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
-                        <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
-                        <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_extra_large.url }}" alt="Record Alt" class="card-group-record-summary__image-fallback">
-                    </picture>
-                </div>
+                {% if teaser_image %}
+
+                    {% image teaser_image fill-288x292 as teaser_image_small %}
+                    {% image teaser_image fill-328x322 as teaser_image_medium %}
+                    {% image teaser_image fill-348x352 as teaser_image_large %}
+                    {% image teaser_image fill-543x549 as teaser_image_extra_large %}
+
+                    <div class="card-group-record-summary__image">
+                        <picture>
+                            <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
+                            <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
+                            <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
+                            <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                            <img src="{{ teaser_image_extra_large.url }}" alt="Record Alt" class="card-group-record-summary__image-fallback">
+                        </picture>
+                    </div>
+                {% endif %}
                 <div class="card-group-record-summary__body">
                     <figcaption>{{ description_override|default:record_page.description|safe }}</figcaption>
                 </div>


### PR DESCRIPTION
`teaser_image` for a record on the results page is optional.

Images should be associated with all highlight records for launch but currently many of them don't have images yet.