### PR TITLE
Put transcript in details element

### DIFF
--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -65,12 +65,33 @@
     background-color: $color__dark;
     font-size: 1.2rem;
     margin-top: 2rem;
-    padding: 2rem;
+    padding: 1rem;
+
+    details {
+      summary{
+        text-align: left;
+        padding: 1rem;
+
+        &:focus {
+          outline: 0.313rem solid $color__focus-blue-outline-dark-bg;
+        }
+      }
+
+      summary::marker {
+        color: $color__white;
+      }
+    }
   }
 
-  &__transcript-heading, &__transcript-text {
+  &__transcript-heading {
+    color: $color__white;
+    display: inline;
+  }
+
+  &__transcript-text {
     color: $color__white;
     text-align: left;
+    margin-top: 2rem;
   }
 }
 

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -68,8 +68,8 @@
     padding: 1rem;
 
     details {
+      text-align: left;
       summary{
-        text-align: left;
         padding: 1rem;
 
         &:focus {
@@ -90,7 +90,6 @@
 
   &__transcript-text {
     color: $color__white;
-    text-align: left;
     margin-top: 2rem;
   }
 }

--- a/templates/media/blocks/media-block--audio.html
+++ b/templates/media/blocks/media-block--audio.html
@@ -35,9 +35,13 @@
 
 {% if value.transcript %}
 <div class="media-embed__transcript">
-    <h4 class="media-embed__transcript-heading">Transcript</h4>
-    <div class="media-embed__transcript-text">
-        {{ value.transcript|richtext }}
-    </div>
+    <details>
+        <summary>
+            <h4 class="media-embed__transcript-heading">Transcript</h4>
+        </summary>
+        <div class="media-embed__transcript-text">
+            {{ value.transcript|richtext }}
+        </div>
+    </details>
 </div>
 {% endif %}

--- a/templates/media/blocks/media-block--video.html
+++ b/templates/media/blocks/media-block--video.html
@@ -35,9 +35,13 @@
 
 {% if value.transcript %}
 <div class="media-embed__transcript">
-    <h4 class="media-embed__transcript-heading">Transcript</h4>
-    <div class="media-embed__transcript-text">
-        {{ value.transcript|richtext }}
-    </div>
+    <details>
+        <summary>
+            <h4 class="media-embed__transcript-heading">Transcript</h4>
+        </summary>
+        <div class="media-embed__transcript-text">
+            {{ value.transcript|richtext }}
+        </div>
+    </details>
 </div>
 {% endif %}


### PR DESCRIPTION
Hi @gtvj,

This PR puts the transcript within a `<details>` element so it can be toggled. This is to solve the issue where a very long transcript would result in a very long webpage.

Thank you 👍 