### PR TITLE
Feature/image viewer fe fixes

### DIFF
--- a/sass/includes/_image-viewer-panel.scss
+++ b/sass/includes/_image-viewer-panel.scss
@@ -13,7 +13,7 @@
       display: block;
       margin: 0 auto;
 
-      @media only screen and (max-width: 768px) {
+      @media only screen and (max-width: $screen__md) {
         height: auto;
         width: 100%;
       }

--- a/sass/includes/_image-viewer-panel.scss
+++ b/sass/includes/_image-viewer-panel.scss
@@ -12,6 +12,11 @@
       height: 25rem;
       display: block;
       margin: 0 auto;
+
+      @media only screen and (max-width: 768px) {
+        height: auto;
+        width: 100%;
+      }
     }
   }
 
@@ -33,6 +38,11 @@
     &:focus {
       outline: 0.313rem solid $color__focus-blue-outline-dark-bg;
     }
+
+    &:hover {
+      color: $color__white;
+      text-decoration: none;
+    }
   }
 
   &__image-link:hover, &__image-link:focus {
@@ -41,3 +51,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Hi @gtvj,

This PR fixes the details page image resize issue mentioned in the stand up. It uses a media query at 768px to modify the height and width. It also fixes an issue with the image viewer text link hover style; on localhost it stays white but on live it switches to dark blue on hover so I've added an explicit rule. Thank you 👍 