### PR TITLE
Fix the padding bottom on browse pagination

### DIFF
--- a/sass/includes/_pagination.scss
+++ b/sass/includes/_pagination.scss
@@ -10,6 +10,7 @@
 
         display: flex;
         justify-content: start;
+        margin-bottom: 0;
 
         &-pages {
             padding: 0;


### PR DESCRIPTION
I noticed on the Beta site that there's a margin bottom on the pagination component which seems to have been inherited by the list. This PR overrides that.