### PR TITLE
Add CSS to provide some spacing around XSLT generated markup

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -66,3 +66,4 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/disambiguation-explanation';
 @import 'includes/login-status';
 @import 'includes/forms';
+@import 'includes/xslt-patches';

--- a/sass/includes/_xslt-patches.scss
+++ b/sass/includes/_xslt-patches.scss
@@ -1,0 +1,19 @@
+// This stylesheet has been added in response to a launch date request
+// from the data team to patch some issues which are present in the data
+
+// This is intended for only padding and block levelling items. WE SHOULD
+// BE VERY MINDFUL OF Success Criterion 1.3.1 when working here and not
+// introduce anything that is to make up for a lack of information or
+// relationships that should be present in the HTML.
+
+.xslt_patches {
+
+  [altrender=doctype] {
+    display: none;
+  }
+
+  span {
+    display: block;
+    margin-bottom: 1rem;
+  }
+}

--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -10,7 +10,7 @@
             {% if page.description %}
                 <tr>
                     <th scope="row">Record description</th>
-                    <td>{{ page.description|safe }}</td>
+                    <td class="xslt_patches">{{ page.description|safe }}</td>
                 </tr>
             {% endif %}
             {% if page.origination_date %}


### PR DESCRIPTION
We were asked by the data team to provide add CSS in order to improve the presentation of XLST generated markup which appears within the Record Description block of details pages. This included a request to make spans appear to be list items.

I have explained that using CSS to make HTML that lacks appropriate semantics appear as it would if the correct semantics were in place would fail a [Level A WCAG Success Criterion 1.3.1](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html). and that the best I can do is to introduce some padding.

It has been acknowledged by data colleagues that this is an issue which needs to be addressed at source.