### PR TITLE
Add title to 404 page

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,9 +1,31 @@
-{% extends "base.html" %}
+{% load static %}
 
-{% block body_class %}template-404{% endblock %}
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>Page not found - The National Archives</title>
+    <meta name="description" content=""/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
-{% block content %}
+    <link rel="stylesheet" type="text/css" href="{% static 'css/dist/etna.css' %}">
+    <meta name="description" content=""/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
+    {% include 'includes/gtm-script.html' %}
+
+    {# Google Fonts #}
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap"
+          rel="stylesheet">
+    <script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';</script>
+</head>
+
+<body class="template-404">
+{% include 'includes/gtm-no-script.html' %}
+{% include 'includes/header.html' %}
+
+<main id="maincontent">
     <div class="generic-intro">
         <div class="container">
             <div class="row">
@@ -23,5 +45,9 @@
             </div>
         </div>
     </div>
+</main>
 
-{% endblock %}
+{% include 'includes/footer.html' %}
+
+</body>
+</html>


### PR DESCRIPTION
Having been contacted by analytics colleagues this morning to add a title to the 404 page I noticed that base.html relies upon values that are not available in the 404 page.

Having done a bit of research online it seems the default 404 view provides two variables to the view: `request_path` and `exception`. It might be that `exception` would allow us to add a condition to `base.html` but since I can't set `DEBUG` to `False` (which I'd need to do in order to examine `exception`) it seemed most pragmatic to replicate the static content of base.html within 404.html