### PR TITLE
Front end fixes - Part 2

### DIFF
--- a/sass/includes/_hierarchy-global-nav.scss
+++ b/sass/includes/_hierarchy-global-nav.scss
@@ -1,6 +1,8 @@
 .hierarchy-global {
 
-  position: sticky;
+  @media only screen and (min-width: $screen__xl) {
+    position: sticky;
+  }
   top: 2em;
 
   details {

--- a/sass/includes/_hierarchy-local-nav.scss
+++ b/sass/includes/_hierarchy-local-nav.scss
@@ -6,10 +6,6 @@
 
   &__nav-item {
     margin: 0;
-
-    a {
-      display: block;
-    }
   }
 
   &__nav-indicator {
@@ -32,11 +28,19 @@
   }
 
 
-  &__nav-label, &__nav-link {
+  &__nav-label, &__nav-link-span {
     display: none;
 
     @media only screen and (min-width: $screen__lg) {
       display: inline;
+    }
+  }
+
+  &__nav-link {
+    display: none;
+
+    @media only screen and (min-width: $screen__lg) {
+      display: block;
     }
   }
 }

--- a/sass/includes/_record-access-options.scss
+++ b/sass/includes/_record-access-options.scss
@@ -15,6 +15,7 @@
 
     &:focus {
       outline: 0.312rem solid $color__link;
+      outline-offset: 0.125rem;
     }
 
   }

--- a/scripts/src/details.js
+++ b/scripts/src/details.js
@@ -1,6 +1,7 @@
 import manage_details_element from './modules/manage_details_element';
 import scroll_to_bottom from "./modules/scroll_to_bottom";
 import push_reference_and_series from "./modules/analytics/push_reference_and_series";
+import add_unique_ids from "./modules/analytics/add_unique_ids";
 
 const summary_element = document.querySelector('#js-hierarchy-global summary');
 const hierarchy_list = document.querySelector('.hierarchy-global__list');
@@ -18,6 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
     manage_details_element();
     scroll_to_bottom(hierarchy_list);
     push_reference_and_series();
+    add_unique_ids();
 });
 
 window.addEventListener("resize", () => {

--- a/scripts/src/details.js
+++ b/scripts/src/details.js
@@ -1,5 +1,6 @@
 import manage_details_element from './modules/manage_details_element';
 import scroll_to_bottom from "./modules/scroll_to_bottom";
+import push_reference_and_series from "./modules/analytics/push_reference_and_series";
 
 const summary_element = document.querySelector('#js-hierarchy-global summary');
 const hierarchy_list = document.querySelector('.hierarchy-global__list');
@@ -16,6 +17,7 @@ summary_element.addEventListener('click', e => {
 document.addEventListener("DOMContentLoaded", () => {
     manage_details_element();
     scroll_to_bottom(hierarchy_list);
+    push_reference_and_series();
 });
 
 window.addEventListener("resize", () => {

--- a/scripts/src/details.js
+++ b/scripts/src/details.js
@@ -3,23 +3,25 @@ import scroll_to_bottom from "./modules/scroll_to_bottom";
 import push_reference_and_series from "./modules/analytics/push_reference_and_series";
 import add_unique_ids from "./modules/analytics/add_unique_ids";
 
-const summary_element = document.querySelector('#js-hierarchy-global summary');
-const hierarchy_list = document.querySelector('.hierarchy-global__list');
-
-
-summary_element.addEventListener('click', e => {
-
-    if (window.innerWidth < 1200) {
-        return;
-    }
-    e.preventDefault();
-});
-
 document.addEventListener("DOMContentLoaded", () => {
+
+    const hierarchy_list = document.querySelector('.hierarchy-global__list');
+
     manage_details_element();
     scroll_to_bottom(hierarchy_list);
     push_reference_and_series();
     add_unique_ids();
+
+    const summary_element = document.querySelector('#js-hierarchy-global summary');
+
+    summary_element.addEventListener('click', e => {
+
+        if (window.innerWidth < 1200) {
+            return;
+        }
+        e.preventDefault();
+    });
+
 });
 
 window.addEventListener("resize", () => {

--- a/scripts/src/explorer.js
+++ b/scripts/src/explorer.js
@@ -1,4 +1,5 @@
 import add_analytics_data_card_position from './modules/analytics/card_position'
+import add_unique_ids from "./modules/analytics/add_unique_ids";
 
 add_analytics_data_card_position('.card-group-promo--green');
 add_analytics_data_card_position('.card-group-secondary-nav__link');
@@ -7,3 +8,7 @@ add_analytics_data_card_position('.card-group--list-style-none');
 add_analytics_data_card_position('.card-group--no-flex');
 add_analytics_data_card_position('.card-group-promo__card');
 add_analytics_data_card_position('.card-group-promo__card-heading a');
+
+document.addEventListener("DOMContentLoaded", () => {
+   add_unique_ids();
+});

--- a/scripts/src/explorer.js
+++ b/scripts/src/explorer.js
@@ -1,14 +1,15 @@
 import add_analytics_data_card_position from './modules/analytics/card_position'
 import add_unique_ids from "./modules/analytics/add_unique_ids";
 
-add_analytics_data_card_position('.card-group-promo--green');
-add_analytics_data_card_position('.card-group-secondary-nav__link');
-add_analytics_data_card_position('.card-group-record-summary');
-add_analytics_data_card_position('.card-group--list-style-none');
-add_analytics_data_card_position('.card-group--no-flex');
-add_analytics_data_card_position('.card-group-promo__card');
-add_analytics_data_card_position('.card-group-promo__card-heading a');
 
 document.addEventListener("DOMContentLoaded", () => {
-   add_unique_ids();
+    add_analytics_data_card_position('.card-group-promo--green');
+    add_analytics_data_card_position('.card-group-secondary-nav__link');
+    add_analytics_data_card_position('.card-group-record-summary');
+    add_analytics_data_card_position('.card-group--list-style-none');
+    add_analytics_data_card_position('.card-group--no-flex');
+    add_analytics_data_card_position('.card-group-promo__card');
+    add_analytics_data_card_position('.card-group-promo__card-heading a');
+
+    add_unique_ids();
 });

--- a/scripts/src/image-browse.js
+++ b/scripts/src/image-browse.js
@@ -4,12 +4,14 @@ import calc_scroll_percent_increment from "./modules/analytics/scroll_tracking/c
 import update_scroll_obj from "./modules/analytics/scroll_tracking/update_scroll_obj";
 import get_scroll_percentage from "./modules/analytics/scroll_tracking/get_scroll_percentage";
 
-add_data_link('.image-browse__listing a');
-
 let scrollObj = {
     'event': 'image-viewer-browse',
     highestScrollPercentage: get_scroll_percentage()
 };
+
+document.addEventListener('DOMContentLoaded', () => {
+    add_data_link('.image-browse__listing a');
+});
 
 document.addEventListener('scroll', e => {
     const percentageIncrement = calc_scroll_percent_increment();

--- a/scripts/src/image-browse.js
+++ b/scripts/src/image-browse.js
@@ -4,20 +4,20 @@ import calc_scroll_percent_increment from "./modules/analytics/scroll_tracking/c
 import update_scroll_obj from "./modules/analytics/scroll_tracking/update_scroll_obj";
 import get_scroll_percentage from "./modules/analytics/scroll_tracking/get_scroll_percentage";
 
-let scrollObj = {
-    'event': 'image-viewer-browse',
-    highestScrollPercentage: get_scroll_percentage()
-};
-
 document.addEventListener('DOMContentLoaded', () => {
     add_data_link('.image-browse__listing a');
-});
 
-document.addEventListener('scroll', e => {
-    const percentageIncrement = calc_scroll_percent_increment();
-    scrollObj = update_scroll_obj(percentageIncrement, scrollObj);
-});
+    let scrollObj = {
+        'event': 'image-viewer-browse',
+        highestScrollPercentage: get_scroll_percentage()
+    };
 
-window.addEventListener('beforeunload', e => {
-    push_to_data_layer(scrollObj);
+    document.addEventListener('scroll', e => {
+        const percentageIncrement = calc_scroll_percent_increment();
+        scrollObj = update_scroll_obj(percentageIncrement, scrollObj);
+    });
+
+    window.addEventListener('beforeunload', e => {
+        push_to_data_layer(scrollObj);
+    });
 });

--- a/scripts/src/insights.js
+++ b/scripts/src/insights.js
@@ -3,10 +3,10 @@ import audio_tracking from "./modules/analytics/audio_tracking"
 import video_tracking from "./modules/analytics/video_tracking"
 import add_unique_ids from "./modules/analytics/add_unique_ids";
 
-add_analytics_data_card_position('.record-embed-no-image');
-add_analytics_data_card_position('.card-group-secondary-nav');
-
 document.addEventListener('DOMContentLoaded', () => {
+    add_analytics_data_card_position('.record-embed-no-image');
+    add_analytics_data_card_position('.card-group-secondary-nav');
+
     audio_tracking();
     video_tracking();
     add_unique_ids();

--- a/scripts/src/insights.js
+++ b/scripts/src/insights.js
@@ -1,6 +1,7 @@
 import add_analytics_data_card_position from './modules/analytics/card_position'
 import audio_tracking from "./modules/analytics/audio_tracking"
 import video_tracking from "./modules/analytics/video_tracking"
+import add_unique_ids from "./modules/analytics/add_unique_ids";
 
 add_analytics_data_card_position('.record-embed-no-image');
 add_analytics_data_card_position('.card-group-secondary-nav');
@@ -8,4 +9,5 @@ add_analytics_data_card_position('.card-group-secondary-nav');
 document.addEventListener('DOMContentLoaded', () => {
     audio_tracking();
     video_tracking();
+    add_unique_ids();
 });

--- a/scripts/src/modules/analytics/add_unique_ids.js
+++ b/scripts/src/modules/analytics/add_unique_ids.js
@@ -2,7 +2,9 @@ const add_unique_ids = () => {
 
     const items = [
         {selector: '.blog-embed', id_prefix: 'analytics-blog-embed'},
-        {selector: '.related-resources ul', id_prefix: 'analytics-related-resources'}
+        {selector: '.related-resources ul', id_prefix: 'analytics-related-resources'},
+        {selector: '.record-embed-no-image', id_prefix: 'analytics-record-embed-no-image'},
+        {selector: '.featured-records__list', id_prefix: 'analytics-featured-records'}
     ];
 
     items.forEach((item) => {

--- a/scripts/src/modules/analytics/add_unique_ids.js
+++ b/scripts/src/modules/analytics/add_unique_ids.js
@@ -1,0 +1,23 @@
+const add_unique_ids = () => {
+
+    const items = [
+        {selector: '.blog-embed', id_prefix: 'analytics-blog-embed'},
+        {selector: '.related-resources ul', id_prefix: 'analytics-related-resources'}
+    ];
+
+    items.forEach((item) => {
+
+        try {
+            const elements = document.querySelectorAll(item.selector);
+
+            Array.prototype.forEach.call(elements, (element, index) => {
+                element.id = `${item.id_prefix}-${index + 1}`;
+            });
+
+        } catch (e) {
+            console.error(`Error in generate_unique_ids module`);
+        }
+    })
+};
+
+export default add_unique_ids;

--- a/scripts/src/modules/analytics/push_reference_and_series.js
+++ b/scripts/src/modules/analytics/push_reference_and_series.js
@@ -1,0 +1,35 @@
+import push_to_data_layer from './push_to_data_layer'
+
+const push_reference_and_series = () => {
+
+    const hierarchy_items = document.getElementsByClassName('hierarchy-global__list-item'),
+        record_reference = document.getElementById('analytics-record-reference');
+
+    try {
+        if (hierarchy_items && hierarchy_items.length < 3) {
+
+            push_to_data_layer({
+                'event': 'reference',
+                'reference': `${record_reference.innerText}`,
+                'series': 'Above series level'
+            })
+        }
+
+        if (hierarchy_items && hierarchy_items.length >= 3) {
+
+            const series_title = hierarchy_items[2].querySelector('[data-link]').innerText,
+                series_reference = hierarchy_items[2].querySelector('.hierarchy-global__reference').innerText;
+
+            push_to_data_layer({
+                'event': 'reference',
+                'reference': `${record_reference.innerText}`,
+                'series': `${series_reference} - ${series_title}`,
+            })
+        }
+
+    } catch (e) {
+        console.error(`Error push_series_from_hierarchy module: ${e}`)
+    }
+};
+
+export default push_reference_and_series;

--- a/templates/collections/blocks/time_period_explorer.html
+++ b/templates/collections/blocks/time_period_explorer.html
@@ -15,7 +15,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_small.url }}" alt="" role="presentation" class="card-group-promo__card-image">
+                    <img src="{{ teaser_image_small.url }}" alt="" class="card-group-promo__card-image">
                 </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">

--- a/templates/collections/blocks/topic_explorer.html
+++ b/templates/collections/blocks/topic_explorer.html
@@ -15,7 +15,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_extra_large.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_small.url }}" alt="" role="presentation" class="card-group-promo__card-image">
+                    <img src="{{ teaser_image_small.url }}" alt="" class="card-group-promo__card-image">
                 </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">

--- a/templates/home/blocks/featured_external_page.html
+++ b/templates/home/blocks/featured_external_page.html
@@ -28,7 +28,7 @@ from a block for containing external page data or Wagtail page via its URL
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/home/blocks/featured_page.html
+++ b/templates/home/blocks/featured_page.html
@@ -27,7 +27,7 @@ containging a page with fields to optionally override some fields.
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/card-group-promo--dark.html
+++ b/templates/includes/card-group-promo--dark.html
@@ -19,7 +19,6 @@
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                     <img src="{{ teaser_image_extra_large.url }}"
                          alt=""
-                         role="presentation"
                          class="card-group-promo__card-image">
                 </picture>
             </div>

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -19,7 +19,6 @@
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                     <img src="{{ teaser_image_extra_large.url }}"
                          alt=""
-                         role="presentation"
                          class="card-group-promo__card-image">
                 </picture>
             </div>

--- a/templates/includes/card-group-secondary-nav-time-period.html
+++ b/templates/includes/card-group-secondary-nav-time-period.html
@@ -23,7 +23,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -18,7 +18,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
         </a>

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -5,7 +5,7 @@
         <div class="container py-3">
             <div class="row justify-content-md-center text-center">
                 <div class="col-sm-12 col-lg-2">
-                    <img src="{% static 'images/fontawesome-svgs/envelope.svg' %}" class="cta-banner-newsletter__icon" alt="" role="presentation" width="60" height="60"/>
+                    <img src="{% static 'images/fontawesome-svgs/envelope.svg' %}" class="cta-banner-newsletter__icon" alt="" width="60" height="60"/>
                 </div>
                 <div class="col-sm-12 col-lg-6">
                     <h3 class="cta-banner-newsletter__heading">Sign me up to The National Archives' mailing list</h3>

--- a/templates/includes/records/hierarchy-local.html
+++ b/templates/includes/records/hierarchy-local.html
@@ -8,12 +8,12 @@
                     <span class="hierarchy-local__nav-indicator hierarchy-local__nav-indicator--up"></span>
                     <span class="hierarchy-local__nav-label">This record is in</span>
                     {% if page.parent.reference_number %}
-                        <a href="{% url 'details-page-human-readable' page.parent.reference_number %}" data-link="Series level">
-                            <span class="hierarchy-local__nav-link">{{ page.parent.title }}</span>
+                        <a href="{% url 'details-page-human-readable' page.parent.reference_number %}" data-link="Series level" class="hierarchy-local__nav-link">
+                            <span class="hierarchy-local__nav-link-span">{{ page.parent.title }}</span>
                         </a>
                     {% elif page.parent.iaid %}
-                        <a href="{% url 'details-page-machine-readable' page.parent.iaid %}" data-link="Series level">
-                            <span class="hierarchy-local__nav-link">{{ page.parent.title }}</span>
+                        <a href="{% url 'details-page-machine-readable' page.parent.iaid %}" data-link="Series level" class="hierarchy-local__nav-link">
+                            <span class="hierarchy-local__nav-link-span">{{ page.parent.title }}</span>
                         </a>
                     {% endif %}
                 </p>

--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -4,7 +4,7 @@
             {% if page.reference_number %}
                 <tr>
                     <th scope="row">Reference</th>
-                    <td>{{ page.reference_number }}</td>
+                    <td id="analytics-record-reference">{{ page.reference_number }}</td>
                 </tr>
             {% endif %}
             {% if page.description %}

--- a/templates/includes/records/taxonomy-tags.html
+++ b/templates/includes/records/taxonomy-tags.html
@@ -1,5 +1,5 @@
 <div class="taxonomy-tags">
-    <ul class="taxonomy-tags__list">
+    <ul class="taxonomy-tags__list" id="analytics-taxonomy-tags">
         {% for topic in page.topics %}
             <li>{{ topic.title }}</li>
         {% endfor %}

--- a/templates/insights/blocks/featured_record.html
+++ b/templates/insights/blocks/featured_record.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load wagtailimages_tags %}
 
-<div class="record-embed-no-image" data-container-name="record-embed-no-image" id="analytics-record-embed-no-image">
+<div class="record-embed-no-image" data-container-name="record-embed-no-image">
     <div class="container">
         <div class="record-embed-no-image__icon" style="background-image: url({% static 'images/fontawesome-svgs/search-white.svg' %});"></div>
         <p class="record-embed-no-image__icon-label" role="presentation" aria-hidden="true">

--- a/templates/insights/blocks/featured_record.html
+++ b/templates/insights/blocks/featured_record.html
@@ -16,7 +16,7 @@
         {% endif %}
         {% if value.record.origination_date %}
             <p class="record-embed-no-image__text--inline">
-            Date created: <time datetime="{{ value.record.origination_date }}">{{ value.record.origination_date }}</time>
+            Date created: {{ value.record.origination_date }}
             </p>
         {% endif %}
 

--- a/templates/insights/blocks/featured_records.html
+++ b/templates/insights/blocks/featured_records.html
@@ -5,7 +5,7 @@
             {{ value.introduction }}
         </p>
 
-        <dl class="featured-records__list" data-container-name="featured-records" id="analytics-featured-records">
+        <dl class="featured-records__list" data-container-name="featured-records">
             {% for record in value.records %}
                 <div class="featured-records__list-item">
                     <dt>

--- a/templates/insights/blocks/related_item.html
+++ b/templates/insights/blocks/related_item.html
@@ -6,8 +6,8 @@
 {% image value.teaser_image fill-543x325 as teaser_image_extra_large %}
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
-    <div class="card-group-secondary-nav" data-card-title="{{ value.title }}" data-card-type="card-group-secondary-nav">
-        <a href="{{ value.url }}" class="card-group-secondary-nav__link">
+    <div class="card-group-secondary-nav">
+        <a href="{{ value.url }}" class="card-group-secondary-nav__link" data-card-title="{{ value.title }}" data-card-type="card-group-secondary-nav">
             <div class="card-group-secondary-nav__image">
                 <picture>
                     <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/insights/blocks/related_item.html
+++ b/templates/insights/blocks/related_item.html
@@ -14,7 +14,7 @@
                     <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                     <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                     <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_medium.url }}" alt="" role="presentation" class="card-group-secondary-nav__image-fallback">
+                    <img src="{{ teaser_image_medium.url }}" alt="" class="card-group-secondary-nav__image-fallback">
                 </picture>
             </div>
             <div class="card-group-secondary-nav__body">

--- a/templates/media/blocks/media-block--audio.html
+++ b/templates/media/blocks/media-block--audio.html
@@ -26,7 +26,7 @@
 {% endif %}
 
 <div class="media-embed__audio-container">
-    <audio controls="">
+    <audio controls="" {% if value.transcript %}aria-label="Transcript provided below"{% endif %}>
         <source src="{{ src }}" type="{{ type }}">
         <p>Your browser doesn't support HTML5 audio. Here is a <a href="{{ src }}">link to the audio</a>
             instead.</p>

--- a/templates/media/blocks/media-block--video.html
+++ b/templates/media/blocks/media-block--video.html
@@ -26,7 +26,7 @@
 {% endif %}
 
 <div class="media-embed__video-container">
-    <video class="media-embed__video" controls="">
+    <video class="media-embed__video" controls="" {% if value.transcript %}aria-label="Transcript provided below"{% endif %}>
         <source src="{{ src }}" type="{{ type }}">
         <p>Your browser doesn't support HTML5 video. Here is a <a href="{{ src }}">link to the video</a>
             instead.</p>


### PR DESCRIPTION
This PR includes further changes from the front end review and some additional analytics requirements that have been requested. The full changes are: 

- [x] Moving `data-*` attributes onto the link within related items cards
- [x] On details page, adding ID to taxonomy tags list `id="analytics-taxonomy-tags"`
- [x] Adding unique IDs to blog embeds - for example `analytics-blog-embed-1` (incrementing from 1)
- [x] Adding unique IDs to related resources `<ul>` -  for example `analytics-related-resources-1` (incrementing from 1) 
- [x] On details page, push reference and series to data layer` {'event': 'reference', 'series': 'WO 95 - War Office: First World War and Army of Occupation War Diaries', 'reference': 'WO 95/2/3/4'}` - if there’s no third item (i.e. series) then series should be `Above series level`
- [x] Move all DOM dependent JavaScript into a `DOMContentLoaded` event listener 
- [x] Remove `role=presentation` from images with empty `alt` attribute
- [x] Remove `<time>` element from Insights page record embeds 
- [x] Add `aria-label` to `<audio>` elements referencing the transcript which follows 

**Related considerations**

I've found something odd happening with headings in the Letter from Cyril to Morris insights page. We’ve got two headings at different levels that are identical. They are:
- `<h2>` Transcript of the letter
    - `<h3>` Transcript of the letter

It seems the `<h3>` - which is presented only to screen readers - is redundant. I think this is going to come up in the accessibility audit as something which is annoying to users. Looking at the editorial interface it seems these are coming from the **Section Heading** component and the **Quote** component - both of which require a heading. It seems in this circumstance we need the heading within **Quote** to be optional. I have raised this on Slack and added it to the UAT spreadsheet.