### PR TITLE
Details page fixes

### DIFF
--- a/sass/includes/_hierarchy-global-nav.scss
+++ b/sass/includes/_hierarchy-global-nav.scss
@@ -24,21 +24,12 @@
         outline: 0.312rem solid $color__link;
       }
     }
-
   }
 
   &__heading {
     display: inline;
-
-    h2 {
-      font-size: 1.3rem;
-      padding-left: 0.5rem;
-      display: inline;
-    }
-
-    p {
-      margin: 0;
-    }
+    font-size: 1.3rem;
+    padding-left: 0.5rem;
   }
 
   &__list {

--- a/templates/base-images.html
+++ b/templates/base-images.html
@@ -8,7 +8,15 @@
             The title should vary depending on whether this layout is being applied to the image viewer or browse
             and contain the same text as is in the h1 for those pages
         {% endcomment %}
-        <title>CAB 23/78</title>
+        <title>
+            {{ page.reference_number }}
+            {% if images_count %}
+                - {{ images_count }} Images
+
+            {% else %}
+                - Image {{ index|add:'1' }} of {{ images.count }}
+            {% endif %}
+        </title>
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -4,9 +4,7 @@
 
     <details id="js-hierarchy-global" open>
         <summary id="analytics-hierarchy-link">
-            <div class="hierarchy-global__heading">
-                <h2>Where am I in the catalogue?</h2>
-            </div>
+            <h2 class="hierarchy-global__heading">Where am I in the catalogue?</h2>
         </summary>
 
         <ul class="hierarchy-global__list">

--- a/templates/includes/records/image-viewer-panel.html
+++ b/templates/includes/records/image-viewer-panel.html
@@ -2,6 +2,7 @@
     <div class="container">
         <figure>
             <a class="image-viewer-panel__image-link" href="{% url 'image-browse' iaid=page.iaid %}">
+                <span class="sr-only">Open in our image viewer</span>
                 <img src="{% url 'image-serve' location=image.location %}" alt="">
             </a>
             <figcaption>

--- a/templates/records/image-browse.html
+++ b/templates/records/image-browse.html
@@ -36,7 +36,7 @@
     </div>
 
     {% if images.has_other_pages %}
-        <nav class="pagination" role="navigation" aria-label="Results pagination" data-container-name="Pagination" id="analytics-pagination">
+        <nav class="pagination" aria-label="Results pagination" data-container-name="Pagination" id="analytics-pagination">
             <ul class="pagination__list">
                 {% if images.has_previous %}
                     <li class="pagination__list-item">

--- a/templates/records/image-viewer.html
+++ b/templates/records/image-viewer.html
@@ -9,7 +9,7 @@
         <div class="image-viewer" data-container-name="image-viewer" id="analytics-image-viewer">
             <div class="image-viewer__header">
                 <div class="image-viewer__reference">
-                    <h1>{{ images.has_other_pages }} {{ images.count }} {{ images.paginator.count }}<strong>{{ page.reference_number }}</strong> <span>- Image {{ index|add:'1' }} of {{ images_count }}</span></h1>
+                    <h1>{{ images.has_other_pages }}<strong>{{ page.reference_number }}</strong> <span>- Image {{ index|add:'1' }} of {{ images_count }}</span></h1>
                 </div>
                 <div class="image-viewer__toolbar" id="js-viewer-toolbar">
                     <button id="zoom-in" aria-controls="js-image-viewer" data-image-viewer-controls="Zoom in">Zoom in</button>

--- a/templates/records/image-viewer.html
+++ b/templates/records/image-viewer.html
@@ -18,7 +18,7 @@
                     <button id="full-page" aria-controls="js-image-viewer" data-image-viewer-controls="Full screen">Full screen</button>
                 </div>
             </div>
-            <div class="image-viewer__viewer" id="js-image-viewer"></div>
+            <div class="image-viewer__viewer" id="js-image-viewer" role="region" aria-label="Image viewer"></div>
 
             {% comment %}
                 This noscript tag is used to provide a static image


### PR DESCRIPTION
- [x] Add name to image preview link
- [x] Fix `<title>` tags on Image Browse and Image Viewer pages
- [x] Remove unnecessary number from Image Viewer `<h1>`
- [x] Fix hierarchy global so that `<div>` does not appear as child of `<summary>`
- [x] Add ARIA role and label to image viewer component
