### PR TITLE
Fix explorer issues identified in accessibility testing

### DIFF
--- a/templates/collections/results_page.html
+++ b/templates/collections/results_page.html
@@ -21,9 +21,8 @@
                     <p>{{ page.introduction }}</p>
                 </div>
                 <div class="results">
-                    <h2 class="sr-only">Results</h2>
                     <div class="row">
-                        <h3 class="sr-only">Items</h3>
+                        <h2 class="sr-only">Items</h2>
                         <ul class="card-group--list-style-none" id="analytics-explorer-results" data-container-name="explorer-results">
                             {% for record_page_result in page.records.all %}
                                 {% comment %}

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -8,7 +8,7 @@
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record_page.title }}">
-            <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
+            <h3 class="card-group-record-summary__heading">{{ record_page.title }}</h3>
             <div class="card-group-record-summary__body">
                 <p>{{ description_override|default:record_page.description|striptags|truncatewords:40 }}</p>
             </div>

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -3,7 +3,7 @@
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
         <a href="{% url 'details-page-machine-readable' iaid=record_page.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record_page.title }}">
-            <h4 class="card-group-record-summary__heading">{{ record_page.title }}</h4>
+            <h3 class="card-group-record-summary__heading">{{ record_page.title }}</h3>
             <figure>
                 {% if teaser_image %}
 
@@ -18,7 +18,7 @@
                             <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                             <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                             <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                            <img src="{{ teaser_image_extra_large.url }}" alt="Record Alt" class="card-group-record-summary__image-fallback">
+                            <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-record-summary__image-fallback">
                         </picture>
                     </div>
                 {% endif %}

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -19,7 +19,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h3 class="sr-only">Associated records</h3>
+            <h2 class="sr-only">Associated records</h2>
 
             <ul class="card-group--list-style-none" data-container-name="associated-records"
                 id="analytics-associated-records">


### PR DESCRIPTION
Hi @gtvj 

This PR:

- Gives the result card images an empty alt tag `alt=""`. I didn't use `role=presentation` here due to your commit message here: https://github.com/nationalarchives/ds-wagtail/commit/d5d1eb7029a73c2b3ea7d0f22b7d6ca31293753e
- Changes record summary cards to use `<h3>` elements for their titles.
- Adjusts the explorer results page and record disambiguation page headings, to preserve good structure since the card titles are now `<h3>` elements.

Would you be able to merge this?

Thanks :+1: