### PR TITLE
Feature/fix image viewer focus

### DIFF
--- a/sass/includes/_image-viewer.scss
+++ b/sass/includes/_image-viewer.scss
@@ -166,4 +166,26 @@
       }
     }
   }
+
+  .openseadragon-canvas {
+    &:focus {
+      border: 0.3125rem solid $color__focus-blue-outline-dark-bg !important;
+    }
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  &__viewer.fullpage {
+    .openseadragon-canvas {
+      height: 95% !important;
+
+      &:focus {
+        border: 0.3125rem solid $color__focus-blue-outline-dark-bg !important;
+      }
+      &:focus-visible {
+        outline: none;
+      }
+    }
+  }
 }

--- a/scripts/src/image-viewer.js
+++ b/scripts/src/image-viewer.js
@@ -40,13 +40,16 @@ if (image_source) {
         }
     });
 
-    canvas.addEventListener("focus", () => {
-        header.style.borderBottom = "solid 0.3125rem #8EC0EC";
-        footer.style.borderTop = "solid 0.3125rem #8EC0EC";
-    });
+    if(canvas) {
+        canvas.addEventListener("focus", () => {
+            header.style.borderBottom = "solid 0.3125rem #8EC0EC";
+            footer.style.borderTop = "solid 0.3125rem #8EC0EC";
+        });
 
-    canvas.addEventListener("blur", () => {
-        header.style.borderBottom = "none";
-        footer.style.borderTop = "none";
-    });
+        canvas.addEventListener("blur", () => {
+
+            header.style.borderBottom = "none";
+            footer.style.borderTop = "none";
+        });
+    }
 }

--- a/scripts/src/image-viewer.js
+++ b/scripts/src/image-viewer.js
@@ -36,4 +36,18 @@ if (image_source) {
             full_screen_button.focus();
         }
     });
+
+    const canvas = document.getElementsByClassName("openseadragon-canvas")[0];
+    const header = document.getElementsByClassName("image-viewer__header")[0];
+    const footer = document.getElementsByClassName("image-viewer__footer")[0];
+
+    canvas.addEventListener("focus", () => {
+        header.style.borderBottom = "solid 0.3125rem #8EC0EC";
+        footer.style.borderTop = "solid 0.3125rem #8EC0EC";
+    });
+
+    canvas.addEventListener("blur", () => {
+        header.style.borderBottom = "none";
+        footer.style.borderTop = "none";
+    });
 }

--- a/scripts/src/image-viewer.js
+++ b/scripts/src/image-viewer.js
@@ -40,7 +40,7 @@ if (image_source) {
         }
     });
 
-    if(canvas) {
+    try {
         canvas.addEventListener("focus", () => {
             header.style.borderBottom = "solid 0.3125rem #8EC0EC";
             footer.style.borderTop = "solid 0.3125rem #8EC0EC";
@@ -50,5 +50,8 @@ if (image_source) {
             header.style.borderBottom = "none";
             footer.style.borderTop = "none";
         });
+    }
+    catch (e) {
+        console.error(e);
     }
 }

--- a/scripts/src/image-viewer.js
+++ b/scripts/src/image-viewer.js
@@ -47,7 +47,6 @@ if (image_source) {
         });
 
         canvas.addEventListener("blur", () => {
-
             header.style.borderBottom = "none";
             footer.style.borderTop = "none";
         });

--- a/scripts/src/image-viewer.js
+++ b/scripts/src/image-viewer.js
@@ -22,6 +22,9 @@ if (image_source) {
     };
 
     const viewer = Openseadragon(seadragon_options);
+    const canvas = document.getElementsByClassName("openseadragon-canvas")[0];
+    const header = document.getElementsByClassName("image-viewer__header")[0];
+    const footer = document.getElementsByClassName("image-viewer__footer")[0];
 
     viewer.addHandler("full-page", data => {
 
@@ -36,10 +39,6 @@ if (image_source) {
             full_screen_button.focus();
         }
     });
-
-    const canvas = document.getElementsByClassName("openseadragon-canvas")[0];
-    const header = document.getElementsByClassName("image-viewer__header")[0];
-    const footer = document.getElementsByClassName("image-viewer__footer")[0];
 
     canvas.addEventListener("focus", () => {
         header.style.borderBottom = "solid 0.3125rem #8EC0EC";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,5 +27,6 @@ module.exports = {
                 }
             }
         ]
-    }
+    },
+    target: ['web', 'es5']
 };


### PR DESCRIPTION
Hi @gtvj,

This PR applies the light blue focus styles to the image viewer canvas when it receives focus. I switched to using `border` rather than `outline` because the `outline` wasn't visible when zoomed in, whereas `border` is and I had to apply `!important` because OpenSeadragon's CSS was overriding it. 

I've applied `height: 95%` when full screen is activated because the bottom border wasn't showing otherwise. I did try experimenting with `padding`, `margin`, and positioning i.e. `bottom` but I couldn't quite get it to work properly with those properties. And I had to apply `!important` because OpenSeadragon's CSS was overriding it again.

I've also put an `outline: none` rule on `focus-visible` because this was causing a thin dark blue line to appear on the sides of the window when the canvas received focus.

I've tested this in Chrome, Firefox, Edge, Safari, and IE11 and it all seems to be working okay (apologies for the delay, I kept encountering issues when testing locally in LambaTest).

This PR also addresses a transpilation issue which was causing the image viewer to not display in IE11.

Would it be possible to merge if you are happy? Thank you 👍 