### PR TITLE
Move figcaption outside of div on explorer record cards

### DIFF
--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -22,9 +22,7 @@
                         </picture>
                     </div>
                 {% endif %}
-                <div class="card-group-record-summary__body">
-                    <figcaption>{{ description_override|default:record_page.description|safe }}</figcaption>
-                </div>
+                    <figcaption class="card-group-record-summary__body">{{ description_override|default:record_page.description|safe }}</figcaption>
             </figure>
         </a>
     </div>


### PR DESCRIPTION
Hi @gtvj,


This addresses a HTML issue where a figcaption can only be a first or last child of a figure. I simply removed the figcaption from the div and kept the class. I've tested on Firefox, Chrome and IE11.

Would you be able to merge this?

Thanks :+1: