### PR TITLE
Refactor scroll_to_bottom so that it works in IE11

### DIFF
--- a/scripts/src/details.js
+++ b/scripts/src/details.js
@@ -6,9 +6,10 @@ import add_unique_ids from "./modules/analytics/add_unique_ids";
 document.addEventListener("DOMContentLoaded", () => {
 
     const hierarchy_list = document.querySelector('.hierarchy-global__list');
+    const hierarchy_list_current_item = document.querySelector(".hierarchy-global__list-item--current-item");
 
     manage_details_element();
-    scroll_to_bottom(hierarchy_list);
+    scroll_to_bottom(hierarchy_list_current_item, hierarchy_list);
     push_reference_and_series();
     add_unique_ids();
 

--- a/scripts/src/modules/scroll_to_bottom.js
+++ b/scripts/src/modules/scroll_to_bottom.js
@@ -1,7 +1,13 @@
-const scroll_to_bottom = (element) => {
-	if(element){
-		element.scrollTo(0, element.scrollHeight)
+const scroll_to_bottom = (element, container) => {
+	try{
+		const elementRect = element.getBoundingClientRect();
+		const scrollY = elementRect.top;
+		container.scrollLeft = 0;
+		container.scrollTop = scrollY;
 	}
-};
+	catch(e){
+		console.error(e)
+	}
+}
 
 export default scroll_to_bottom;


### PR DESCRIPTION
Hi @gtvj,

This PR modifies the scroll_to_bottom function to work in IE11 (the previous approach, which used `scrollTo`, is not compatible with IE). I've tested on Chrome, FF, IE, Edge, and Safari and didn't see any issues. Would it be possible to merge if you are happy?

Thank you 👍 