### PR TITLE
Fix social media link accessibility

### DIFF
--- a/sass/includes/_footer.scss
+++ b/sass/includes/_footer.scss
@@ -10,6 +10,9 @@
     }
 
     &__social-media-links {
+
+        font-size: 0.85rem;
+
         .tna-footer__social-media-icon {
             height: 2.187rem;
             padding: .5rem;

--- a/sass/tna-toolkit/_footer.scss
+++ b/sass/tna-toolkit/_footer.scss
@@ -1,7 +1,0 @@
-.tna-footer {
-  background-color: $color__grey-light;
-
-  &__social-media-links {
-    font-size: 2rem
-  }
-}

--- a/sass/tna-toolkit/tna-toolkit.scss
+++ b/sass/tna-toolkit/tna-toolkit.scss
@@ -37,6 +37,5 @@ html {
 @import "lists";
 @import "buttons";
 @import "header";
-@import "footer";
 @import "card";
 @import "hero-banner";

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -72,40 +72,41 @@
     <div class="tna-footer__social-media-links tna-bg--dark">
         <div class="container pb-3">
             <div class="row justify-content-md-center text-center">
-                <div class="col-4 col-sm-4 col-md-1">
+                <h3 class="sr-only">Follow us on social media</h3>
+                <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://twitter.com/UKNatArchives" class="d-inline-block" target="_blank" rel="noopener noreferrer">
-                        <img src="{% static 'images/fontawesome-svgs/twitter.svg' %}" class="tna-footer__social-media-icon" alt="Twitter logo" width="35" height="35"/>
-                        <span class="sr-only">Follow us on Twitter. Opens a new window.</span>
+                        <img src="{% static 'images/fontawesome-svgs/twitter.svg' %}" class="tna-footer__social-media-icon" alt="" width="35" height="35"/><br>
+                        <span>Twitter</span>
                     </a>
                 </div>
-                <div class="col-4 col-sm-4 col-md-1">
-                    <a href="https://www.youtube.com/c/TheNationalArchivesUK" class="d-inline-block" target="_blank" rel="noopener noreferrer">
-                        <img src="{% static 'images/fontawesome-svgs/youtube.svg' %}" class="tna-footer__social-media-icon" alt="YouTube logo" width="40" height="35"/>
-                        <span class="sr-only">Follow us on YouTube. Opens a new window</span>
+                <div class="col-4 col-sm-4 col-md-2">
+                    <a href="https://www.youtube.com/c/TheNationalArchivesUK" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="YouTube">
+                        <img src="{% static 'images/fontawesome-svgs/youtube.svg' %}" class="tna-footer__social-media-icon" alt="" width="40" height="35"/><br>
+                        <span>YouTube</span>
                     </a>
                 </div>
-                <div class="col-4 col-sm-4 col-md-1">
-                    <a href="https://www.flickr.com/photos/nationalarchives" class="d-inline-block" target="_blank" rel="noopener noreferrer">
-                        <img src="{% static 'images/fontawesome-svgs/flickr.svg' %}" class="tna-footer__social-media-icon" alt="Flickr logo" width="31" height="35"/>
-                        <span class="sr-only">Follow us on Flickr. Opens a new window</span>
+                <div class="col-4 col-sm-4 col-md-2">
+                    <a href="https://www.flickr.com/photos/nationalarchives" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Flickr">
+                        <img src="{% static 'images/fontawesome-svgs/flickr.svg' %}" class="tna-footer__social-media-icon" alt="" width="31" height="35"/><br>
+                        <span>Flickr</span>
                     </a>
                 </div>
-                <div class="col-4 col-sm-4 col-md-1">
-                    <a href="https://www.facebook.com/TheNationalArchives" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Follow us on Facebook. Opens a new window">
-                        <img src="{% static 'images/fontawesome-svgs/facebook.svg' %}" class="tna-footer__social-media-icon" alt="Facebook logo" width="35" height="35"/>
-                        <span class="sr-only">Follow us on Facebook. Opens a new window</span>
+                <div class="col-4 col-sm-4 col-md-2">
+                    <a href="https://www.facebook.com/TheNationalArchives" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Facebook">
+                        <img src="{% static 'images/fontawesome-svgs/facebook.svg' %}" class="tna-footer__social-media-icon" alt="" width="35" height="35"/><br>
+                        <span>Facebook</span>
                     </a>
                 </div>
-                <div class="col-4 col-sm-4 col-md-1">
-                    <a href="https://www.instagram.com/nationalarchivesuk/" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Follow us on Instagram. Opens a new window">
-                        <img src="{% static 'images/fontawesome-svgs/instagram.svg' %}" class="tna-footer__social-media-icon" alt="Instagram logo" width="31" height="35"/>
-                        <span class="sr-only">Follow us on Instagram. Opens a new window</span>
+                <div class="col-4 col-sm-4 col-md-2">
+                    <a href="https://www.instagram.com/nationalarchivesuk/" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Instagram">
+                        <img src="{% static 'images/fontawesome-svgs/instagram.svg' %}" class="tna-footer__social-media-icon" alt="" width="31" height="35"/><br>
+                        <span>Instagram</span>
                     </a>
                 </div>
-                <div class="col-4 col-sm-4 col-md-1">
-                    <a href="https://www.nationalarchives.gov.uk/rss/" class="d-inline-block" data-link="Follow us via RSS">
-                        <img src="{% static 'images/fontawesome-svgs/rss.svg' %}" class="tna-footer__social-media-icon" alt="RSS logo" width="31" height="35"/>
-                        <span class="sr-only">Follow us via RSS</span>
+                <div class="col-4 col-sm-4 col-md-2">
+                    <a href="https://www.nationalarchives.gov.uk/rss/" class="d-inline-block" data-link="RSS">
+                        <img src="{% static 'images/fontawesome-svgs/rss.svg' %}" class="tna-footer__social-media-icon" alt="" width="31" height="35"/><br>
+                        <span>RSS</span>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
This commit fixes #187

The changes include: 

* Making the logos presentational, as recommended by DAC
* Exposing the name of the platform below the icon (so that people don't have to rely upon hover or recognition of the logo)
* A slight change to column width (to accommodate different zoom levels - it rendered correctly up to 500% zoom in testing)

I've tested this using LambdaTest again Chrome, Firefox, Safari, Edge, IE11, Android (Chrome) and iOS (Safari)

This required a change to a TNA toolkit stylesheet which is now redundant and has therefore been removed.