### PR TITLE
Add links to relevant fields within error summary

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -126,6 +126,7 @@ LOGIN_REDIRECT_URL = "/"
 WAGTAIL_FRONTEND_LOGIN_URL = LOGIN_URL
 # Custom adapter to prevent self-signup
 ACCOUNT_ADAPTER = "etna.users.adapters.NoSelfSignupAccountAdapter"
+ACCOUNT_FORMS = {'login': 'etna.users.forms.EtnaLoginForm'}
 
 
 WSGI_APPLICATION = 'config.wsgi.application'

--- a/etna/users/forms.py
+++ b/etna/users/forms.py
@@ -1,0 +1,14 @@
+from allauth.account.forms import LoginForm
+
+
+class EtnaLoginForm(LoginForm):
+
+    def login(self, *args, **kwargs):
+        return super(EtnaLoginForm, self).login(*args, **kwargs)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields['login'].error_messages = {'required': 'The email field is required'}
+
+        self.fields['password'].error_messages = {'required': 'The password field is required'}

--- a/sass/includes/_forms.scss
+++ b/sass/includes/_forms.scss
@@ -11,6 +11,10 @@
         font-size: 1.3rem;
         font-weight: bold;
       }
+
+      a {
+        color: $color__white;
+      }
     }
 
     .tna-form__error-messages {

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -28,15 +28,28 @@
 
                     {% if form.non_field_errors or form.errors %}
                         <div class="tna-form__error-summary" role="alert" id="analytics-error-message">
-                            <h2>There is a problem.</h2>
-                            {% if not form.non_field_errors %}
-                                <p>Check the highlighted fields below.</p>
-                            {% endif %}
-                            {% if form.non_field_errors %}
-                                {% for error in form.non_field_errors %}
-                                    <p>{{ error|escape }}</p>
-                                {% endfor %}
-                            {% endif %}
+                            <h2>There is a problem</h2>
+                            <ul>
+                                {% if form.non_field_errors %}
+                                    {% for error in form.non_field_errors %}
+                                        <li>{{ error|escape }}</li>
+                                    {% endfor %}
+                                {% endif %}
+                                {% if form.login.errors %}
+                                    {% for error in form.login.errors %}
+                                        <li>
+                                            <a href="#id_login">{{ error|escape }}</a>
+                                        </li>
+                                    {% endfor %}
+                                {% endif %}
+                                {% if form.password.errors %}
+                                    {% for error in form.password.errors %}
+                                        <li>
+                                            <a href="#id_password">{{ error|escape }}</a>
+                                        </li>
+                                    {% endfor %}
+                                {% endif %}
+                            </ul>
                         </div>
                     {% endif %}
 

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -38,14 +38,14 @@
                                 {% if form.login.errors %}
                                     {% for error in form.login.errors %}
                                         <li>
-                                            <a href="#id_login">{{ error|escape }}</a>
+                                            <a href="#id_login" id="analytics-login-error">{{ error|escape }}</a>
                                         </li>
                                     {% endfor %}
                                 {% endif %}
                                 {% if form.password.errors %}
                                     {% for error in form.password.errors %}
                                         <li>
-                                            <a href="#id_password">{{ error|escape }}</a>
+                                            <a href="#id_password" id="analytics-password-error">{{ error|escape }}</a>
                                         </li>
                                     {% endfor %}
                                 {% endif %}


### PR DESCRIPTION
This PR fixes #166 by introducing links from the error summary to the relevant field. 

It is mostly straightforward but note the approach to update error message text.