### PR TITLE
Accessibility improvements to hierarchy global

### DIFF
--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -4,10 +4,10 @@
 
     <details id="js-hierarchy-global" open>
         <summary id="analytics-hierarchy-link">
-            <h2 class="hierarchy-global__heading">Where am I in the catalogue?</h2>
+            <h2 class="hierarchy-global__heading" id="hierarchy-label">Where am I in the catalogue?</h2>
         </summary>
 
-        <ul class="hierarchy-global__list">
+        <ol class="hierarchy-global__list" aria-labelledby="hierarchy-label">
             {% for item in page.hierarchy %}
                 {% is_page_current_item_in_hierarchy page item as is_current_item %}
                 {% if is_current_item %}
@@ -24,6 +24,6 @@
                     </li>
                 {% endif %}
             {% endfor %}
-        </ul>
+        </ol>
     </details>
 </nav>


### PR DESCRIPTION
This PR fixes #167 

Rather than using `aria-label` as has been suggested by DAC I've opted to use `aria-labelledby` in order to avoid introducing redundancy (i.e. having the text "Where am I in the catalogue" appear in multiple places) and follow the DRY principle. 