### PR TITLE
Chore: Add fabric commands for common tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,41 +45,53 @@ container to communicate with those services.
 
 #### Create `.env`
 
-`cp .env.example .env`
+```console
+$ cp .env.example .env
+```
 
-#### Docker
+#### Build Docker containers
 
-##### Build containers
+```console
+$ fab build
+```
 
-`docker-compose build`
+#### Run Docker containers
 
-##### Run containers (in background)
+```console
+$ fab start
+```
 
-`docker-compose up --detach`
+#### Access a container shell
 
-#### Database
+```console
+$ fab sh
+```
 
-##### Run migrations
+#### Run database migrations
 
-`docker-compose exec web poetry run python manage.py migrate`
+```console
+$ python manage.py migrate
+```
 
-#### User management
-
-`docker-compose exec web poetry run python manage.py createsuperuser --username sysadmin`
-
-##### Access site
+#### Access site
 
 <http://127.0.0.1:8000>
 
 **Note: compiled CSS is not included and therefore needs to be built initially, and after each git pull. See the "Working with SASS/CSS section**
 
-##### Access site admin
+#### Access the admin site
 
-Log in using `sysadmin`, along with the password set with `createsuperuser` command.
+From a container shell, first create a Django user for yourself using:
+
+```console
+$ python manage.py createsuperuser
+```
+
+Now, navigate to the admin URL in your browser, and sign in using the username/password combination you chose for your user:
 
 <http://127.0.0.1:8000/admin/>
 
-##### Copying content to another development instance
+### Copying content to another development instance
 
 To copy uploaded files, zip up your `/media` directory and replace the second
 site's `/media` with the contents of the zip.
@@ -91,6 +103,26 @@ To copy your CMS's content, **export** the database:
 And then **import**:
 
 `cat <database-dump> |  docker-compose exec  -T db psql -U postgres postgres`
+
+### Generating database migrations
+
+To run any Django management command, first access the shell using:
+
+```console
+$ fab sh
+```
+
+To make migrations for a new app:
+
+```console
+$ python manage.py makemigrations [appname]
+```
+
+To make migrations for an existing app, use the `-n` argument to provide a meaninful name to help your peers understand what the migration does:
+
+```console
+$ python manage.py makemigrations [appname] -n meaningful_name_here
+```
 
 ### Front end development
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,114 @@
+import os
+import subprocess
+
+from shlex import quote
+
+from invoke import run as local
+from invoke.tasks import task
+
+LOCAL_DATABASE_NAME = "postgres"
+LOCAL_DATABASE_USERNAME = "postgres"
+
+
+# Process .env file
+if os.path.exists(".env"):
+    with open(".env", "r") as f:
+        for line in f.readlines():
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            var, value = line.strip().split("=", 1)
+            os.environ.setdefault(var, value)
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def container_exec(cmd, container_name="web"):
+    return local(f"docker-compose exec -T {container_name} bash -c {quote(cmd)}")
+
+
+def db_exec(cmd):
+    return container_exec(cmd, "db")
+
+
+def web_exec(cmd):
+    return container_exec(cmd, "web")
+
+
+# -----------------------------------------------------------------------------
+# Container management
+# -----------------------------------------------------------------------------
+
+
+@task
+def build(c):
+    """
+    Build local containers
+    """
+    local("docker-compose build")
+
+
+@task
+def start(c):
+    """
+    Start the development environment
+    """
+    local("docker-compose up -d")
+
+
+@task
+def stop(c):
+    """
+    Start the development environment
+    """
+    local("docker-compose stop")
+
+
+@task
+def restart(c):
+    """
+    Restart the development environment
+    """
+    start(c)
+    stop(c)
+
+
+@task
+def sh(c):
+    """
+    Run bash in a local container (with access to dependencies)
+    """
+    subprocess.run(["docker-compose", "exec", "web", "poetry", "run", "bash"])
+
+
+# -----------------------------------------------------------------------------
+# Database operations
+# -----------------------------------------------------------------------------
+
+
+def delete_db(c):
+    db_exec(f"dropdb --if-exists --host db --username={LOCAL_DATABASE_USERNAME} {LOCAL_DATABASE_NAME}")
+    db_exec(f"createdb --host db --username={LOCAL_DATABASE_USERNAME} {LOCAL_DATABASE_NAME}")
+
+
+@task
+def dump_db(c, filename):
+    """Snapshot the database, files will be stored in the db container"""
+    if not filename.endswith(".psql"):
+        filename += '.psql'
+    db_exec(f"pg_dump -d {LOCAL_DATABASE_NAME} -U {LOCAL_DATABASE_USERNAME} > {filename}")
+    print(f"Database dumped to: {filename}")
+
+
+@task
+def restore_db(c, filename):
+    """Restore the database from a snapshot in the db container"""
+    print("Stopping 'web' to sever DB connection")
+    local("docker-compose stop web")
+    if not filename.endswith(".psql"):
+        filename += '.psql'
+    delete_db(c)
+    db_exec(f"psql -d {LOCAL_DATABASE_NAME} -U {LOCAL_DATABASE_USERNAME} < {filename}")
+    print(f"Database restored from: {filename}")
+    local("docker-compose start web")


### PR DESCRIPTION
I've added these fab commands locally to make it easier to do most common things, so thought I might as well contribute them back (along with some documentation changes).

Fabric can be installed everywhere that Python can, so is a great option for simplifying this sort of thing on Django projects.

