### PR TITLE
Chore: Tweak data anonymisation settings

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -298,3 +298,4 @@ AVAILABILITY_CONDITION_CATEGORIES = {
 
 # Don't anonymise data by default, so we don't accidentally lose production data
 BIRDBATH_REQUIRED = False
+BIRDBATH_PROCESSORS = ['etna.users.anonymisation.UserAnonymiser']

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -11,11 +11,6 @@ ALLOWED_HOSTS = ['*']
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-# Force data anonymisation
-BIRDBATH_REQUIRED = True
-
-BIRDBATH_PROCESSORS = ['etna.users.anonymisation.UserAnonymiser']
-
 try:
     from .local import *  # noqa: F401
 except ImportError:


### PR DESCRIPTION
Having `BIRDBATH_REQUIRED = True` in dev settings is problematic for those who have not pulled data from a live environment and still want to run the app.

Since the `pull-production-data` command runs birdbath automatically, I think it's safe enough to remove these settings overrides.