### PR TITLE
Add superuser re-creation instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ NOTE: Data is automatically anonymised after downloading to protect sensitive da
 
 `fab pull-production-data`
 
+**NOTE:** Any Django users you were using before running this command will no longer exist. You may want to run `python manage.py createsuperuser` from a container shell to create yourself a new one.
+
 #### Download all production media
 
 `fab pull-production-media`


### PR DESCRIPTION
Explains that superuser will need to be recreated after having run `fab pull-production-data`. While this information is output on the terminal when the command is run it is easily missed and the inclusion of it in the README is to make it more evident alongside other steps outlined there.