### PR TITLE
Update wagtailmedia config to match the new format (0.8+)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -222,8 +222,10 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
-WAGTAILMEDIA_MEDIA_MODEL = 'media.EtnaMedia'
-WAGTAILMEDIA_MEDIA_FORM_BASE = 'etna.media.forms.BaseMediaForm'
+WAGTAILMEDIA = {
+    "MEDIA_MODEL": "media.EtnaMedia",
+    "MEDIA_FORM_BASE": "etna.media.forms.BaseMediaForm",
+}
 
 # Wagtail settings
 


### PR DESCRIPTION
`wagtailmedia` was recently upgraded in another PR, and we failed to spot that our custom config was no longer being respected (the format for configuration changed - without warning - to use a single dictionary). This was most likely missed because nobody had content locally, and so couldn't see the impact of the change. Hopefully, now that realistic content is available to pull down from other environments, this sort of thing should be much easier to spot in future.