### PR TITLE
Change record-summary link to inline-block

### DIFF
--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -81,7 +81,7 @@
 
     &__link {
       @extend .tna-card__link;
-      display: inline;
+      display: inline-block;
       color: $color__blue_3;
       text-decoration: underline;
       margin-left: 0.5rem;


### PR DESCRIPTION
Hi @JamesWChan 

I noticed a small issue with the record summary cards that have a title that's more than one line long. I think we didn't see it as we only looked at records with a short title.

It looks like this because of a `display: inline` I added:

![image](https://user-images.githubusercontent.com/8880610/144456492-865fecce-2a1c-4da5-a261-4a4bdb6edba0.png)

I fixed it by changing it to an `inline-block`, and I've checked it in Firefox, IE11 and Chrome.

![image](https://user-images.githubusercontent.com/8880610/144456424-694007b1-234f-4172-9461-6dcb39404fa4.png)

Would you be able to merge this?

Thanks :+1: