### PR TITLE
Fix: Windows compatibility changes 'pull-data' operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,19 @@ Now, navigate to the admin URL in your browser, and sign in using the username/p
 
 ### Working with production data locally
 
-NOTE: For any of the following commands to work, you must first install the [Platform.sh CLI](https://docs.platform.sh/development/cli.html), and run the CLI's `platform` command to sign into an account with access to the relevant project.
+#### Prerequisites
+
+The following steps must be completed before you can pull data from an evironment:
+
+1. Ask on the `#ds-etna` or `#dev-etna` channels to be granted access to Platform.sh.
+2. Once you have access, [follow these instructions](https://docs.platform.sh/development/ssh.html#authenticate-with-ssh-keys) to add your SSH key to your Platform account.
+3. Install the Platform.sh CLI, authenticate, and try out some of the commands, by [following these instructions](https://docs.platform.sh/development/cli.html). **For Windows users**: The CLI requires PHP to run. If you haven't done so already, you may also need to [install PHP](https://www.sitepoint.com/how-to-install-php-on-windows/#installphp) before the CLI will work.
 
 #### Download production data
 
-NOTE: Data is automatically anonymised after downloading to protect sensitive data.
-
 `fab pull-production-data`
 
-**NOTE:** Any Django users you were using before running this command will no longer exist. You may want to run `python manage.py createsuperuser` from a container shell to create yourself a new one.
+**NOTE:** Data is automatically anonymised after downloading to protect sensitive data, so user logins from production will NOT work locally. Also, any Django users you created locally before running the command will no longer exist. You can run `python manage.py createsuperuser` from a container shell to create yourself a new one.
 
 #### Download all production media
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -259,6 +259,7 @@ def pull_database_from_platform(c, environment_name):
     )
 
     print("Replacing local database with downloaded version")
+    start(c, "db")
     delete_db(c)
     restore_db(c, f"app/{LOCAL_DB_DUMP_DIR}/{timestamp}.psql")
     local(f"rm {LOCAL_DB_DUMP_DIR}/{timestamp}.psql")

--- a/fabfile.py
+++ b/fabfile.py
@@ -2,8 +2,6 @@ import datetime
 import os
 import subprocess
 
-from shlex import quote
-
 from invoke import run as local
 from invoke.tasks import task
 
@@ -34,7 +32,7 @@ LOCAL_DB_DUMP_DIR = "database_dumps"
 
 
 def container_exec(cmd, container_name="web"):
-    return local(f"docker-compose exec -T {container_name} bash -c {quote(cmd)}")
+    return subprocess.run(["docker-compose", "exec", "-T", container_name, "bash", "-c", cmd])
 
 
 def db_exec(cmd):

--- a/fabfile.py
+++ b/fabfile.py
@@ -240,8 +240,12 @@ def pull_staging_images(c):
 
 
 def enable_platform_ssh(c):
-    local("ssh-keyscan 'ssh.uk-1.platform.sh' >> $HOME/.ssh/known_hosts")
-    local("ssh-keyscan 'git.uk-1.platform.sh' >> $HOME/.ssh/known_hosts")
+    known_hosts = os.path.expanduser("~/.ssh/known_hosts")
+    for hostname in ('ssh.uk-1.platform.sh', 'git.uk-1.platform.sh'):
+        # Remove existing keys for this hostname
+        local(f"ssh-keygen -q -R {hostname} >> {known_hosts}")
+        # Add new ones
+        local(f"ssh-keyscan {hostname} >> {known_hosts}")
 
 
 def pull_database_from_platform(c, environment_name):

--- a/fabfile.py
+++ b/fabfile.py
@@ -243,7 +243,7 @@ def enable_platform_ssh(c):
     known_hosts = os.path.expanduser("~/.ssh/known_hosts")
     for hostname in ('ssh.uk-1.platform.sh', 'git.uk-1.platform.sh'):
         # Remove existing keys for this hostname
-        local(f"ssh-keygen -q -R {hostname} >> {known_hosts}")
+        local(f"ssh-keygen -q -R {hostname}")
         # Add new ones
         local(f"ssh-keyscan {hostname} >> {known_hosts}")
 


### PR DESCRIPTION
For `enable_platform_ssh()`:
* Use os.path.expanduser to get a platform-specific known_hosts path
* Use ssh-keygen to remove existing keys before adding a new one

General:
* Use subprocess.run() instead of local() for docker commands, as `shlex.escape()` doesn't work for windows