### PR TITLE
Fix poetry install issue on platform.sh.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -15,7 +15,8 @@ variables:
 
 dependencies:
   python3:
-    poetry: '1.1.4'
+    poetry: '1.1.12'
+    pip: '21.3.1'
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app/
 
 COPY poetry.lock /app/
 COPY pyproject.toml /app/
-RUN pip install poetry
+RUN python -m pip install pip==21.3.1
+RUN pip install poetry==1.1.12
 RUN poetry install
 
 EXPOSE 8000


### PR DESCRIPTION
`poetry install` raised: `AttributeError: 'Link' object has no attribute 'is_absolute'` during build on platform.sh.

It appears that it's possible for poetry-core to update even if poetry is locked. Our issue was a caused by a regression introduced in 1.0.4.

Updated poetry following the advice in the linked github issue and updated pip to fix an issue selecting the correct wheel for cryptography `36.0.0` on platform.sh.

Locked Poetry to `1.1.12` and pip to `21.3.1` for docker and platform.sh

 - [Link object being passed instead of Path to poetry.core.packages.file_dependency.FileDependency in poetry-core 1.0.5](https://github.com/python-poetry/poetry/issues/4541)
 - [fix: Broken cache on Windows #4531](https://github.com/python-poetry/poetry/pull/4531)