### PR TITLE
Reduce width of main body text

### DIFF
--- a/sass/includes/_content-block.scss
+++ b/sass/includes/_content-block.scss
@@ -1,6 +1,15 @@
 .content-block {
-  margin: 1rem 0;
+  margin: 1rem auto;
   padding: 0.5rem 0;
+  width: 65%;
+
+  @media (max-width: $screen__lg) {
+    width: 70%;
+  }
+
+  @media (max-width: $screen__md) {
+    width: 80%;
+  }
 
   &__heading {
     font-size: 2rem;

--- a/sass/includes/_promoted-item.scss
+++ b/sass/includes/_promoted-item.scss
@@ -61,7 +61,12 @@
     &__text {
       font-size: 1.2rem;
       text-align: left;
-      margin-top: 1rem;
+      margin: 1rem auto 0 auto;
+      width: 75%;
+
+      @media (max-width: $screen__md) {
+        width: 85%;
+      }
     }
   
     &__link-heading {

--- a/sass/includes/_quote.scss
+++ b/sass/includes/_quote.scss
@@ -1,6 +1,11 @@
 .quote {
   position: relative;
-  margin: 2rem 0;
+  margin: 2rem auto;
+  width: 70%;
+
+  @media (max-width: $screen__md) {
+    width: 80%;
+  }
 
   &__icon {
     position: absolute;


### PR DESCRIPTION
Hi @AshTNA,

Would it be possible to merge this if you are happy? It reduces the text width on insights pages and uses `margin: auto` to keep everything centred. Thank you 👍 