### PR TITLE
DF-81

### DIFF
--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -1,11 +1,17 @@
 import enum
+import json
 import logging
 
-from typing import Optional
+from typing import Any, Optional
 
 import requests
 
-from .exceptions import ConnectionError, KongError
+from .exceptions import (
+    KongBadRequestError,
+    KongCommunicationError,
+    KongInternalServerError,
+    KongServiceUnavailableError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +79,13 @@ def format_list_param(items: Optional[list]) -> Optional[str]:
 
 class KongClient:
     """Client used to Fetch and validate data from Kong."""
+
+    http_error_classes = {
+        400: KongBadRequestError,
+        500: KongInternalServerError,
+        503: KongServiceUnavailableError,
+    }
+    default_http_error_class = KongCommunicationError
 
     def __init__(
         self,

--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -39,7 +39,7 @@ class SortOrder(str, enum.Enum):
 
 
 class Template(str, enum.Enum):
-    """Include @template block to assist parsing/rendering of record data.
+    """@template block to include with response.
 
     Supported by all endpoints.
     """

--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -24,7 +24,7 @@ class Stream(str, enum.Enum):
     INTERPRETIVE = "interpretive"
 
 
-class Sort(str, enum.Enum):
+class SortBy(str, enum.Enum):
     """Options for sorting /search results by a given field."""
 
     TITLE = "title"
@@ -135,7 +135,7 @@ class KongClient:
         keyword: Optional[str] = None,
         web_reference: Optional[str] = None,
         stream: Optional[Stream] = None,
-        sort: Optional[Sort] = None,
+        sort_by: Optional[SortBy] = None,
         sort_order: Optional[SortOrder] = None,
         template: Optional[Template] = None,
         show_buckets: Optional[bool] = None,
@@ -160,7 +160,7 @@ class KongClient:
             Return matches on references_number
         stream:
             Restrict results to given stream
-        sort:
+        sort_by:
             Field to sort results.
         sortOrder:
             Order of sorted results
@@ -183,7 +183,7 @@ class KongClient:
             "keyword": keyword,
             "webReference": web_reference,
             "stream": stream,
-            "sort": sort,
+            "sort": sort_by,
             "sortOrder": sort_order,
             "template": template,
             "showBuckets": show_buckets,

--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import requests
 
-from .exceptions import ConnectionError, InvalidResponse, KongError, KubernetesError
+from .exceptions import ConnectionError, KongError
 
 logger = logging.getLogger(__name__)
 
@@ -255,18 +255,12 @@ class KongClient:
         return self.validate_and_parse_response(response)
 
     def validate_and_parse_response(self, response: requests.Response) -> dict:
-        """Validates response post and pre JSON decode."""
+        """Validates response pre-JSON decode."""
         if not response.ok:
-            raise InvalidResponse("Invalid response.", json=response.json())
+            raise KongError("Invalid response.", response=response)
 
         json = response.json()
 
         logger.debug(f"Response from Kong: {json}")
-
-        if "message" in json:
-            raise KubernetesError(json["message"])
-
-        if "error" in json:
-            raise KongError(f"Kong returned status {json['status']}")
 
         return json

--- a/etna/ciim/exceptions.py
+++ b/etna/ciim/exceptions.py
@@ -1,65 +1,27 @@
-from json.decoder import JSONDecodeError
+import requests
 
 
-class KongException(Exception):
-    """Exception to group exceptions received from Kong client."""
-
-
-class ConnectionError(KongException):
-    """Raised if Kong isn't accessible"""
-
-
-class KongError(KongException):
+class KongAPIError(requests.HTTPError):
     """Raised if Kong returns an error instead of results"""
 
-    def __init__(self, message, response, *args, **kwargs):
-        """Attempt to parse out error message from ES."""
 
-        try:
-            json = response.json()
-        except JSONDecodeError:
-            json = {}
-
-        # Parse Elasticsearch error:
-        #
-        # Expect the following format:
-        #
-        # "error" : {
-        #   "root_cause" : [{
-        #     "type" : "illegal_argument_exception",
-        #     "reason" : "The bulk request must be terminated by a newline [\n]"
-        #   }],
-        #   "type" : "illegal_argument_exception",
-        #   "reason" : "The bulk request must be terminated by a newline [\n]"
-        # },
-        # "status" : 400
-        try:
-            message = f'{message} {json["error"]["reason"]}'
-        except (KeyError, TypeError):
-            # Failed to find error message, in Elasticseach error
-            pass
-
-        # Parse Kubernetes or Kong error response:
-        #
-        # Expect the following format:
-        #
-        # {
-        #   "timestamp": "2022-02-04T13:46:22.445",
-        #   "status": "Bad Request",
-        #   "statusCode": 400,
-        #   "message": "Failed to convert value of type 'java.lang.String' to required type 'java.lang.Boolean';",
-        #   "path": "/api/v1/data/fetch"
-        # }
-        try:
-            message = f'{message} {json["message"]}'
-        except KeyError:
-            # Failed to find error message, in Elasticseach error
-            pass
-
-        super().__init__(message, *args, **kwargs)
+class KongBadRequestError(KongAPIError):
+    """Raised if Kong responds with 400"""
 
 
-class SearchManagerException(KongException):
+class KongInternalServerError(KongAPIError):
+    """Raised if Kong responds with 500"""
+
+
+class KongServiceUnavailableError(KongAPIError):
+    """Raised if Kong responds with 503"""
+
+
+class KongCommunicationError(KongAPIError):
+    """Raised if Kong responds with a non-200 status code"""
+
+
+class SearchManagerException(Exception):
     """Exception to group exceptions raised by SearchManager"""
 
 

--- a/etna/ciim/exceptions.py
+++ b/etna/ciim/exceptions.py
@@ -1,3 +1,6 @@
+from json.decoder import JSONDecodeError
+
+
 class KongException(Exception):
     """Exception to group exceptions received from Kong client."""
 
@@ -6,29 +9,54 @@ class ConnectionError(KongException):
     """Raised if Kong isn't accessible"""
 
 
-class InvalidResponse(KongException):
-    """Raised if Kong returns non-200 reponse"""
-
-    def __init__(self, message, *args, **kwargs):
-        """Attempt to parse out error message from ES."""
-
-        self.json = kwargs.pop("json", {})
-
-        try:
-            reason = self.json["error"]["root_cause"][0]["reason"]
-            message = f"{message} Reason: {reason}"
-        except (IndexError, KeyError, TypeError):
-            """Failed to find error message, raise without message"""
-
-        super().__init__(message, *args, **kwargs)
-
-
-class KubernetesError(KongException):
-    """Raised if kubernetes returns an error instead of results"""
-
-
 class KongError(KongException):
     """Raised if Kong returns an error instead of results"""
+
+    def __init__(self, message, response, *args, **kwargs):
+        """Attempt to parse out error message from ES."""
+
+        try:
+            json = response.json()
+        except JSONDecodeError:
+            json = {}
+
+        # Parse Elasticsearch error:
+        #
+        # Expect the following format:
+        #
+        # "error" : {
+        #   "root_cause" : [{
+        #     "type" : "illegal_argument_exception",
+        #     "reason" : "The bulk request must be terminated by a newline [\n]"
+        #   }],
+        #   "type" : "illegal_argument_exception",
+        #   "reason" : "The bulk request must be terminated by a newline [\n]"
+        # },
+        # "status" : 400
+        try:
+            message = f'{message} {json["error"]["reason"]}'
+        except (KeyError, TypeError):
+            # Failed to find error message, in Elasticseach error
+            pass
+
+        # Parse Kubernetes or Kong error response:
+        #
+        # Expect the following format:
+        #
+        # {
+        #   "timestamp": "2022-02-04T13:46:22.445",
+        #   "status": "Bad Request",
+        #   "statusCode": 400,
+        #   "message": "Failed to convert value of type 'java.lang.String' to required type 'java.lang.Boolean';",
+        #   "path": "/api/v1/data/fetch"
+        # }
+        try:
+            message = f'{message} {json["message"]}'
+        except KeyError:
+            # Failed to find error message, in Elasticseach error
+            pass
+
+        super().__init__(message, *args, **kwargs)
 
 
 class SearchManagerException(KongException):

--- a/etna/ciim/models.py
+++ b/etna/ciim/models.py
@@ -6,7 +6,7 @@ from .client import KongClient
 from .exceptions import (
     DoesNotExist,
     InvalidQuery,
-    KongError,
+    KongAPIError,
     MultipleObjectsReturned,
     UnsupportedSlice,
 )
@@ -210,7 +210,7 @@ class FetchQuery(Query):
         for iaid in ids:
             try:
                 instance = self.get(iaid=iaid)
-            except (KongError, DoesNotExist):
+            except (KongAPIError, DoesNotExist):
                 continue
             records.append(instance)
 

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -3,7 +3,12 @@ from django.test import SimpleTestCase
 import responses
 
 from ..client import KongClient, SortBy, SortOrder, Stream, Template
-from ..exceptions import KongError
+from ..exceptions import (
+    KongBadRequestError,
+    KongCommunicationError,
+    KongInternalServerError,
+    KongServiceUnavailableError,
+)
 
 
 class ClientSearchTest(SimpleTestCase):
@@ -338,7 +343,7 @@ class TestClientFetchReponse(SimpleTestCase):
         )
 
         with self.assertRaisesMessage(
-            KongError, "failure to get a peer from the ring-balancer"
+            KongServiceUnavailableError, "failure to get a peer from the ring-balancer"
         ):
             self.client.fetch()
 
@@ -361,7 +366,7 @@ class TestClientFetchReponse(SimpleTestCase):
             status=503,
         )
 
-        with self.assertRaisesMessage(KongError, "all shards failed"):
+        with self.assertRaisesMessage(KongServiceUnavailableError, "all shards failed"):
             self.client.fetch()
 
     @responses.activate
@@ -384,7 +389,37 @@ class TestClientFetchReponse(SimpleTestCase):
             status=400,
         )
 
-        with self.assertRaisesMessage(KongError, "Failed to convert value of type"):
+        with self.assertRaisesMessage(
+            KongBadRequestError, "Failed to convert value of type"
+        ):
+            self.client.fetch()
+
+    @responses.activate
+    def test_internal_server_error(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/fetch",
+            json={
+                "message": ("Internal Server Error"),
+            },
+            status=500,
+        )
+
+        with self.assertRaisesMessage(KongInternalServerError, "Internal Server Error"):
+            self.client.fetch()
+
+    @responses.activate
+    def test_default_exception(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/fetch",
+            json={
+                "message": ("I'm a teapot"),
+            },
+            status=418,
+        )
+
+        with self.assertRaisesMessage(KongCommunicationError, "I'm a teapot"):
             self.client.fetch()
 
     @responses.activate
@@ -423,7 +458,7 @@ class TestClientSearchReponse(SimpleTestCase):
         )
 
         with self.assertRaisesMessage(
-            KongError, "failure to get a peer from the ring-balancer"
+            KongServiceUnavailableError, "failure to get a peer from the ring-balancer"
         ):
             self.client.search()
 
@@ -446,7 +481,7 @@ class TestClientSearchReponse(SimpleTestCase):
             status=503,
         )
 
-        with self.assertRaisesMessage(KongError, "all shards failed"):
+        with self.assertRaisesMessage(KongServiceUnavailableError, "all shards failed"):
             self.client.search()
 
     @responses.activate
@@ -469,7 +504,37 @@ class TestClientSearchReponse(SimpleTestCase):
             status=400,
         )
 
-        with self.assertRaisesMessage(KongError, "Failed to convert value of type"):
+        with self.assertRaisesMessage(
+            KongBadRequestError, "Failed to convert value of type"
+        ):
+            self.client.search()
+
+    @responses.activate
+    def test_internal_server_error(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/search",
+            json={
+                "message": ("Internal Server Error"),
+            },
+            status=500,
+        )
+
+        with self.assertRaisesMessage(KongInternalServerError, "Internal Server Error"):
+            self.client.search()
+
+    @responses.activate
+    def test_default_exception(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/search",
+            json={
+                "message": ("I'm a teapot"),
+            },
+            status=418,
+        )
+
+        with self.assertRaisesMessage(KongCommunicationError, "I'm a teapot"):
             self.client.search()
 
     @responses.activate
@@ -508,7 +573,7 @@ class TestClientFetchAllReponse(SimpleTestCase):
         )
 
         with self.assertRaisesMessage(
-            KongError, "failure to get a peer from the ring-balancer"
+            KongServiceUnavailableError, "failure to get a peer from the ring-balancer"
         ):
             self.client.fetch_all()
 
@@ -531,7 +596,7 @@ class TestClientFetchAllReponse(SimpleTestCase):
             status=503,
         )
 
-        with self.assertRaisesMessage(KongError, "all shards failed"):
+        with self.assertRaisesMessage(KongServiceUnavailableError, "all shards failed"):
             self.client.fetch_all()
 
     @responses.activate
@@ -554,7 +619,37 @@ class TestClientFetchAllReponse(SimpleTestCase):
             status=400,
         )
 
-        with self.assertRaisesMessage(KongError, "Failed to convert value of type"):
+        with self.assertRaisesMessage(
+            KongBadRequestError, "Failed to convert value of type"
+        ):
+            self.client.fetch_all()
+
+    @responses.activate
+    def test_internal_server_error(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/fetchAll",
+            json={
+                "message": ("Internal Server Error"),
+            },
+            status=500,
+        )
+
+        with self.assertRaisesMessage(KongInternalServerError, "Internal Server Error"):
+            self.client.fetch_all()
+
+    @responses.activate
+    def test_default_exception(self):
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/fetchAll",
+            json={
+                "message": ("I'm a teapot"),
+            },
+            status=418,
+        )
+
+        with self.assertRaisesMessage(KongCommunicationError, "I'm a teapot"):
             self.client.fetch_all()
 
     @responses.activate

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -1,140 +1,331 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
 import responses
 
-from ..client import KongClient
-from ..exceptions import InvalidResponse, KongError, KubernetesError
+from ..client import KongClient, Sort, SortOrder, Stream, Template
+from ..exceptions import KongError
 
 
-class ClientSearchTest(TestCase):
+class ClientSearchTest(SimpleTestCase):
     def setUp(self):
         self.client = KongClient("https://kong.test", api_key="")
 
         responses.add(responses.GET, "https://kong.test/data/search", json={})
 
     @responses.activate
-    def test_default_parameters(self):
+    def test_no_arguments_makes_request_with_no_parameters(self):
         self.client.search()
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
-            responses.calls[0].request.url,
-            "https://kong.test/data/search?from=0",
+            responses.calls[0].request.url, "https://kong.test/data/search"
         )
 
     @responses.activate
-    def test_from_paramter_conversion(self):
-        self.client.search(start=10)
+    def test_with_keyword(self):
+        self.client.search(keyword="Egypt")
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?from=10",
+            "https://kong.test/data/search?keyword=Egypt",
         )
 
     @responses.activate
-    def test_search_with_reference_number(self):
-        self.client.search(reference_number="ADM 223/3")
+    def test_with_web_reference(self):
+        self.client.search(web_reference="ADM/223/3")
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0",
+            "https://kong.test/data/search?webReference=ADM%2F223%2F3",
         )
 
     @responses.activate
-    def test_search_with_iaid(self):
-        self.client.search(iaid="C10297")
+    def test_with_evidential_stream(self):
+        self.client.search(stream=Stream.EVIDENTIAL)
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=C10297&from=0",
+            "https://kong.test/data/search?stream=evidential",
         )
 
     @responses.activate
-    def test_search_with_term(self):
-        self.client.search(term="Egypt")
+    def test_with_interpretive_stream(self):
+        self.client.search(stream=Stream.INTERPRETIVE)
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=Egypt&from=0",
+            "https://kong.test/data/search?stream=interpretive",
+        )
+
+    @responses.activate
+    def test_with_sort_title(self):
+        self.client.search(sort=Sort.TITLE)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?sort=title",
+        )
+
+    @responses.activate
+    def test_with_sort_date_created(self):
+        self.client.search(sort=Sort.DATE_CREATED)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?sort=date_created",
+        )
+
+    @responses.activate
+    def test_with_sort_order_asc(self):
+        self.client.search(sort_order=SortOrder.ASC)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?sortOrder=asc",
+        )
+
+    @responses.activate
+    def test_with_sort_order_desc(self):
+        self.client.search(sort_order=SortOrder.DESC)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?sortOrder=desc",
+        )
+
+    @responses.activate
+    def test_with_template_details(self):
+        self.client.search(template=Template.DETAILS)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?template=details",
+        )
+
+    @responses.activate
+    def test_with_template_results(self):
+        self.client.search(template=Template.RESULTS)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?template=results",
+        )
+
+    @responses.activate
+    def test_with_show_buckets_true(self):
+        self.client.search(show_buckets=True)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?showBuckets=True",
+        )
+
+    @responses.activate
+    def test_with_show_buckets_false(self):
+        self.client.search(show_buckets=False)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?showBuckets=False",
+        )
+
+    @responses.activate
+    def test_with_buckets(self):
+        self.client.search(buckets=["bucket-one", "bucket-two", "bucket-three"])
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?buckets=bucket-one%2C+bucket-two%2C+bucket-three",
+        )
+
+    @responses.activate
+    def test_with_topics(self):
+        self.client.search(topics=["topic-one", "topic-two", "topic-three"])
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?topics=topic-one%2C+topic-two%2C+topic-three",
+        )
+
+    @responses.activate
+    def test_with_references(self):
+        self.client.search(
+            references=["reference-one", "reference-two", "reference-three"]
+        )
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?references=reference-one%2C+reference-two%2C+reference-three",
+        )
+
+    @responses.activate
+    def test_with_offset(self):
+        self.client.search(offset=20)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?from=20",
+        )
+
+    @responses.activate
+    def test_with_size(self):
+        self.client.search(size=20)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?size=20",
         )
 
 
-class ClientFetchTest(TestCase):
+class ClientFetchTest(SimpleTestCase):
     def setUp(self):
         self.client = KongClient("https://kong.test", api_key="")
 
         responses.add(responses.GET, "https://kong.test/data/fetch", json={})
 
     @responses.activate
-    def test_default_parameters(self):
-
+    def test_no_arguments_makes_request_with_no_parameters(self):
         self.client.fetch()
 
         self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(
-            responses.calls[0].request.url,
-            "https://kong.test/data/fetch?from=0&expand=false",
-        )
+        self.assertEqual(responses.calls[0].request.url, "https://kong.test/data/fetch")
 
     @responses.activate
-    def test_reference_number_conversion(self):
-        self.client.fetch(reference_number="PROD 1/4")
-
-        self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(
-            responses.calls[0].request.url,
-            "https://kong.test/data/fetch?ref=PROD+1%2F4&from=0&expand=false",
-        )
-
-    @responses.activate
-    def test_expand_parameter_conversion_true(self):
-        self.client.fetch(expand=True)
-
-        self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(
-            responses.calls[0].request.url,
-            "https://kong.test/data/fetch?from=0&expand=true",
-        )
-
-    @responses.activate
-    def test_expand_parameter_conversion_false(self):
-        self.client.fetch(expand=False)
-
-        self.assertEqual(len(responses.calls), 1)
-        self.assertEqual(
-            responses.calls[0].request.url,
-            "https://kong.test/data/fetch?from=0&expand=false",
-        )
-
-    @responses.activate
-    def test_fetch_with_iaid(self):
+    def test_with_iaid(self):
         self.client.fetch(iaid="C198022")
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C198022&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C198022",
+        )
+
+    @responses.activate
+    def test_with_id(self):
+        self.client.fetch(id="ADM 223/3")
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetch?id=ADM+223%2F3",
+        )
+
+    @responses.activate
+    def test_with_template_details(self):
+        self.client.fetch(template=Template.DETAILS)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetch?template=details",
+        )
+
+    @responses.activate
+    def test_with_template_results(self):
+        self.client.fetch(template=Template.RESULTS)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetch?template=results",
+        )
+
+    @responses.activate
+    def test_with_expand_true(self):
+        self.client.fetch(expand=True)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetch?expand=True",
+        )
+
+    @responses.activate
+    def test_with_expand_false(self):
+        self.client.fetch(expand=False)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetch?expand=False",
         )
 
 
-class TestClientFetchReponse(TestCase):
+class ClientFetchAllTest(SimpleTestCase):
     def setUp(self):
         self.client = KongClient("https://kong.test", api_key="")
 
+        responses.add(responses.GET, "https://kong.test/data/fetchAll", json={})
+
     @responses.activate
-    def test_test_mode_doesnt_use_requests(self):
-        responses.add(
-            responses.GET,
-            "https://kong.test/data/fetch",
-            status=500,
+    def test_no_arguments_makes_request_with_no_parameters(self):
+        self.client.fetch_all()
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url, "https://kong.test/data/fetchAll"
         )
 
-        with self.assertRaises(InvalidResponse):
-            self.client.fetch()
+    @responses.activate
+    def test_with_ids(self):
+        self.client.fetch_all(ids=["id-one", "id-two", "id-three"])
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetchAll?ids=id-one%2C+id-two%2C+id-three",
+        )
+
+    @responses.activate
+    def test_with_iaids(self):
+        self.client.fetch_all(iaids=["iaid-one", "iaid-two", "iaid-three"])
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetchAll?iaids=iaid-one%2C+iaid-two%2C+iaid-three",
+        )
+
+    @responses.activate
+    def test_with_rid(self):
+        self.client.fetch_all(rid="rid-123")
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetchAll?rid=rid-123",
+        )
+
+    @responses.activate
+    def test_with_size(self):
+        self.client.fetch_all(size=20)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/fetchAll?size=20",
+        )
+
+class TestClientFetchReponse(SimpleTestCase):
+    def setUp(self):
+        self.client = KongClient("https://kong.test", api_key="")
 
     @responses.activate
     def test_raises_kubernetes_error(self):
@@ -181,7 +372,7 @@ class TestClientFetchReponse(TestCase):
                     "Failed to convert value of type 'java.lang.String' "
                     "to required type 'java.lang.Integer'; "
                     "nested exception is java.lang.NumberFormatException: "
-                    "For input string: \"999999999999999999\""
+                    'For input string: "999999999999999999"'
                 ),
                 "path": "/search",
             },
@@ -213,7 +404,7 @@ class TestClientFetchReponse(TestCase):
         self.assertEqual(response, valid_response)
 
 
-class TestClientSearchReponse(TestCase):
+class TestClientSearchReponse(SimpleTestCase):
     def setUp(self):
         self.client = KongClient("https://kong.test", api_key="")
 

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -2,7 +2,7 @@ from django.test import SimpleTestCase
 
 import responses
 
-from ..client import KongClient, Sort, SortOrder, Stream, Template
+from ..client import KongClient, SortBy, SortOrder, Stream, Template
 from ..exceptions import KongError
 
 
@@ -63,7 +63,7 @@ class ClientSearchTest(SimpleTestCase):
 
     @responses.activate
     def test_with_sort_title(self):
-        self.client.search(sort=Sort.TITLE)
+        self.client.search(sort_by=SortBy.TITLE)
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
@@ -73,7 +73,7 @@ class ClientSearchTest(SimpleTestCase):
 
     @responses.activate
     def test_with_sort_date_created(self):
-        self.client.search(sort=Sort.DATE_CREATED)
+        self.client.search(sort_by=SortBy.DATE_CREATED)
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(

--- a/etna/ciim/tests/test_models.py
+++ b/etna/ciim/tests/test_models.py
@@ -10,7 +10,7 @@ import responses
 from ...records.models import Record
 from ..exceptions import (
     DoesNotExist,
-    KongException,
+    KongAPIError,
     MultipleObjectsReturned,
     UnsupportedSlice,
 )
@@ -290,7 +290,7 @@ class KongExceptionTest(TestCase):
             status=500,
         )
 
-        with self.assertRaises(KongException):
+        with self.assertRaises(KongAPIError):
             self.manager.get(iaid="C140")
 
 

--- a/etna/ciim/tests/test_models.py
+++ b/etna/ciim/tests/test_models.py
@@ -61,7 +61,7 @@ class SearchManagerFilterTest(TestCase):
             ),
         )
 
-        results = self.manager.filter(reference_number="ADM 223/3")
+        results = self.manager.filter(web_reference="ADM 223/3")
 
         self.assertEqual(len(results), 2)
         self.assertTrue(isinstance(results[0], Record))
@@ -77,7 +77,7 @@ class SearchManagerFilterTest(TestCase):
             json=create_response(records=[create_record()]),
         )
 
-        results = self.manager.filter(reference_number="ADM 223/3")
+        results = self.manager.filter(web_reference="ADM 223/3")
 
         with self.assertRaises(IndexError):
             results[1]
@@ -97,7 +97,7 @@ class SearchManagerFilterTest(TestCase):
             callback=partial(paginate_records_callback, records),
         )
 
-        results = [r for r in self.manager.filter(reference_number="ADM 223/3")]
+        results = [r for r in self.manager.filter(web_reference="ADM 223/3")]
 
         self.assertEqual(len(results), 2)
         self.assertTrue(isinstance(results[0], Record))
@@ -121,7 +121,7 @@ class SearchManagerKongCount(TestCase):
 
     @responses.activate
     def test_hits_with_subscript_for_first_result(self):
-        result = self.manager.filter(reference_number="ADM 223/3")
+        result = self.manager.filter(web_reference="ADM 223/3")
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result.count(), 1)
@@ -146,62 +146,62 @@ class SearchManagerKongClientIntegrationTest(TestCase):
     @responses.activate
     def test_url_for_with_subscript_for_first_result(self):
 
-        self.manager.filter(reference_number="ADM 223/3")[0]
+        self.manager.filter(web_reference="ADM 223/3")[0]
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0&size=10",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=0&size=10",
         )
 
     @responses.activate
     def test_url_for_subscript_for_first_result_with_limit(self):
-        self.manager.filter(reference_number="ADM 223/3")[0:1]
+        self.manager.filter(web_reference="ADM 223/3")[0:1]
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0&size=1",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=0&size=1",
         )
 
     @responses.activate
     def test_url_for_subscript_for_second_result_with_limit(self):
-        self.manager.filter(reference_number="ADM 223/3")[0:1]
+        self.manager.filter(web_reference="ADM 223/3")[0:1]
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0&size=1",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=0&size=1",
         )
 
     @responses.activate
     def test_url_for_subscript_for_first_page(self):
-        self.manager.filter(reference_number="ADM 223/3")[0:5]
+        self.manager.filter(web_reference="ADM 223/3")[0:5]
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0&size=5",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=0&size=5",
         )
 
     @responses.activate
     def test_url_for_subscript_for_second_page(self):
-        self.manager.filter(reference_number="ADM 223/3")[5:10]
+        self.manager.filter(web_reference="ADM 223/3")[5:10]
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=5&size=5",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=5&size=5",
         )
 
     @responses.activate
     def test_url_for_subscript_for_third_page(self):
-        self.manager.filter(reference_number="ADM 223/3")[10:15]
+        self.manager.filter(web_reference="ADM 223/3")[10:15]
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=10&size=5",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=10&size=5",
         )
 
     @responses.activate
@@ -229,47 +229,47 @@ class SearchManagerKongClientIntegrationTest(TestCase):
 
     @responses.activate
     def test_len_performs_fetch_for_zero_results(self):
-        len(self.manager.filter(reference_number="ADM 223/3"))
+        len(self.manager.filter(web_reference="ADM 223/3"))
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0&size=0",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=0&size=0",
         )
 
     @responses.activate
     def test_count_performs_fetch_for_zero_results(self):
-        self.manager.filter(reference_number="ADM 223/3").count()
+        self.manager.filter(web_reference="ADM 223/3").count()
 
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?term=ADM+223%2F3&from=0&size=0",
+            "https://kong.test/data/search?webReference=ADM+223%2F3&from=0&size=0",
         )
 
     @responses.activate
     def test_iteration_performs_fetch(self):
-        for _ in self.manager.filter(reference_number="ADM 223/3"):
+        for _ in self.manager.filter(web_reference="ADM 223/3"):
             ...
 
         self.assertTrue(len(responses.calls) > 0)
 
     @responses.activate
     def test_comprehension_performs_fetch(self):
-        [r for r in self.manager.filter(reference_number="ADM 223/3")]
+        [r for r in self.manager.filter(web_reference="ADM 223/3")]
 
         self.assertTrue(len(responses.calls) > 0)
 
     @responses.activate
     def test_cast_to_list_performs_fetch(self):
-        list(self.manager.filter(reference_number="ADM 223/3"))
+        list(self.manager.filter(web_reference="ADM 223/3"))
 
         self.assertTrue(len(responses.calls) > 0)
 
     @responses.activate
     def test_iterator(self):
 
-        pages = self.manager.filter(reference_number="ADM 223/3")
+        pages = self.manager.filter(web_reference="ADM 223/3")
 
         self.assertEquals(len(pages), 15)
         self.assertEquals(len([p for p in pages]), 15)

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -9,7 +9,7 @@ from wagtail.images import get_image_model_string
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..alerts.models import AlertMixin
-from ..ciim.exceptions import KongException
+from ..ciim.exceptions import KongAPIError, SearchManagerException
 from ..records.models import Record
 from ..records.widgets import RecordChooser
 from ..teasers.models import TeaserImageMixin
@@ -261,7 +261,7 @@ class ResultsPageRecord(Orderable, models.Model):
         """
         try:
             return Record.search.get(iaid=self.record_iaid)
-        except KongException:
+        except (KongAPIError, SearchManagerException):
             return None
 
     panels = [

--- a/etna/collections/tests/test_views.py
+++ b/etna/collections/tests/test_views.py
@@ -78,11 +78,11 @@ class TestRecordChooseView(WagtailPageTests):
         self.assertEqual(len(responses.calls), 2)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?stream=evidential&term=law&from=0&size=0",
+            "https://kong.test/data/search?stream=evidential&keyword=law&from=0&size=0",
         )
         self.assertURLEqual(
             responses.calls[1].request.url,
-            "https://kong.test/data/search?stream=evidential&size=1&term=law&from=0",
+            "https://kong.test/data/search?stream=evidential&size=1&keyword=law&from=0",
         )
 
     @responses.activate

--- a/etna/collections/tests/test_views.py
+++ b/etna/collections/tests/test_views.py
@@ -104,7 +104,13 @@ class TestRecordChooseView(WagtailPageTests):
 
     @responses.activate
     def test_select_failed(self):
+
         responses.reset()
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/fetch",
+            json=create_response(),
+        )
 
         response = self.client.get("/admin/record-chooser/invalid/")
 

--- a/etna/records/blocks.py
+++ b/etna/records/blocks.py
@@ -4,7 +4,7 @@ from django.utils.functional import cached_property
 
 from wagtail.core.blocks import ChooserBlock
 
-from ..ciim.exceptions import KongError
+from ..ciim.exceptions import KongAPIError, SearchManagerException
 
 
 class RecordChooserBlock(ChooserBlock):
@@ -85,7 +85,7 @@ class RecordChooserBlock(ChooserBlock):
 
         try:
             return self.target_model.search.get(iaid=value)
-        except KongError:
+        except (KongAPIError, SearchManagerException):
             # If there's a connection issue with Kong, return a stub Record
             # so we have something to render on the ResultsPage edit form.
             return self.target_model(iaid=value)

--- a/etna/records/tests/test_blocks.py
+++ b/etna/records/tests/test_blocks.py
@@ -87,11 +87,11 @@ class TestFeaturedRecordBlockIntegration(WagtailPageTests):
         self.assertEqual(len(responses.calls), 3)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456",
         )
         self.assertEqual(
             responses.calls[1].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456",
         )
 
     @responses.activate
@@ -177,7 +177,7 @@ class TestFeaturedRecordBlockIntegration(WagtailPageTests):
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456&expand=False",
         )
 
     @responses.activate
@@ -226,7 +226,7 @@ class TestFeaturedRecordBlockIntegration(WagtailPageTests):
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456&expand=False",
         )
 
 
@@ -313,11 +313,11 @@ class TestFeaturedRecordsBlockIntegration(WagtailPageTests):
         self.assertEqual(len(responses.calls), 3)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456",
         )
         self.assertEqual(
             responses.calls[1].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456",
         )
 
     @responses.activate
@@ -384,7 +384,7 @@ class TestFeaturedRecordsBlockIntegration(WagtailPageTests):
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456&expand=False",
         )
 
     @responses.activate
@@ -439,5 +439,5 @@ class TestFeaturedRecordsBlockIntegration(WagtailPageTests):
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/fetch?iaid=C123456&from=0&expand=false",
+            "https://kong.test/data/fetch?iaid=C123456&expand=False",
         )

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.test import TestCase, override_settings
 
 import responses
@@ -6,6 +8,9 @@ from ...ciim.tests.factories import create_media, create_response
 from ..models import Image
 
 
+@unittest.skip(
+    "Kong open beta API does not support media. Re-enable/update once media is available."
+)
 @override_settings(
     KONG_CLIENT_BASE_URL="https://kong.test",
     KONG_IMAGE_PREVIEW_BASE_URL="https://media.preview/",

--- a/etna/records/tests/test_views.py
+++ b/etna/records/tests/test_views.py
@@ -1,5 +1,6 @@
 import io
 import re
+import unittest
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -142,6 +143,9 @@ class TestRecordView(TestCase):
         )
         self.assertTemplateUsed(response, "records/record_detail.html")
 
+    @unittest.skip(
+        "Kong open beta API does not support media. Re-enable/update once media is available."
+    )
     @responses.activate
     def test_record_renders_for_record_with_no_image(self):
         responses.add(
@@ -169,6 +173,9 @@ class TestRecordView(TestCase):
         self.assertTemplateUsed(response, "records/record_detail.html")
         self.assertTemplateNotUsed(response, "records/image-viewer-panel.html")
 
+    @unittest.skip(
+        "Kong open beta API does not support media. Re-enable/update once media is available."
+    )
     @responses.activate
     def test_record_renders_for_record_with_image(self):
         responses.add(
@@ -205,6 +212,9 @@ class TestRecordView(TestCase):
         self.assertTemplateUsed(response, "includes/records/image-viewer-panel.html")
 
 
+@unittest.skip(
+    "Kong open beta API does not support media. Re-enable/update once media is available."
+)
 @override_settings(
     KONG_CLIENT_BASE_URL="https://kong.test",
 )
@@ -244,6 +254,9 @@ class TestImageServeView(TestCase):
         self.assertTrue(response.streaming)
 
 
+@unittest.skip(
+    "Kong open beta API does not support media. Re-enable/update once media is available."
+)
 @override_settings(
     KONG_CLIENT_BASE_URL="https://kong.test",
 )
@@ -325,6 +338,9 @@ class TestImageBrowseView(TestCase):
         self.assertEquals(response.resolver_match.url_name, "image-browse")
 
 
+@unittest.skip(
+    "Kong open beta API does not support media. Re-enable/update once media is available."
+)
 @override_settings(
     KONG_CLIENT_BASE_URL="https://kong.test",
 )

--- a/etna/records/views/choosers.py
+++ b/etna/records/views/choosers.py
@@ -23,7 +23,7 @@ class KongModelChooserMixinIn(ChooserMixin):
 
     def get_object_list(self, search_term=""):
         """Filter object list by user's search term"""
-        return self.model.search.filter(term=search_term, stream="evidential")
+        return self.model.search.filter(keyword=search_term, stream="evidential")
 
     def get_object(self, pk):
         """Fetch selected object"""

--- a/etna/records/views/choosers.py
+++ b/etna/records/views/choosers.py
@@ -3,6 +3,7 @@ from django.shortcuts import Http404
 
 from generic_chooser.views import BaseChosenView, ChooserMixin, ChooserViewSet
 
+from ...ciim.client import Stream
 from ...ciim.exceptions import KongException
 from ..models import Record
 
@@ -23,7 +24,7 @@ class KongModelChooserMixinIn(ChooserMixin):
 
     def get_object_list(self, search_term=""):
         """Filter object list by user's search term"""
-        return self.model.search.filter(keyword=search_term, stream="evidential")
+        return self.model.search.filter(keyword=search_term, stream=Stream.EVIDENTIAL)
 
     def get_object(self, pk):
         """Fetch selected object"""

--- a/etna/records/views/choosers.py
+++ b/etna/records/views/choosers.py
@@ -4,7 +4,7 @@ from django.shortcuts import Http404
 from generic_chooser.views import BaseChosenView, ChooserMixin, ChooserViewSet
 
 from ...ciim.client import Stream
-from ...ciim.exceptions import KongException
+from ...ciim.exceptions import KongAPIError, SearchManagerException
 from ..models import Record
 
 
@@ -55,7 +55,7 @@ class KongChosenView(BaseChosenView):
         """
         try:
             return super().get(request, pk)
-        except KongException:
+        except (KongAPIError, SearchManagerException):
             raise Http404
 
 

--- a/etna/records/views/images.py
+++ b/etna/records/views/images.py
@@ -6,7 +6,7 @@ from django.views.decorators.cache import cache_control
 from ...ciim.exceptions import (
     DoesNotExist,
     InvalidQuery,
-    KongException,
+    KongAPIError,
     UnsupportedSlice,
 )
 from ...ciim.utils import convert_sort_key_to_index
@@ -41,7 +41,7 @@ def image_viewer(request, iaid, sort):
         # Attempted to fetch using a negative index meaning we're viewing the
         # first image and therefore there's no previous image to fetch.
         previous_image = None
-    except KongException:
+    except KongAPIError:
         # Subscripting for the previous image will trigger a request to Kong.
         # If the query isn't valid, this is where the exception will be raised..
         raise Http404

--- a/etna/records/views/records.py
+++ b/etna/records/views/records.py
@@ -19,7 +19,7 @@ def record_disambiguation_view(request, reference_number):
 
     https://discovery.nationalarchives.gov.uk/browse/r/h/C4122893
     """
-    pages = Record.search.filter(webReference=reference_number)
+    pages = Record.search.filter(web_reference=reference_number)
 
     if len(pages) == 0:
         raise Http404

--- a/etna/records/widgets.py
+++ b/etna/records/widgets.py
@@ -1,6 +1,6 @@
 from generic_chooser.widgets import AdminChooser
 
-from ..ciim.exceptions import KongException
+from ..ciim.exceptions import KongAPIError, SearchManagerException
 from .models import Record
 
 
@@ -30,7 +30,7 @@ class RecordChooser(AdminChooser):
         """Fetch related instance on edit form."""
         try:
             return Record.search.get(iaid=pk)
-        except KongException:
+        except (KongAPIError, SearchManagerException):
             # If there's a connection issue with Kong, return a stub Record
             # so we have something to render on the ResultsPage edit form.
             return Record(iaid=pk, title="", reference_number="")

--- a/etna/users/tests/test_access.py
+++ b/etna/users/tests/test_access.py
@@ -1,3 +1,5 @@
+import unittest
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import TestCase, override_settings
@@ -271,6 +273,9 @@ class TestRecordRoutes(UserAccessTestCase, TestCase):
         self.assertEquals(expected_status_code, response.status_code)
 
 
+@unittest.skip(
+    "Kong open beta API does not support media. Re-enable/update once media is available."
+)
 @ddt
 @override_settings(
     KONG_CLIENT_BASE_URL="https://kong.test",


### PR DESCRIPTION
 - Improved documentation
 - Explicit keyword parameters (matching Kong’s parameters where possible)
 - Type hints for parameters  (including enums matching Kong's parameter definitions)
 - Return types
 - Transform lists into comma-separated strings to pass to Kong
 - Simplified error handling. Kong should correctly respond with a non-200 status code on error.
 - Add support for `fetchAll/`

Additionally, In order to run the whole test suite I needed to disable image-based tests as the Kong Open beta API has no `/media` endpoint.