### PR TITLE
CHORE: Prep for datalayer tickets DF-74 + UN-141

### DIFF
--- a/etna/analytics/mixins.py
+++ b/etna/analytics/mixins.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict
+
+from django.http import HttpRequest
+
+
+class DataLayerMixin:
+    """
+    A mixin applied to Page types, Record subclasses,
+    or View classes to allow them to customise the Google Analytics
+    datalayer.
+    """
+
+    def get_gtm_content_group(self) -> str:
+        raise NotImplementedError
+
+    def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
+        """
+        Return values that should be included in the Google Analytics datalayer
+        when rendering this object for the provided ``request``.
+
+        Override this method on subclasses to add data that is relevant to the
+        subclass.
+        """
+
+        # Set defaults
+        data = {
+            "contentGroup1": self.get_gtm_content_group(),
+            "customDimension3": "",
+            "customDimension4": "",
+            "customDimension5": "",
+            "customDimension6": "",
+            "customDimension7": "",
+            "customDimension8": "",
+            "customDimension9": "",
+            "customDimension10": "",
+            "customDimension11": "",
+            "customDimension12": "",
+            "customDimension13": "",
+            "customDimension14": "",
+            "customDimension15": "",
+            "customDimension16": "",
+            "customDimension17": "",
+        }
+
+        # Add request-specific data
+        # NOTE: Could potentially be added via JS if we want to keep
+        # server responses cacheable
+        data.update(
+            customDimension1="offsite",
+            customDimension2=getattr(request.user, "id", ""),
+        )
+        return data

--- a/etna/analytics/templatetags/datalayer_tags.py
+++ b/etna/analytics/templatetags/datalayer_tags.py
@@ -1,7 +1,4 @@
-import json
-
 from django import template
-from django.core.serializers.json import DjangoJSONEncoder
 
 register = template.Library()
 
@@ -13,14 +10,12 @@ def render_gtm_datalayer(context, obj) -> dict:
     https://developers.google.com/tag-manager/devguide
     """
     try:
-        data_json = json.dumps(
-            obj.get_datalayer_data(context["request"]), cls=DjangoJSONEncoder
-        )
+        data = obj.get_datalayer_data(context["request"])
     except AttributeError:
-        data_json = ""
+        data = {}
 
     # Add a json serialized version of the data for output
-    return {"data_json": data_json}
+    return {"data": data}
 
 
 @register.simple_tag(takes_context=True)

--- a/etna/analytics/templatetags/datalayer_tags.py
+++ b/etna/analytics/templatetags/datalayer_tags.py
@@ -1,83 +1,26 @@
+import json
+
 from django import template
-from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 
 register = template.Library()
 
 
-def get_content_group(page):
+@register.inclusion_tag("includes/gtm-datalayer.html", takes_context=True)
+def render_gtm_datalayer(context, obj) -> dict:
     """
-    Get the content group name for a specified page.
-
-    The group name is derived from the page model's app name.
-
-    If the model has no defined group, the page title is returned by default.
-    """
-    appname = page.__module__.split(".")[1]
-    groups = {
-        "home": "Homepage",
-        "insights": "Insights",
-        "collections": "Explorer",
-        "records": "TNA catalogue",
-    }
-    return groups.get(appname, page.title)
-
-
-def get_availability_condition_category(availability_condition):
-    """
-    Return a category for the availability condition of the page.
-
-    If an availability condition is not present, return an empty string.
-    """
-    return settings.AVAILABILITY_CONDITION_CATEGORIES.get(availability_condition, "")
-
-
-@register.filter
-def datalayer(page, request) -> dict:
-    """
-    Return Datalayer data for a Page object.
-
+    Render the datalayer for an instance of a ``DataLayerMixin`` subclass.
     https://developers.google.com/tag-manager/devguide
     """
+    try:
+        data_json = json.dumps(
+            obj.get_datalayer_data(context["request"]), cls=DjangoJSONEncoder
+        )
+    except AttributeError:
+        data_json = ""
 
-    return {
-        # Name of the content group - [Always has a value]
-        "contentGroup1": get_content_group(page),
-        # The reader type (options are "offsite",
-        # "onsite_public", "onsite_staff", "subscription")
-        "customDimension1": "offsite",
-        # - User ID for participants.
-        "customDimension2": request.user.id,
-        # Page type - [Always has a value]
-        "customDimension3": page.get_verbose_name(),
-        # Taxonomy topics for the page, delineated by semi-colons. Empty string if no value.
-        "customDimension4": "",
-        # Taxonomy sub topic where applicable. Empty string if not applicable.
-        "customDimension5": "",
-        # Taxonomy term where applicable. Empty string if not applicable.
-        "customDimension6": "",
-        # Time period where applicable. Empty string if not applicable.
-        "customDimension7": "",
-        # Sub time period where applicable. Empty string if not applicable.
-        "customDimension8": "",
-        # Entity type where applicable. Empty string if not applicable.
-        "customDimension9": "",
-        # Entity label where applicable. Empty string if not applicable.
-        "customDimension10": "",
-        # Catalogue repository where applicable. Empty string if not applicable.
-        "customDimension11": "",
-        # Catalogue level where applicable. Empty string if not applicable.
-        "customDimension12": "",
-        # Catalogue series where applicable. Empty string if not applicable.
-        "customDimension13": "",
-        # Catalogue reference where applicable. Empty string if not applicable.
-        "customDimension14": "",
-        # CatalogueDataSource where applicable. Empty string if not applicable.
-        "customDimension15": "",
-        # Availability condition category where applicable.  Empty string if not applicable.
-        "customDimension16": "",
-        # Availability condition where applicable.  Empty string if not applicable.
-        "customDimension17": "",
-    }
+    # Add a json serialized version of the data for output
+    return {"data_json": data_json}
 
 
 @register.simple_tag(takes_context=True)
@@ -93,59 +36,4 @@ def image_browse_datalayer(context) -> dict:
         # The user type and is private beta specific - the user ID for participants.
         "customDimension2": context["request"].user.id,
         "customDimension18": context.get("images_count", ""),
-    }
-
-
-@register.simple_tag(takes_context=True)
-def record_datalayer(context) -> dict:
-    """Custom tag for image browse datalayer.
-
-    Image browse isn't a page served by Wagtail, therefore we're unable to
-    query the page object to populate the datalayer.
-    """
-    user = context["request"].user
-    page = context["page"]
-    availability_condition = page.availability_delivery_condition
-    availability_condition_category = get_availability_condition_category(
-        availability_condition
-    )
-
-    return {
-        # The name of the content group - [Always has a value]
-        "contentGroup1": get_content_group(page),
-        # The reader type (options are "offsite",
-        # "onsite_public", "onsite_staff", "subscription")
-        "customDimension1": "offsite",
-        # ser ID for participants.
-        "customDimension2": user.id,
-        # The page type - [Always has a value]
-        "customDimension3": "Record page",
-        # Taxonomy topics for the page, delineated by semi-colons. Empty string if no value.
-        "customDimension4": "",
-        # Taxonomy sub topic where applicable. Empty string if not applicable.
-        "customDimension5": "",
-        # Taxonomy term where applicable. Empty string if not applicable.
-        "customDimension6": "",
-        # Time period where applicable. Empty string if not applicable.
-        "customDimension7": "",
-        # Sub time period where applicable. Empty string if not applicable.
-        "customDimension8": "",
-        # Entity type where applicable. Empty string if not applicable.
-        "customDimension9": "",
-        # Entity label where applicable. Empty string if not applicable.
-        "customDimension10": "",
-        # Catalogue repository where applicable. Empty string if not applicable.
-        "customDimension11": "",
-        # Catalogue level where applicable. Empty string if not applicable.
-        "customDimension12": "",
-        # Catalogue series where applicable. Empty string if not applicable.
-        "customDimension13": "",
-        # Catalogue reference where applicable. Empty string if not applicable.
-        "customDimension14": "",
-        # CatalogueDataSource where applicable. Empty string if not applicable.
-        "customDimension15": "",
-        # Availability condition category where applicable.  Empty string if not applicable.
-        "customDimension16": availability_condition_category,
-        # Availability condition where applicable.  Empty string if not applicable.
-        "customDimension17": availability_condition,
     }

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -4,12 +4,13 @@ from django.utils.functional import cached_property
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, StreamFieldPanel
 from wagtail.core.fields import StreamField
-from wagtail.core.models import Orderable, Page
+from wagtail.core.models import Orderable
 from wagtail.images import get_image_model_string
 from wagtail.images.edit_handlers import ImageChooserPanel
 
 from ..alerts.models import AlertMixin
 from ..ciim.exceptions import APIManagerException, KongAPIError
+from ..core.models import BasePage
 from ..records.models import Record
 from ..records.widgets import RecordChooser
 from ..teasers.models import TeaserImageMixin
@@ -22,8 +23,8 @@ from .blocks import (
 )
 
 
-class ExplorerIndexPage(AlertMixin, TeaserImageMixin, Page):
-    """Collection Explorer landing page.
+class ExplorerIndexPage(AlertMixin, TeaserImageMixin, BasePage):
+    """Collection Explorer landing BasePage.
 
     This page is the starting point for a user's journey through the collection
     explorer.
@@ -32,12 +33,12 @@ class ExplorerIndexPage(AlertMixin, TeaserImageMixin, Page):
     sub_heading = models.CharField(max_length=200, blank=False)
     body = StreamField(ExplorerIndexPageStreamBlock, blank=True)
 
-    content_panels = Page.content_panels + [
+    content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
         StreamFieldPanel("body"),
     ]
-    promote_panels = Page.promote_panels + TeaserImageMixin.promote_panels
-    settings_panels = Page.settings_panels + AlertMixin.settings_panels
+    promote_panels = BasePage.promote_panels + TeaserImageMixin.promote_panels
+    settings_panels = BasePage.settings_panels + AlertMixin.settings_panels
 
     parent_page_types = ["home.HomePage"]
     subpage_types = [
@@ -46,8 +47,8 @@ class ExplorerIndexPage(AlertMixin, TeaserImageMixin, Page):
     ]
 
 
-class TopicExplorerIndexPage(TeaserImageMixin, Page):
-    """Topic explorer page.
+class TopicExplorerIndexPage(TeaserImageMixin, BasePage):
+    """Topic explorer BasePage.
 
     This page lists all child TopicExplorerPages
     """
@@ -55,11 +56,11 @@ class TopicExplorerIndexPage(TeaserImageMixin, Page):
     sub_heading = models.CharField(max_length=200, blank=False)
     body = StreamField(TopicExplorerIndexPageStreamBlock, blank=True)
 
-    content_panels = Page.content_panels + [
+    content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
         StreamFieldPanel("body"),
     ]
-    promote_panels = Page.promote_panels + TeaserImageMixin.promote_panels
+    promote_panels = BasePage.promote_panels + TeaserImageMixin.promote_panels
 
     @cached_property
     def featured_pages(self):
@@ -90,8 +91,8 @@ class TopicExplorerIndexPage(TeaserImageMixin, Page):
     ]
 
 
-class TopicExplorerPage(AlertMixin, TeaserImageMixin, Page):
-    """Topic explorer page.
+class TopicExplorerPage(AlertMixin, TeaserImageMixin, BasePage):
+    """Topic explorer BasePage.
 
     This page represents one of the many categories a user may select in the
     collection explorer.
@@ -105,12 +106,12 @@ class TopicExplorerPage(AlertMixin, TeaserImageMixin, Page):
 
     body = StreamField(TopicExplorerPageStreamBlock, blank=True)
 
-    content_panels = Page.content_panels + [
+    content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
         StreamFieldPanel("body"),
     ]
-    promote_panels = Page.promote_panels + TeaserImageMixin.promote_panels
-    settings_panels = Page.settings_panels + AlertMixin.settings_panels
+    promote_panels = BasePage.promote_panels + TeaserImageMixin.promote_panels
+    settings_panels = BasePage.settings_panels + AlertMixin.settings_panels
 
     @property
     def results_pages(self):
@@ -124,8 +125,8 @@ class TopicExplorerPage(AlertMixin, TeaserImageMixin, Page):
     subpage_types = ["collections.TopicExplorerPage", "collections.ResultsPage"]
 
 
-class TimePeriodExplorerIndexPage(TeaserImageMixin, Page):
-    """Time period explorer page.
+class TimePeriodExplorerIndexPage(TeaserImageMixin, BasePage):
+    """Time period explorer BasePage.
 
     This page lists all child TimePeriodExplorerPage
     """
@@ -133,11 +134,11 @@ class TimePeriodExplorerIndexPage(TeaserImageMixin, Page):
     sub_heading = models.CharField(max_length=200, blank=False)
     body = StreamField(TimePeriodExplorerIndexPageStreamBlock, blank=True)
 
-    content_panels = Page.content_panels + [
+    content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
         StreamFieldPanel("body"),
     ]
-    promote_panels = Page.promote_panels + TeaserImageMixin.promote_panels
+    promote_panels = BasePage.promote_panels + TeaserImageMixin.promote_panels
 
     @cached_property
     def featured_pages(self):
@@ -168,8 +169,8 @@ class TimePeriodExplorerIndexPage(TeaserImageMixin, Page):
     ]
 
 
-class TimePeriodExplorerPage(AlertMixin, TeaserImageMixin, Page):
-    """Time period page.
+class TimePeriodExplorerPage(AlertMixin, TeaserImageMixin, BasePage):
+    """Time period BasePage.
 
     This page represents one of the many categories a user may select in the
     collection explorer.
@@ -184,14 +185,14 @@ class TimePeriodExplorerPage(AlertMixin, TeaserImageMixin, Page):
     start_year = models.IntegerField(blank=False)
     end_year = models.IntegerField(blank=False)
 
-    content_panels = Page.content_panels + [
+    content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
         StreamFieldPanel("body"),
         FieldPanel("start_year"),
         FieldPanel("end_year"),
     ]
-    promote_panels = Page.promote_panels + TeaserImageMixin.promote_panels
-    settings_panels = Page.settings_panels + AlertMixin.settings_panels
+    promote_panels = BasePage.promote_panels + TeaserImageMixin.promote_panels
+    settings_panels = BasePage.settings_panels + AlertMixin.settings_panels
 
     @property
     def results_pages(self):
@@ -205,8 +206,8 @@ class TimePeriodExplorerPage(AlertMixin, TeaserImageMixin, Page):
     subpage_types = ["collections.TimePeriodExplorerPage", "collections.ResultsPage"]
 
 
-class ResultsPage(AlertMixin, TeaserImageMixin, Page):
-    """Results page.
+class ResultsPage(AlertMixin, TeaserImageMixin, BasePage):
+    """Results BasePage.
 
     This page is a placeholder for the results page at the end of a user's
     journey through the collection explorer.
@@ -219,14 +220,14 @@ class ResultsPage(AlertMixin, TeaserImageMixin, Page):
     sub_heading = models.CharField(max_length=200, blank=False)
     introduction = models.TextField(blank=False)
 
-    content_panels = Page.content_panels + [
+    content_panels = BasePage.content_panels + [
         FieldPanel("title_prefix"),
         FieldPanel("sub_heading"),
         FieldPanel("introduction"),
         InlinePanel("records", heading="Records"),
     ]
-    promote_panels = Page.promote_panels + TeaserImageMixin.promote_panels
-    settings_panels = Page.settings_panels + AlertMixin.settings_panels
+    promote_panels = BasePage.promote_panels + TeaserImageMixin.promote_panels
+    settings_panels = BasePage.settings_panels + AlertMixin.settings_panels
 
     parent_page_types = [
         "collections.TimePeriodExplorerPage",
@@ -254,10 +255,10 @@ class ResultsPageRecord(Orderable, models.Model):
 
     @cached_property
     def record(self):
-        """Fetch associated record page.
+        """Fetch associated record BasePage.
 
         Capture any exception thrown by KongClient and return None so we can
-        skip this record on the results page.
+        skip this record on the results BasePage.
         """
         try:
             return Record.api.fetch(iaid=self.record_iaid)

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -1,7 +1,11 @@
+from typing import Any, Dict
+
+from django.http import HttpRequest
 from django.utils.decorators import method_decorator
 
 from wagtail.core.models import Page
 
+from etna.analytics.mixins import DataLayerMixin
 from etna.core.cache_control import (
     apply_default_cache_control,
     apply_default_vary_headers,
@@ -12,9 +16,17 @@ __all__ = [
 ]
 
 
+GTM_CONTENT_GROUPS = {
+    "home": "Homepage",
+    "insights": "Insights",
+    "collections": "Explorer",
+    "records": "TNA catalogue",
+}
+
+
 @method_decorator(apply_default_vary_headers, name="serve")
 @method_decorator(apply_default_cache_control, name="serve")
-class BasePage(Page):
+class BasePage(DataLayerMixin, Page):
     """
     An abstract base model that is used for all Page models within
     the project. Any common fields, Wagtail overrides or custom
@@ -23,3 +35,23 @@ class BasePage(Page):
 
     class Meta:
         abstract = True
+
+    def get_gtm_content_group(self) -> str:
+        """
+        Overrides DataLayerMixin.get_gtm_content_group() to
+        derive a string from the model's app label.
+        """
+        app_label = self._meta.label.split(".")[0]
+        return GTM_CONTENT_GROUPS.get(app_label, self.title)
+
+    def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
+        """
+        Return values that should be included in the Google Analytics datalayer
+        when rendering this page.
+
+        Override this method on subclasses to add data that is relevant to a
+        specific page type.
+        """
+        data = super().get_datalayer_data(request)
+        data.update(customDimension3=self._meta.verbose_name)
+        return data

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,21 +1,17 @@
-{% load wagtailcore_tags %}
-{% load static wagtailuserbar %}
-{% load alert_tags %}
-
-{% wagtail_site as current_site %}
-
-<!DOCTYPE html>
+{% load static wagtailuserbar wagtailcore_tags %}<!DOCTYPE html>
 <html class="no-js" lang="en">
     <head>
         <meta charset="utf-8" />
         <title>
-            {% if form.errors %}Error: {% endif %}
-
+            {% block title_prefix %}
+                {% if form.errors %}Error: {% endif %}
+            {% endblock %}
             {% block title %}
                 {% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}
             {% endblock %}
             {% block title_suffix %}
-                - {{ current_site.site_name }}
+                {% wagtail_site as current_site %}
+                 - {{ current_site.site_name }}
             {% endblock %}
         </title>
         <meta name="description" content="" />
@@ -28,38 +24,44 @@
             {# Override this in templates to add extra stylesheets #}
         {% endblock %}
 
-    {% block extra_gtm_js %}
-        {# Override this in templates to add extra javascript to be used by GTM #}
-    {% endblock %}
+        {% block extra_gtm_js %}
+            {# Override this in templates to add extra javascript to be used by GTM #}
+        {% endblock %}
 
-    {% include 'includes/gtm-script.html' %}
+        {% include 'includes/gtm-script.html' %}
 
-    {# Google Fonts #}
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap"
-          rel="stylesheet">
-    <script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';</script>
+        {# Google Fonts #}
+        <link rel="preconnect" href="https://fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap"
+            rel="stylesheet">
+        <script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';</script>
 
-    {# Favicon #}
-    <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
-    <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
-</head>
+        {# Favicon #}
+        <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+        <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+    </head>
 
-<body class="{% block body_class %}{% endblock %}">
-{% wagtailuserbar %}
-<a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable" data-link="Skip to main content">Skip to main content</a>
-{% block alerts %}{% alerts page=page %}{% endblock %}
-{% include 'includes/gtm-no-script.html' %}
-{% include 'includes/header.html' %}
+    <body class="{% block body_class %}{% endblock %}">
+        <a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable" data-link="Skip to main content">Skip to main content</a>
 
-<main id="maincontent">
-    {% block content %}{% endblock %}
-</main>
+        {% include 'includes/gtm-no-script.html' %}
 
-{% include 'includes/footer.html' %}
+        {% block header %}
+            {% include 'includes/header.html' %}
+        {% endblock %}
 
-{% block extra_js %}
-    {# Override this in templates to add extra javascript #}
-{% endblock %}
-</body>
+        {% block main %}
+            <main id="maincontent">
+                {% block content %}{% endblock %}
+            </main>
+        {% endblock %}
+
+        {% block footer %}
+            {% include 'includes/footer.html' %}
+        {% endblock %}
+
+        {% block extra_js %}
+            {# Override this in templates to add extra javascript #}
+        {% endblock %}
+    </body>
 </html>

--- a/templates/base_page.html
+++ b/templates/base_page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load alert_tags datalayer_tags %}
+
+{% comment %}
+    Base template for rendering Wagtail page instances
+{% endcomment %}
+
+{% block extra_gtm_js %}
+    {% render_gtm_datalayer page %}
+{% endblock %}
+
+{% block header %}
+    {% alerts page=page %}
+    {{ block.super }}
+{% endblock %}

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/collections/results_page.html
+++ b/templates/collections/results_page.html
@@ -1,15 +1,5 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 {% load static %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
 

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -1,17 +1,7 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -1,17 +1,7 @@
-{% extends "base.html" %}
+{% extends "base_page.html" %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block body_class %}template-homepage{% endblock %}
 

--- a/templates/includes/gtm-datalayer.html
+++ b/templates/includes/gtm-datalayer.html
@@ -1,6 +1,5 @@
+{{ data | json_script:"gtmDatalayer" }}
 <script>
     window.dataLayer = window.dataLayer || [];
-    {% if data_json %}
-    window.dataLayer.push({{ data_json|safe }});
-    {% endif %}
+    window.dataLayer.push(JSON.parse(document.getElementById('gtmDatalayer').textContent));
 </script>

--- a/templates/includes/gtm-datalayer.html
+++ b/templates/includes/gtm-datalayer.html
@@ -1,0 +1,6 @@
+<script>
+    window.dataLayer = window.dataLayer || [];
+    {% if data_json %}
+    window.dataLayer.push({{ data_json|safe }});
+    {% endif %}
+</script>

--- a/templates/insights/insights_index_page.html
+++ b/templates/insights/insights_index_page.html
@@ -1,18 +1,8 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load i18n %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags %}
-
-{% block extra_gtm_js %}
-{{ page | datalayer:request | json_script:"datalayer" }}
-
-<script>
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-</script>
-{% endblock extra_gtm_js %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/insights/insights_page.html
+++ b/templates/insights/insights_page.html
@@ -1,17 +1,8 @@
-{% extends 'base.html' %}
+{% extends 'base_page.html' %}
 
 {% load static %}
 {% load wagtailcore_tags %}
-{% load datalayer_tags sections_tags %}
-
-{% block extra_gtm_js %}
-    {{ page | datalayer:request | json_script:"datalayer" }}
-
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-    </script>
-{% endblock extra_gtm_js %}
+{% load sections_tags %}
 
 {% block content %}
     {% include 'includes/generic-intro.html' %}

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -4,15 +4,8 @@
 {% load datalayer_tags %}
 
 {% block extra_gtm_js %}
-    {% record_datalayer as datalayer %}
-    {{ datalayer | json_script:"datalayer" }}
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        window.dataLayer.push(JSON.parse(document.getElementById('datalayer').textContent));
-    </script>
+    {% render_gtm_datalayer page %}
 {% endblock extra_gtm_js %}
-
-{% block alerts %}{# Alerts not currently supported on details page. #}{% endblock alerts %}
 
 {% block content %}
 


### PR DESCRIPTION
The aim of this PR is to lay the groundwork for individual datalayer enhancement tickets by providing a more convenient way for page classes (and record/result classes) to make type-specific additions/changes.

In the process, I also:
- Simplified the way datalayer code is rendered (a simple tag that renders to a template)
- Introduced a `base_page.html` template where page-specific template code can live - Allowing us to remove a large amount of repeating code from individual page templates
- Used the `{% wagtail_site %}` tag in `base.html` to derive the 'current site' from the request (which is then cached and used for other things)