### PR TITLE
DF-186 Add support for `/searchUnified` to API client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     command: tail -f /dev/null  # do nothing forever. Use fab sh to run the django server
     restart: on-failure
     init: true
+    stdin_open: true
     tty: true
     env_file:
       - .env

--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -284,6 +284,61 @@ class KongClient:
             f"{self.base_url}/data/searchAll", params=params
         ).json()
 
+    def search_unified(
+        self,
+        *,
+        q: Optional[str] = None,
+        web_reference: Optional[str] = None,
+        stream: Optional[Stream] = None,
+        template: Optional[Template] = None,
+        sort_by: Optional[SortBy] = None,
+        sort_order: Optional[SortOrder] = None,
+        offset: Optional[int] = None,
+        size: Optional[int] = None,
+    ) -> dict:
+        """Make request and return response for Kong's /searchUnified endpoint.
+
+        /searchUnified reproduces the private beta’s /search endpoint, turning
+        a single response for a q, webReference-based query.
+
+        Search all metadata by title, identifier or web reference. Unlike the
+        main search endpoint, boolean operators, aggregations and filtering are
+        NOT supported.
+
+        Keyword arguments:
+
+        q:
+            String to query all indexed fields
+        web_reference:
+            Return matches on references_number
+        stream:
+            Restrict results to given stream
+        template:
+            @template data to include with response
+        sort_by:
+            Field to sort results.
+        sort_order:
+            Order of sorted results
+        offset:
+            Offset for results. Mapped to 'from' before making request
+        size:
+            Number of results to return
+        """
+        params = {
+            "q": q,
+            "webReference": web_reference,
+            "stream": stream,
+            "template": template,
+            "sort": sort_by,
+            "sortOrder": sort_order,
+            "from": offset,
+            "size": size,
+        }
+
+        return self.make_request(
+            f"{self.base_url}/data/searchUnified", params=params
+        ).json()
+
     def fetch_all(
         self,
         *,

--- a/etna/ciim/models.py
+++ b/etna/ciim/models.py
@@ -53,6 +53,12 @@ class APIManager:
         count, hits = self._extract_hits_and_count(response)
         return count, [self.model.from_api_response(h) for h in hits]
 
+    def search_unified(self, **kwargs) -> tuple[int, list[APIModel]]:
+        """Make request to /searchUnified and transform the response."""
+        response = self.client.search_unified(**kwargs)
+        count, hits = self._extract_hits_and_count(response)
+        return count, [self.model.from_api_response(h) for h in hits]
+
     def fetch(self, **kwargs) -> APIModel:
         """Make request to /fetch and transform the response."""
         response = self.client.fetch(**kwargs)

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -367,6 +367,162 @@ class ClientSearchTest(SimpleTestCase):
         )
 
 
+class ClientSearchUnifiedTest(SimpleTestCase):
+    def setUp(self):
+        self.client = KongClient("https://kong.test", api_key="")
+
+        responses.add(responses.GET, "https://kong.test/data/searchUnified", json={})
+
+    @responses.activate
+    def test_no_arguments_makes_request_with_no_parameters(self):
+        self.client.search_unified()
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url, "https://kong.test/data/searchUnified"
+        )
+
+    @responses.activate
+    def test_with_q(self):
+        self.client.search_unified(q="Egypt")
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?q=Egypt",
+        )
+
+    @responses.activate
+    def test_with_web_reference(self):
+        self.client.search_unified(web_reference="ADM/223/3")
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?webReference=ADM%2F223%2F3",
+        )
+
+    @responses.activate
+    def test_with_evidential_stream(self):
+        self.client.search_unified(stream=Stream.EVIDENTIAL)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?stream=evidential",
+        )
+
+    @responses.activate
+    def test_with_interpretive_stream(self):
+        self.client.search_unified(stream=Stream.INTERPRETIVE)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?stream=interpretive",
+        )
+
+    @responses.activate
+    def test_with_template_details(self):
+        self.client.search_unified(template=Template.DETAILS)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?template=details",
+        )
+
+    @responses.activate
+    def test_with_template_results(self):
+        self.client.search_unified(template=Template.RESULTS)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?template=results",
+        )
+
+    @responses.activate
+    def test_with_sort_title(self):
+        self.client.search_unified(sort_by=SortBy.TITLE)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?sort=title",
+        )
+
+    @responses.activate
+    def test_with_sort_date_created(self):
+        self.client.search_unified(sort_by=SortBy.DATE_CREATED)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?sort=dateCreated",
+        )
+
+    @responses.activate
+    def test_with_sort_date_opening(self):
+        self.client.search_unified(sort_by=SortBy.DATE_OPENING)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?sort=dateOpening",
+        )
+
+    @responses.activate
+    def test_with_sort_relevance(self):
+        self.client.search_unified(sort_by=SortBy.RELEVANCE)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?sort=",
+        )
+
+    @responses.activate
+    def test_with_sort_order_asc(self):
+        self.client.search_unified(sort_order=SortOrder.ASC)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?sortOrder=asc",
+        )
+
+    @responses.activate
+    def test_with_sort_order_desc(self):
+        self.client.search_unified(sort_order=SortOrder.DESC)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?sortOrder=desc",
+        )
+
+    @responses.activate
+    def test_with_offset(self):
+        self.client.search_unified(offset=20)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?from=20",
+        )
+
+    @responses.activate
+    def test_with_size(self):
+        self.client.search_unified(size=20)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/searchUnified?size=20",
+        )
+
+
 class ClientFetchTest(SimpleTestCase):
     def setUp(self):
         self.client = KongClient("https://kong.test", api_key="")

--- a/etna/collections/tests/test_views.py
+++ b/etna/collections/tests/test_views.py
@@ -24,7 +24,7 @@ class TestRecordChooseView(WagtailPageTests):
 
         responses.add(
             responses.GET,
-            "https://kong.test/data/search",
+            "https://kong.test/data/searchUnified",
             json=create_response(
                 records=[
                     create_record(
@@ -78,7 +78,7 @@ class TestRecordChooseView(WagtailPageTests):
         self.assertEqual(len(responses.calls), 1)
         self.assertURLEqual(
             responses.calls[0].request.url,
-            "https://kong.test/data/search?stream=evidential&q=law&from=0&size=10",
+            "https://kong.test/data/searchUnified?stream=evidential&q=law&from=0&size=10",
         )
 
     @responses.activate

--- a/etna/records/tests/test_views.py
+++ b/etna/records/tests/test_views.py
@@ -32,7 +32,7 @@ class TestRecordDisambiguationView(TestCase):
     def test_no_matches_respond_with_404(self):
         responses.add(
             responses.GET,
-            "https://kong.test/data/search",
+            "https://kong.test/data/searchUnified",
             json=create_response(records=[]),
         )
 
@@ -47,7 +47,7 @@ class TestRecordDisambiguationView(TestCase):
     def test_disambiguation_page_rendered_for_multiple_results(self):
         responses.add(
             responses.GET,
-            "https://kong.test/data/search",
+            "https://kong.test/data/searchUnified",
             json=create_response(
                 records=[
                     create_record(reference_number="ADM 223/3"),
@@ -67,7 +67,7 @@ class TestRecordDisambiguationView(TestCase):
     def test_rendering_deferred_to_details_page_view(self):
         responses.add(
             responses.GET,
-            "https://kong.test/data/search",
+            "https://kong.test/data/searchUnified",
             json=create_response(
                 records=[
                     create_record(iaid="C123456", reference_number="ADM 223/3"),

--- a/etna/records/views/choosers.py
+++ b/etna/records/views/choosers.py
@@ -26,13 +26,16 @@ class KongModelChooserMixinIn(ChooserMixin):
 
     def get_paginated_object_list(self, page_number, search_term="", **kwargs):
         offset = ((page_number - 1) * self.per_page,)
+        count = 0
+        results = []
 
-        count, results = self.model.api.search(
-            q=search_term,
-            stream=Stream.EVIDENTIAL,
-            size=self.per_page,
-            offset=offset,
-        )
+        if search_term:
+            count, results = self.model.api.search_unified(
+                q=search_term,
+                stream=Stream.EVIDENTIAL,
+                size=self.per_page,
+                offset=offset,
+            )
 
         paginator = APIPaginator(count, self.per_page)
         page = Page(results, page_number, paginator)

--- a/etna/records/views/records.py
+++ b/etna/records/views/records.py
@@ -24,7 +24,7 @@ def record_disambiguation_view(request, reference_number):
     page_number = int(request.GET.get("page", 1))
     offset = (page_number - 1) * per_page
 
-    count, records = Record.api.search(
+    count, records = Record.api.search_unified(
         web_reference=reference_number, offset=offset, size=per_page
     )
 

--- a/etna/users/tests/test_access.py
+++ b/etna/users/tests/test_access.py
@@ -254,7 +254,7 @@ class TestRecordRoutes(UserAccessTestCase, TestCase):
     def test_human_readable_route(self, email, expected_status_code):
         responses.add(
             responses.GET,
-            "https://kong.test/data/search",
+            "https://kong.test/data/searchUnified",
             json=create_response(
                 records=[
                     # Return multiple records to prevent an additional


### PR DESCRIPTION
Fixes disambiguation page and record chooser.

Let me know if you have any questions