### PR TITLE
Add logic to highlight selected bucket

### DIFF
--- a/templates/search/blocks/search_buckets.html
+++ b/templates/search/blocks/search_buckets.html
@@ -3,35 +3,34 @@
 
 <nav class="search-buckets" aria-label="Result categories">
     <ul class="search-buckets__list" data-id="search-buckets-list">
-        {% comment %} TODO make attributes change based on page {% endcomment %}
-        <li class="search-buckets__list-item" data-current="true">
+        <li class="search-buckets__list-item" data-current="{% if form.group.value == 'group:tna' %}true{% else %}false{% endif %}">
             {% bucket_count bucket_count_response 'tna' as tna_bucket_count %}
-            <span class="search-buckets__link" aria-current="true">
+            <span class="search-buckets__link" aria-current="{% if form.group.value == 'group:tna' %}true{% else %}false{% endif %}">
                 Records from The National Archives ({{ tna_bucket_count|intcomma }})
             </span>
         </li>
 
-        <li class="search-buckets__list-item" data-current="false">
+        <li class="search-buckets__list-item" data-current="{% if form.group.value == 'group:tna' %}true{% else %}false{% endif %}">
             {% bucket_count bucket_count_response 'tna' as tna_bucket_count %}
-            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:tna" class="search-buckets__link" aria-current="false">
+            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:tna" class="search-buckets__link" aria-current="{% if form.group.value == 'group:tna' %}true{% else %}false{% endif %}">
                 Online records from The National Archives ({{ tna_bucket_count|intcomma }})
             </a>
         </li>
-        <li class="search-buckets__list-item" data-current="false">
+        <li class="search-buckets__list-item" data-current="{% if form.group.value == 'group:nonTna' %}true{% else %}false{% endif %}">
             {% bucket_count bucket_count_response 'nonTna' as non_tna_bucket_count %}
-            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:nonTna" class="search-buckets__link" aria-current="false">
+            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:nonTna" class="search-buckets__link" aria-current="{% if form.group.value == 'group:nonTna' %}true{% else %}false{% endif %}">
                 Records from other UK archives ({{ non_tna_bucket_count|intcomma }})
             </a>
         </li>
-        <li class="search-buckets__list-item" data-current="false">
+        <li class="search-buckets__list-item" data-current="{% if form.group.value == 'group:creator' %}true{% else %}false{% endif %}">
             {% bucket_count bucket_count_response 'creator' as creator_bucket_count %}
-            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:creator" class="search-buckets__link" aria-current="false">
+            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:creator" class="search-buckets__link" aria-current="{% if form.group.value == 'group:creator' %}true{% else %}false{% endif %}">
                 Record creators ({{ creator_bucket_count|intcomma }})
             </a>
         </li>
-        <li class="search-buckets__list-item" data-current="false">
+        <li class="search-buckets__list-item" data-current="{% if form.group.value == 'group:archive' %}true{% else %}false{% endif %}">
             {% bucket_count bucket_count_response 'archive' as archive_bucket_count %}
-            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:archive" class="search-buckets__link" aria-current="false">
+            <a href="{% url 'search-catalogue' %}?{% if form.q.value %}q={{ form.q.value }}&{% endif %}group=group:archive" class="search-buckets__link" aria-current="{% if form.group.value == 'group:archive' %}true{% else %}false{% endif %}">
                 Find an archive ({{ archive_bucket_count|intcomma }})
             </a>
         </li>


### PR DESCRIPTION
From DF-158:

> The bucket links will also need an `aria-current=true` if it is the selected one. The bucket `<li>` elements will need a  `data-current=true` or `data-current=false` depending on if it is selected, for a JavaScript enhancement on mobile.