### PR TITLE
Fix/global search

### DIFF
--- a/scripts/src/modules/search/global-search.js
+++ b/scripts/src/modules/search/global-search.js
@@ -23,7 +23,7 @@ export default function () {
             <label for="search_term" class="global-search__label">
                 <span class="sr-only">Enter search term.</span> For example, naturalisation or medal cards
             </label>
-            <input type='search' class='global-search__form-search-box' id='search_term' >
+            <input type='search' name='q' class='global-search__form-search-box' id='search_term' >
             <input type="submit" value="Search" class="global-search__form-submit">
         </form>
         <p class='global-search__paragraph'>Other ways to find things:</p>

--- a/scripts/src/modules/search/global-search.js
+++ b/scripts/src/modules/search/global-search.js
@@ -19,7 +19,7 @@ export default function () {
     $globalSearchComponent.innerHTML = 
     `<div class="global-search__container">
         <h1 class="global-search__heading">Search</h1>
-        <form class="global-search__form" action='/search/featured/' method='GET' id='global-search-form' role='search'>
+        <form class="global-search__form" action='/search/featured/' method='GET' id='global-search-form' role='search' aria-label="Search our website">
             <label for="search_term" class="global-search__label">
                 <span class="sr-only">Enter search term.</span> For example, naturalisation or medal cards
             </label>


### PR DESCRIPTION
Global search was missing the `name=q` attribute, as it was unknown what the search url parameter would be during initial development.