### PR TITLE
DF-229: Disable validation for 'collection' field in search

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -19,6 +19,9 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
     """MultipleChoiceField whose choices can be updated to reflect API response data."""
 
     def __init__(self, *args, **kwargs):
+        self.validate_input = bool(kwargs.get("choices")) and kwargs.pop(
+            "validate_input", True
+        )
         super().__init__(*args, **kwargs)
         # The following attribue is used in templates to prevent rendering
         # unless choices have been updated to reflect options from the API
@@ -27,7 +30,7 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
 
     def valid_value(self, value):
         """Disable validation if the field choices are not yet set."""
-        if not self.choices:
+        if not self.validate_input:
             return True
         return super().valid_value(value)
 
@@ -112,6 +115,8 @@ class BaseCollectionSearchForm(forms.Form):
         required=False,
         widget=forms.TextInput(attrs={"class": "search-filters__search"}),
     )
+    # Choices are supplied to this field to benefit validation. The labels
+    # are the same as the API supplied values, so aren't of much benefit
     level = DynamicMultipleChoiceField(
         label="Level",
         choices=LEVEL_CHOICES,
@@ -127,6 +132,8 @@ class BaseCollectionSearchForm(forms.Form):
         ),
         required=False,
     )
+    # Choices are supplied to this field to influence labels only. The options
+    # are not complete enough to be used for validation
     collection = DynamicMultipleChoiceField(
         label="Collection",
         choices=COLLECTION_CHOICES,
@@ -134,6 +141,7 @@ class BaseCollectionSearchForm(forms.Form):
             attrs={"class": "search-filters__list"}
         ),
         required=False,
+        validate_input=False,
     )
     closure = DynamicMultipleChoiceField(
         label="Closure Status",

--- a/etna/search/tests/test_forms.py
+++ b/etna/search/tests/test_forms.py
@@ -106,8 +106,8 @@ class CataglogueSearchFormSelectedFiltersTest(SimpleTestCase):
         form = CatalogueSearchForm(
             {
                 "group": "tna",
+                # only the 'level' field validates values against the choices
                 "level": ["foo"],
-                "collection": ["bar"],
             }
         )
         self.assertFalse(form.is_valid())
@@ -119,8 +119,8 @@ class CataglogueSearchFormSelectedFiltersTest(SimpleTestCase):
                 "group": "tna",
                 "topic": ["topic-one", "topic-two"],  # valid
                 "catalogue_source": ["catalogue-source-one"],  # valid
+                "collection": ["bar"],
                 "level": ["foo"],  # invalid
-                "collection": ["bar"],  # invalid
             }
         )
 
@@ -129,6 +129,9 @@ class CataglogueSearchFormSelectedFiltersTest(SimpleTestCase):
         self.assertEqual(
             form.selected_filters,
             {
+                "collection": [
+                    ("bar", "bar"),
+                ],
                 "topic": [
                     ("topic-one", "topic-one"),
                     ("topic-two", "topic-two"),


### PR DESCRIPTION
Even though they are useful as a label source, the choice values we have for the `collection` field are not complete enough to be used for validation... a selected collection shouldn't be considered invalid just because it isn't in the hardcoded choice list.