### PR TITLE
DF-253: Website results -  add correct URLS to links | DF-255: Add zero results message for all tabs and buckets

### DIFF
--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -87,9 +87,12 @@ def featured_search(request):
         responses = response.get("responses", [])
 
     result_groups = {}
+    no_results = True
     for i, bucket in enumerate(FEATURED_BUCKETS):
         result_groups[bucket.key] = responses[i]
         result_groups[bucket.key]["bucket"] = bucket
+        if result_groups[bucket.key]["hits"]["hits"]:
+            no_results = False
 
     meta_title = "Search results"
     query = form.cleaned_data.get("q")
@@ -104,6 +107,7 @@ def featured_search(request):
             "query": query,
             "form": form,
             "result_groups": result_groups,
+            "no_results": no_results,
         },
     )
 

--- a/sass/includes/search/_featured-search.scss
+++ b/sass/includes/search/_featured-search.scss
@@ -1,5 +1,10 @@
 .featured-search {
 
+    &__no-results {
+        margin-left: 2rem;
+        margin-right: 2rem;
+    }
+
     &__results {
         margin-left: 1rem;
         margin-right: 1rem;

--- a/templates/search/blocks/featured-search__no-results.html
+++ b/templates/search/blocks/featured-search__no-results.html
@@ -1,0 +1,11 @@
+<div class="featured-search__no-results">
+    <h3>We did not find any results for your search</h3>
+
+    <p>Some record descriptions are much less detailed than others and you may not find what you are looking for using a simple keyword search.</p>
+
+    <ul>
+        <li>Try different spellings or search terms</li>
+        <li>Use the advanced search options such as the "AND", "OR", and "NOT" operators</li>
+        <li>Look at our research guides</li>
+    </ul>
+</div>

--- a/templates/search/blocks/featured-search__record-creator.html
+++ b/templates/search/blocks/featured-search__record-creator.html
@@ -1,9 +1,9 @@
 {% load search_tags %}
 {% load humanize %}
+{% if results.hits.hits %}
 <div class="featured-search__results-block">
     <h2 class="featured-search__heading">{{ results.bucket.label }}</h2>
-    
-    {% if results.hits.hits %}
+
 
         {% with record=results.hits.hits.0 %}
         <div class="featured-search__record-creator">
@@ -17,7 +17,6 @@
             <h3 class="featured-search__results-heading"><a href="#" class="featured-search__results-link">{{record|record_detail:"summaryTitle"|striptags }}</a></h3>
         </div>
         {% endwith %}
-    {% endif %}
 
     <div class="featured-search__see-all-link">
         <a class="featured-search__results-link" href="{% url 'search-catalogue' %}?q={{ form.q.value }}&group={{ results.aggregation }}">
@@ -26,3 +25,4 @@
     </div>
 
 </div>
+{% endif %}

--- a/templates/search/blocks/featured-search__results-block.html
+++ b/templates/search/blocks/featured-search__results-block.html
@@ -1,5 +1,6 @@
 {% load search_tags %}
 {% load humanize %}
+{% if results.hits.hits %}
 <div class="featured-search__results-block">
     <h2 class="featured-search__heading">{{results.bucket.label}}</h2>
     <ul class="featured-search__results-list">
@@ -20,3 +21,4 @@
         </a>
     </div>
 </div>
+{% endif %}

--- a/templates/search/blocks/search-results__no-results.html
+++ b/templates/search/blocks/search-results__no-results.html
@@ -1,0 +1,13 @@
+<li>
+    <h3>We did not find any results for your search</h3>
+
+    <p>Some record descriptions are much less detailed than others and you may not find what you are looking for using a simple keyword search.</p>
+
+    <ul>
+        <li>Try different spellings or search terms</li>
+        <li>Try a different search bucket</li>
+        <li>Try removing any filters that you may have applied</li>
+        <li>Use the advanced search options such as the "AND", "OR", and "NOT" operators</li>
+        <li>Look at our research guides</li>
+    </ul>
+</li>

--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -17,12 +17,16 @@
             <ul class="search-results__list--grid">
                 {% for record in page %}
                     {% include './search_results__list-card--grid.html' %}
+                {% empty %}
+                    {% include './search-results__no-results.html' %}
                 {% endfor %}
             </ul>
         {% else %}
             <ul class="search-results__list">
                 {% for record in page %}
                     {% include './search_results__list-card.html' %}
+                {% empty %}
+                    {% include './search-results__no-results.html' %}
                 {% endfor %}
             </ul>
         {% endif %}

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -4,14 +4,22 @@
 <li class="search-results__list-card--grid">
     {% if record|record_detail:"digitised" %}
     <div class="search-results__list-card-delivery-options--grid">
-        <a href="#" aria-hidden="true" tabindex="-1">
+        <a href="/details" 
+            aria-hidden="true" 
+            tabindex="-1">
             <img src="{% static 'images/etna-search-view-download-icon.png' %}" class="search-results__list-card-delivery-options-img" alt="" />
         </a>
     </div>
     {% endif %}
     <div class="search-results__list-card-content">
         <h4 class="search-results__list-card-heading">
-            <a href="#" class="search-results__list-card-link"><span class="sr-only">{{ record|record_detail:"referenceNumber"|default:"N/A" }}</span>
+            <a href="{% if record|record_detail:"sourceUrl" %}
+                        {{ record|record_detail:"sourceUrl" }}
+                    {% else %}
+                        /details/
+                    {% endif %}
+                    " 
+        class="search-results__list-card-link"><span class="sr-only">{{ record|record_detail:"referenceNumber"|default:"N/A" }}</span>
             {{ record|record_title}}
             </a>
         </h4>

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -1,9 +1,15 @@
 {% comment %} TODO downloadable, and record variables {% endcomment %}
 {% load search_tags static %}
+{{record}}
 <li class="search-results__list-card">
     <div class="search-results__list-card-content">
         <h3 class="search-results__list-card-heading">
-            <a href="/details/" class="search-results__list-card-link">
+            <a href="{% if record|record_detail:"sourceUrl" %}
+                        {{ record|record_detail:"sourceUrl" }}
+                    {% else %}
+                        /details/
+                    {% endif %}
+                    " class="search-results__list-card-link">
                 <span class="sr-only">{{ record|record_detail:"referenceNumber"}} </span>
                 {{ record|record_title}}
             </a>

--- a/templates/search/featured_search.html
+++ b/templates/search/featured_search.html
@@ -10,6 +10,9 @@
     {% endwith  %}
     <p class="search-results__explainer--desktop">This page displays a summary of catalogue and non-catalogue content that matches your search.</p>
     <p class="search-results__explainer--mobile">Catalogue and non-catalogue content that matches your search.</p>
+    {% if no_results %}
+        {% include './blocks/featured-search__no-results.html' %}
+    {% endif %}
     <div class="featured-search__results">
 
         {% include './blocks/featured-search__results-block.html' with results=result_groups.tna %}

--- a/templates/search/website_search.html
+++ b/templates/search/website_search.html
@@ -25,6 +25,10 @@
             <div class="catalogue-search-grid__results">
                 {% if page.paginator.count %}
                     {% include './blocks/search_results.html' %}
+                {% else %}
+                    <ul class="search-results__list">
+                        {% include './blocks/search-results__no-results.html' %}
+                    </ul>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Draft PR as the editorial needs to be checked.

This adds zero results messages to the pages (I had to use a Python variable for the featured search page, as there's 6 different results to check)

This also adds the correct URL for website search results (I used an if statement in the template if that's OK)

This relates to https://national-archives.atlassian.net/browse/DF-253 and https://national-archives.atlassian.net/browse/DF-255