### PR TITLE
CHORE: Update {% record_url %} tag to better account for edge cases

### DIFF
--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Union
 
 from django import template
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 from ..field_labels import FIELD_LABELS
 from ..models import Record
@@ -17,9 +17,17 @@ def record_url(record: Union[Record, Dict[str, Any]]) -> str:
     the search() endpoint.
     """
     if ref := record.get("reference_number", record.get("referenceNumber")):
-        return reverse("details-page-human-readable", kwargs={"reference_number": ref})
+        try:
+            return reverse(
+                "details-page-human-readable", kwargs={"reference_number": ref}
+            )
+        except NoReverseMatch:
+            pass
     if iaid := record.get("iaid"):
-        return reverse("details-page-machine-readable", kwargs={"iaid": iaid})
+        try:
+            return reverse("details-page-machine-readable", kwargs={"iaid": iaid})
+        except NoReverseMatch:
+            pass
     if url := record.get("sourceUrl"):
         return url
     try:

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -17,9 +17,9 @@ def record_url(record: Union[Record, Dict[str, Any]]) -> str:
     the search() endpoint.
     """
     if ref := record.get("reference_number", record.get("referenceNumber")):
-        return reverse("details-page-human-readable", kwargs={"record_id": ref})
+        return reverse("details-page-human-readable", kwargs={"reference_number": ref})
     if iaid := record.get("iaid"):
-        return reverse("details-page-machine-readable", kwargs={"record_id": iaid})
+        return reverse("details-page-machine-readable", kwargs={"iaid": iaid})
     if url := record.get("sourceUrl"):
         return url
     try:


### PR DESCRIPTION
The tag is currently using the wrong URL parameter names, so this PR fixes that first of all. However, even when that problem is resolved, some record values simply don't match up to the format we're expecting, so this also updates the tag to handle those situations better.

We need to look much more in-depth at the URLs and accepted patterns in Etna and the API anyway, but that will happen separately.