### PR TITLE
UN-180: Add category choice field to PromotedItemBlock

### DIFF
--- a/etna/insights/blocks.py
+++ b/etna/insights/blocks.py
@@ -65,6 +65,16 @@ class PromotedItemBlock(SectionDepthAwareStructBlock):
         help_text="Title of the promoted page",
         label="Title",
     )
+    category = blocks.ChoiceBlock(
+        label="Category",
+        choices=[
+            ("blog", "Blog post"),
+            ("podcast", "Podcast"),
+            ("video", "Video"),
+            ("video-external", "External video"),
+            ("external-link", "External link"),
+        ],
+    )
     publication_date = blocks.DateBlock(required=False)
     author = blocks.CharBlock(required=False)
     duration = blocks.CharBlock(

--- a/etna/insights/migrations/0039_alter_insightspage_body.py
+++ b/etna/insights/migrations/0039_alter_insightspage_body.py
@@ -253,6 +253,31 @@ class Migration(migrations.Migration):
                                                             ),
                                                         ),
                                                         (
+                                                            "category",
+                                                            wagtail.core.blocks.ChoiceBlock(
+                                                                label="Category",
+                                                                choices=[
+                                                                    (
+                                                                        "blog",
+                                                                        "Blog post",
+                                                                    ),
+                                                                    (
+                                                                        "podcast",
+                                                                        "Podcast",
+                                                                    ),
+                                                                    ("video", "Video"),
+                                                                    (
+                                                                        "video-external",
+                                                                        "External video",
+                                                                    ),
+                                                                    (
+                                                                        "external-link",
+                                                                        "External link",
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                        ),
+                                                        (
                                                             "publication_date",
                                                             wagtail.core.blocks.DateBlock(
                                                                 required=False

--- a/templates/insights/blocks/promoted_item.html
+++ b/templates/insights/blocks/promoted_item.html
@@ -48,9 +48,9 @@
             </div>
 
             {% if value.target_blank %}
-                <a class="promoted-item__link tna-button--yellow" href="{{ value.url }}" data-link="{{ value.cta_label }}" target="_blank">{{ value.cta_label }} <span class="tna-button__target-blank-label">(Opens in a new tab)</span></a>
+                <a class="promoted-item__link tna-button--yellow" href="{{ value.url }}" data-link="{{ value.cta_label }}" data-category="{{ value.category }}" target="_blank">{{ value.cta_label }} <span class="tna-button__target-blank-label">(Opens in a new tab)</span></a>
             {% else %}
-                <a class="promoted-item__link tna-button--yellow" href="{{ value.url }}" data-link="{{ value.cta_label }}">{{ value.cta_label }}</a>
+                <a class="promoted-item__link tna-button--yellow" href="{{ value.url }}" data-link="{{ value.cta_label }}" data-category="{{ value.category }}">{{ value.cta_label }}</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Resolves ticket: https://national-archives.atlassian.net/browse/UN-183

As per discussion from [this comment](https://national-archives.atlassian.net/browse/UN-183?focusedCommentId=20523) and upwards, adding a simple category select back in, which can be picked up by Google Tag Manager.