### PR TITLE
DF-123: Sentry Integration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -165,7 +165,7 @@ if SENTRY_DSN := os.getenv("SENTRY_DSN", ""):
         traces_sample_rate=float(os.getenv("SENTRY_SAMPLE_RATE", "0.5")),
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
-        send_default_pii=False,
+        send_default_pii=strtobool(os.getenv("SENTY_SEND_USER_DATA", "False")),
     )
 
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -153,6 +153,7 @@ LOGGING = {
     },
 }
 
+SENTRY_DEBUG_URL_ENABLED = False
 if SENTRY_DSN := os.getenv("SENTRY_DSN", ""):
     sentry_sdk.init(
         dsn=SENTRY_DSN,
@@ -167,6 +168,8 @@ if SENTRY_DSN := os.getenv("SENTRY_DSN", ""):
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=strtobool(os.getenv("SENTY_SEND_USER_DATA", "False")),
     )
+
+    SENTRY_DEBUG_URL_ENABLED = strtobool(os.getenv("SENTRY_DEBUG_URL_ENABLED", "False"))
 
 
 # Database

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,6 +17,8 @@ import sentry_sdk
 
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from ..versioning import get_git_sha
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -155,6 +157,7 @@ if SENTRY_DSN := os.getenv("SENTRY_DSN", ""):
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         environment=os.getenv("SENTRY_ENVIRONMENT", ""),
+        release=get_git_sha(),
         integrations=[DjangoIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -9,12 +9,15 @@ https://docs.djangoproject.com/en/3.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
-
 import os
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 from distutils.util import strtobool
 
+import sentry_sdk
+
+from sentry_sdk.integrations.django import DjangoIntegration
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
@@ -147,6 +150,21 @@ LOGGING = {
         "level": "WARNING",
     },
 }
+
+if SENTRY_DSN := os.getenv("SENTRY_DSN", ""):
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        environment=os.getenv("SENTRY_ENVIRONMENT", ""),
+        integrations=[DjangoIntegration()],
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        # We recommend adjusting this value in production.
+        traces_sample_rate=float(os.getenv("SENTRY_SAMPLE_RATE", "0.5")),
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=False,
+    )
+
 
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,6 +21,9 @@ from etna.search import views as search_views
 register_converter(converters.ReferenceNumberConverter, "reference_number")
 register_converter(converters.IAIDConverter, "iaid")
 
+# Used by /sentry-debug/
+def trigger_error(request):
+    division_by_zero = 1 / 0
 
 # Private URLs that are not meant to be cached.
 private_urls = [
@@ -28,6 +31,7 @@ private_urls = [
     path("admin/", include(wagtailadmin_urls)),
     path("accounts/", include("allauth.urls")),
     path("documents/", include(wagtaildocs_urls)),
+    path("sentry-debug/", trigger_error),
 ]
 
 # Public URLs that are meant to be cached.

--- a/config/urls.py
+++ b/config/urls.py
@@ -21,9 +21,12 @@ from etna.search import views as search_views
 register_converter(converters.ReferenceNumberConverter, "reference_number")
 register_converter(converters.IAIDConverter, "iaid")
 
+
 # Used by /sentry-debug/
 def trigger_error(request):
-    division_by_zero = 1 / 0
+    # Raise a ZeroDivisionError
+    return 1 / 0
+
 
 # Private URLs that are not meant to be cached.
 private_urls = [
@@ -31,8 +34,11 @@ private_urls = [
     path("admin/", include(wagtailadmin_urls)),
     path("accounts/", include("allauth.urls")),
     path("documents/", include(wagtaildocs_urls)),
-    path("sentry-debug/", trigger_error),
 ]
+
+if settings.SENTRY_DEBUG_URL_ENABLED:
+    # url is toggled via the SENTRY_DEBUG_URL_ENABLED .env var
+    private_urls.append(path("sentry-debug/", trigger_error))
 
 # Public URLs that are meant to be cached.
 public_urls = [

--- a/config/versioning.py
+++ b/config/versioning.py
@@ -1,0 +1,35 @@
+import os
+
+
+def get_git_sha():
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    head_path = os.path.join(base_dir, ".git", "HEAD")
+
+    with open(head_path, "r") as fp:
+        head = fp.read().strip()
+
+    if head.startswith("ref: "):
+        head = head[5:]
+        revision_file = os.path.join(base_dir, ".git", *head.split("/"))
+    else:
+        return head
+
+    if not os.path.exists(revision_file):
+        # Check for Raven .git/packed-refs' file since a `git gc` may have run
+        # https://git-scm.com/book/en/v2/Git-Internals-Maintenance-and-Data-Recovery
+        packed_file = os.path.join(base_dir, ".git", "packed-refs")
+        if os.path.exists(packed_file):
+            with open(packed_file) as fh:
+                for line in fh:
+                    line = line.rstrip()
+                    if line and line[:1] not in ("#", "^"):
+                        try:
+                            revision, ref = line.split(" ", 1)
+                        except ValueError:
+                            continue
+                        if ref == head:
+                            return revision
+
+    with open(revision_file) as fh:
+        return fh.read().strip()

--- a/docs/infra/configuring-an-environment.md
+++ b/docs/infra/configuring-an-environment.md
@@ -115,3 +115,33 @@ Default: **False**
 Whether to use an implicit TLS (secure) connection when talking to the SMTP server. In most email documentation this type of TLS connection is referred to as SSL. It is generally used on port 465. If you are experiencing problems, see the explicit TLS setting `EMAIL_USE_TLS`.
 
 NOTE: `EMAIL_USE_TLS` and `EMAIL_USE_SSL` are mutually exclusive, so only set one of those settings to `True`.
+
+## 5. Sentry (Error logging and performance monitoring)
+
+Below are the key env vars used to configure Sentry for each environment. See [Sentry's official guide](https://docs.sentry.io/platforms/python/guides/django/) for further information on configuring Sentry for Django projects.
+
+### `SENTRY_DSN`
+
+Default: `None`
+
+The project-specific identifier provided by Sentry. This value should remain the same accross all environments... the `SENTRY_ENVIRONMENT` env var value is used to differentiate between environments.
+
+### `SENTRY_ENVIRONMENT`
+
+Default: `None`
+
+A string used to populate the `environment` value on issues and other transactions sent to Sentry from this environment. In the Sentry UI, this value can be used as a filter, allowing you to easily see which issues apply to which environment.
+
+### `SENTRY_SAMPLE_RATE`
+
+Default: 0.5
+
+A number between `0.0` and `1.0`, which determines how many processes out of all processes should be tracked/analysed in order to send performance data to Sentry. A value of `0.0` means that no processes should be tracked, and a value of `1.0` mean that ALL should be tracked.
+
+Performance monitoring has a minimal impact on app performance, but even so, Sentry recommend using a value less than `1.0` in production (hence using `0.5` as the default).
+
+### `SENTY_SEND_USER_DATA`
+
+Default: `False`
+
+This value determines whether data about the 'currently-logged in user' is included in the error reports sent to Sentry. This can be useful in 'testing' environments, as it can help developers to see which tester is having the problem. However, in production, we need to be far more careful leaking personal data - therefore, this option should be turned off in that environment (hence setting `False` as the default).

--- a/docs/infra/testing-an-environment.md
+++ b/docs/infra/testing-an-environment.md
@@ -28,3 +28,10 @@ When you see the login form, enter the credentials you set for your superuser an
 2. From the login page, click the **Forgotton it?** link next to the password input.
 3. Enter the email address you set in the `createsuperuser` step above and request a password reset link.
 4. If email is configured correctly, you'll receive the email.
+
+## 4. Trigger an error
+
+1. Update the `SENTRY_DEBUG_URL_ENABLED` env var to `True` for the environment and restart the container.
+2. When the service is available again, visit the `/sentry-debug/` URL in your browser to trigger a `ZeroDivisionError`.
+3. Log into [Sentry](https://sentry.io/organizations/the-national-archives/projects/) and check the relevant project for a new issue event with an `environment` value matching the `SENTRY_ENVIRONMNET` env var value set for the environment.
+4. Once confirmed that Sentry is working, update the `SENTRY_DEBUG_URL_ENABLED` env var to `False` for the environment, and restart the container.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1073,6 +1073,36 @@ urllib3 = ">=1.25.10"
 tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "types-mock", "types-requests", "types-six", "pytest (>=4.6,<5.0)", "pytest (>=4.6)", "mypy"]
 
 [[package]]
+name = "sentry-sdk"
+version = "1.5.11"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+chalice = ["chalice (>=1.16.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+httpx = ["httpx (>=0.16.0)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1356,7 +1386,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6646de92f7d328aa4970d009dfb65d7ed9147d0e8ef06a6f1f58227ae02ceadc"
+content-hash = "b38fd1ad331ab7ea65eb7b01a23b39b83d5826ac4ffc4cc24fa0de94eae61197"
 
 [metadata.files]
 anyascii = [
@@ -2027,6 +2057,10 @@ requests-oauthlib = [
 responses = [
     {file = "responses-0.13.4-py2.py3-none-any.whl", hash = "sha256:d8d0f655710c46fd3513b9202a7f0dcedd02ca0f8cf4976f27fa8ab5b81e656d"},
     {file = "responses-0.13.4.tar.gz", hash = "sha256:9476775d856d3c24ae660bbebe29fb6d789d4ad16acd723efbfb6ee20990b899"},
+]
+sentry-sdk = [
+    {file = "sentry-sdk-1.5.11.tar.gz", hash = "sha256:6c01d9d0b65935fd275adc120194737d1df317dce811e642cbf0394d0d37a007"},
+    {file = "sentry_sdk-1.5.11-py2.py3-none-any.whl", hash = "sha256:c17179183cac614e900cbd048dab03f49a48e2820182ec686c25e7ce46f8548f"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ django-redis = "^5.0.0"
 wagtail-font-awesome-svg = "0.0.2"
 django-birdbath = "^0.0.5"
 bleach = "^5.0.0"
+sentry-sdk = "^1.5.11"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
Resolves ticket: https://national-archives.atlassian.net/browse/DF-123

Can be tested locally by setting the `SENTRY_DSN` env var to the relevant value (see ticket for more details), as well as the following:
- `SENTRY_ENVIRONMENT=local`
- `SENTRY_DEBUG_URL_ENABLED=True`

You should unset these values after testing is complete, as you should be using Django's built-in debugging tools locally, which are free!