### PR TITLE
Fix: Transformation function erroring on multi-faceted record descriptions

### DIFF
--- a/etna/records/transforms.py
+++ b/etna/records/transforms.py
@@ -25,7 +25,9 @@ def transform_record_result(result):
         )
 
     if description := source.get("description"):
-        data["description"] = format_description_markup(description[0]["value"])
+        for item in description:
+            if item.get("type", "") == "description" or len(description) == 1:
+                data["description"] = format_description_markup(item["value"])
 
     if arrangement := source.get("arrangement"):
         data["arrangement"] = format_description_markup(arrangement["value"])


### PR DESCRIPTION
Account for situations where 'description' has multiple entries, and the one we are interested in isn't the first item.

Resolves Sentry issue: https://sentry.io/organizations/the-national-archives/issues/3266139263/

