### PR TITLE
UN 149: Trigger/content warning for specific content

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -55,6 +55,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/record-title';
 @import 'includes/specifics';
 @import 'includes/content-block';
+@import 'includes/content-warning';
 @import 'includes/quote';
 @import 'includes/featured-record';
 @import 'includes/featured-records';

--- a/sass/includes/_content-warning.scss
+++ b/sass/includes/_content-warning.scss
@@ -1,0 +1,11 @@
+.content-warning {
+    background-color: #26262a;
+    padding: 2rem;
+    margin-top: 2rem;
+
+    p {
+        color: #fff;
+        font-size: 1.25rem;
+        margin-bottom: 0;
+    }
+}

--- a/templates/includes/content-warning.html
+++ b/templates/includes/content-warning.html
@@ -1,7 +1,6 @@
 {% load wagtailcore_tags %}
 
-<div class="content-warning">
-    <span class="sr-only">Warning</span>
+<div class="content-warning" aria-label="Content warning">
     {% if page.custom_warning_text %}
         {{ page.custom_warning_text | richtext }}
     {% else %}

--- a/templates/includes/content-warning.html
+++ b/templates/includes/content-warning.html
@@ -1,10 +1,10 @@
 {% load wagtailcore_tags %}
 
-
-<div>
-{% if page.custom_warning_text %}
- {{ page.custom_warning_text | richtext }}
-{% else %}
-    Default content warning
-{% endif %}
+<div class="content-warning">
+    <span class="sr-only">Warning</span>
+    {% if page.custom_warning_text %}
+        {{ page.custom_warning_text | richtext }}
+    {% else %}
+        <p>This article contains content that some people may find offensive.</p>
+    {% endif %}
 </div>


### PR DESCRIPTION
Hi @AshTNA,

Could you have a look at this small PR? It just adds the frontend for the content warning component. I've put an `aria-label` on the element to communicate its purpose to screen readers. I haven't added `role="alert"` to this component because going by MDN's documentation:

"Because of its intrusive nature, the alert role must be used sparingly and only in situations where the user's immediate attention is required."

I don't think this component needs to be highlighted to the user immediately and they will encounter it before they reach the content anyway.