### PR TITLE
DF-210: Make filters list in long filter page searchable

### DIFF
--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -23,72 +23,75 @@
 
     }
 
-    &__form {
-        @media only screen and (min-width: $screen__md) {
-            display: flex;
+
+
+    &__filters {
+        display: flex;
+
+        @media only screen and (max-width: $screen__md) {
+            margin-top: 2rem;
+            margin-left: 2rem;
         }
 
-        &-filters {
-            @media only screen and (max-width: $screen__md) {
-                margin-top: 2rem;
-                margin-left: 2rem;
+        &-list {
+            padding-left: 0;
+            margin-bottom: 0;
+
+            @media only screen and (min-width: $screen__md) {
+                column-count: 3;
+                column-gap: 1rem;
             }
 
-            &-list {
-                padding-left: 0;
-                margin-bottom: 0;
-
-                @media only screen and (min-width: $screen__md) {
-                    column-count: 3;
-                    column-gap: 2rem;
-                }
-
-                &-item {
-                    list-style: none;
-                    margin-right: 4rem;
-                    width: 100%;
-                    max-width: 20rem;
-                    vertical-align: text-top;
-                }
-            }
-
-            &-checkbox {
-                &:focus {
-                    outline: 5px solid $color__focus-blue-outline-light-bg;
-                }
-                margin-right: 0.2rem;
-            }
-
-            &-label {
-                cursor: pointer;
-                max-width: 85%;
-                vertical-align: top;
-            }
-        }
-
-        &-search {
-            background-color: $color__grey-4;
-            border: 1px solid $color__grey-3;
-            padding: 1rem;
-            max-height: 12rem;
-            &-label {
-                display: block;
-            }
-            &-button {
-                @extend .tna-button;
-                display: block;
-                margin-top: 0.25rem;
-                cursor: pointer;
-            }
-            &-box {
+            &-item {
+                list-style: none;
+                margin-right: 4rem;
                 width: 100%;
-                max-width: 15rem;
-                margin-bottom: 0.5rem;
-                border: 1px solid $color__grey-3;
-                border-radius: 0.5rem;
-                height: 2.7rem;
-                padding: 1rem;
+                max-width: 20rem;
+                vertical-align: text-top;
             }
+        }
+
+        &-checkbox {
+            &:focus {
+                outline: 5px solid $color__focus-blue-outline-light-bg;
+            }
+            margin-right: 0.2rem;
+        }
+
+        &-label {
+            cursor: pointer;
+            max-width: 85%;
+            vertical-align: top;
+        }
+    }
+
+
+
+    &__search {
+        background-color: $color__grey-4;
+        border: 1px solid $color__grey-3;
+        padding: 1rem;
+        max-height: 12rem;
+        margin-right: 1rem;
+        &-label {
+            display: block;
+        }
+        &-button {
+            @extend .tna-button--dark;
+            display: block;
+            margin-top: 0.25rem;
+            font-weight: normal;
+            cursor: pointer;
+        }
+        &-box {
+            width: 100%;
+            max-width: 15rem;
+            margin-bottom: 0.5rem;
+            border: 1px solid $color__grey-3;
+            border-radius: 0.5rem;
+            height: 2.7rem;
+            padding: 1rem;
+            margin-left: -0.2rem;
         }
     }
 

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -39,7 +39,7 @@
                 margin-bottom: 0;
 
                 @media only screen and (min-width: $screen__md) {
-                    column-count: 4;
+                    column-count: 3;
                     column-gap: 2rem;
                 }
 

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -73,7 +73,7 @@
         background-color: $color__grey-4;
         border: 1px solid $color__grey-3;
         padding: 1rem;
-        max-height: 12rem;
+        max-height: 8rem;
         margin-right: 1rem;
         margin-bottom: 1rem;
 
@@ -112,5 +112,10 @@
         @extend .tna-button;
         font-size: 1.3rem;
         cursor: pointer;
+    }
+
+    &__count {
+        font-family: $font__open-sans;
+        font-size: 1.5rem;
     }
 }

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -20,6 +20,7 @@
         @media only screen and (min-width: $screen__md) {
             display: flex;
             justify-content: space-between;
+            align-items: baseline;
         }
 
     }
@@ -102,6 +103,10 @@
             height: 2.7rem;
             padding: 1rem;
             margin-left: -0.2rem;
+
+            &:focus {
+                outline: 5px solid $color__focus-blue-outline-light-bg;
+            }
         }
     }
 

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -73,9 +73,13 @@
         background-color: $color__grey-4;
         border: 1px solid $color__grey-3;
         padding: 1rem;
-        max-height: 8rem;
+        max-height: 12rem;
         margin-right: 1rem;
         margin-bottom: 1rem;
+
+        @media only screen and (min-width: 62rem) {
+            max-width: 20rem;
+        }
 
         &-label {
             display: block;
@@ -90,7 +94,7 @@
         &-box {
             width: 100%;
             @media only screen and (min-width: 62rem) {
-                max-width: 15rem;
+                max-width: 17.5rem;
             }
             margin-bottom: 0.5rem;
             border: 1px solid $color__grey-3;

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -11,9 +11,10 @@
     }
 
     &__options {
-        margin-top: 4rem;
         padding-bottom: 2rem;
-        margin-bottom: 2rem;
+        @media only screen and (min-width: $screen__md) {
+            margin-bottom: 2rem;
+        }
         border-bottom: 3px dotted $color__grey-4;
 
         @media only screen and (min-width: $screen__md) {
@@ -26,11 +27,12 @@
 
 
     &__filters {
-        display: flex;
+        @media only screen and (min-width: 60rem) {
+            display: flex;
+        }
 
         @media only screen and (max-width: $screen__md) {
-            margin-top: 2rem;
-            margin-left: 2rem;
+            margin-top: 1rem;
         }
 
         &-list {
@@ -73,6 +75,8 @@
         padding: 1rem;
         max-height: 12rem;
         margin-right: 1rem;
+        margin-bottom: 1rem;
+
         &-label {
             display: block;
         }
@@ -85,7 +89,9 @@
         }
         &-box {
             width: 100%;
-            max-width: 15rem;
+            @media only screen and (min-width: 62rem) {
+                max-width: 15rem;
+            }
             margin-bottom: 0.5rem;
             border: 1px solid $color__grey-3;
             border-radius: 0.5rem;

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -15,7 +15,7 @@
         @media only screen and (min-width: $screen__md) {
             margin-bottom: 2rem;
         }
-        border-bottom: 3px dotted $color__grey-4;
+        border-bottom: 0.1875rem dotted $color__grey-4;
 
         @media only screen and (min-width: $screen__md) {
             display: flex;
@@ -28,7 +28,7 @@
 
 
     &__filters {
-        @media only screen and (min-width: 60rem) {
+        @media only screen and (min-width: $screen__lg) {
             display: flex;
         }
 
@@ -56,7 +56,7 @@
 
         &-checkbox {
             &:focus {
-                outline: 5px solid $color__focus-blue-outline-light-bg;
+                outline: 0.3125rem solid $color__focus-blue-outline-light-bg;
             }
             margin-right: 0.2rem;
         }
@@ -72,13 +72,13 @@
 
     &__search {
         background-color: $color__grey-4;
-        border: 1px solid $color__grey-3;
+        border: 0.0625rem solid $color__grey-3;
         padding: 1rem;
-        max-height: 12rem;
+        max-height: 14rem;
         margin-right: 1rem;
         margin-bottom: 1rem;
 
-        @media only screen and (min-width: 62rem) {
+        @media only screen and (min-width: $screen__lg) {
             max-width: 20rem;
         }
 
@@ -94,18 +94,18 @@
         }
         &-box {
             width: 100%;
-            @media only screen and (min-width: 62rem) {
+            @media only screen and (min-width: $screen__lg) {
                 max-width: 17.5rem;
             }
             margin-bottom: 0.5rem;
-            border: 1px solid $color__grey-3;
+            border: 0.0625rem solid $color__grey-3;
             border-radius: 0.5rem;
             height: 2.7rem;
             padding: 1rem;
             margin-left: -0.2rem;
 
             &:focus {
-                outline: 5px solid $color__focus-blue-outline-light-bg;
+                outline: 0.3125rem solid $color__focus-blue-outline-light-bg;
             }
         }
     }
@@ -113,7 +113,7 @@
     &__submit-section {
         margin-top: 2rem;
         padding-top: 2rem;
-        border-top: 3px dotted $color__grey-4;
+        border-top: 0.1875rem dotted $color__grey-4;
         margin-bottom: 2rem;
     }
 

--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -5,6 +5,9 @@
     &__list {
         list-style: none;
         padding-left: 0.5rem;
+        &:focus {
+            outline: 5px solid $color__focus-blue-outline-light-bg;
+        }
     }
 
     &__form-block {

--- a/scripts/src/catalogue-search.js
+++ b/scripts/src/catalogue-search.js
@@ -1,5 +1,7 @@
 import mobileFilterExpander from './modules/search/mobile-filter-expander.js';
 import searchBucketsExpander from './modules/search/search-buckets-expander.js';
+import searchLongFilters from './modules/search/search-long-filters';
 
 mobileFilterExpander();
 searchBucketsExpander();
+searchLongFilters();

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -50,7 +50,6 @@ export default function () {
     $longFiltersContainer.insertBefore($searchDiv, $longFiltersContainer.childNodes[0]);
 
     const handleSearch = function(e) {
-        e.preventDefault();
         const keyword = $searchBox.value.toLowerCase();
 
         const narrowedDownFilters = longFiltersArray.filter(filter => {
@@ -86,7 +85,7 @@ export default function () {
     // Prevents the whole form from submitting when pressing "Enter" on search filter box
     const disableSearchSubmit = function(e) {
         if(e.key === "Enter" && e.target.id === $searchBox.id) {
-            handleSearch(e);
+            e.preventDefault();
         }
     }
 

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -1,29 +1,29 @@
 export default function () {
-    let $parentForm = document.querySelector('[data-id="long-filter-form"]');
+    const $parentForm = document.querySelector('[data-id="long-filter-form"]');
 
-    let $longFiltersContainer = document.querySelector('[data-id="long-filters-container"]');
+    const $longFiltersContainer = document.querySelector('[data-id="long-filters-container"]');
 
-    let $longFiltersList = document.querySelector('[data-id="long-filters-list"]');
-    let $longFiltersListItems = document.querySelectorAll('[data-class="long-filters-list-item"]');
+    const $longFiltersList = document.querySelector('[data-id="long-filters-list"]');
+    const $longFiltersListItems = document.querySelectorAll('[data-class="long-filters-list-item"]');
 
     if(!$longFiltersContainer || !$longFiltersListItems || !$longFiltersList) {
         return;
     }
 
-    let longFiltersArray = [...$longFiltersListItems];
+    const longFiltersArray = [].slice.call($longFiltersListItems); // IE11 equivalent of doing [...$longFiltersListItems]
 
-    let $searchDiv = document.createElement('div');
+    const $searchDiv = document.createElement('div');
     $searchDiv.setAttribute('class', 'long-filters__search');
-    let $searchBox = document.createElement('input');
+    const $searchBox = document.createElement('input');
     $searchBox.setAttribute('class', 'long-filters__search-box');
-    let searchId = 'long-filters-search-box';
+    const searchId = 'long-filters-search-box';
     $searchBox.id = searchId;
-    let $searchLabel = document.createElement('label');
+    const $searchLabel = document.createElement('label');
     $searchLabel.innerText = "Narrow down filters";
     $searchLabel.setAttribute('for', searchId);
     $searchLabel.setAttribute('class', 'long-filters__search-label');
 
-    let $searchButton = document.createElement('button');
+    const $searchButton = document.createElement('button');
     $searchButton.innerText = 'Search';
     $searchButton.setAttribute('class', 'long-filters__search-button');
 
@@ -35,22 +35,37 @@ export default function () {
     $longFiltersContainer.insertBefore($searchDiv, $longFiltersContainer.childNodes[0]);
 
 
-    let handleSearch = function(e) {
+    const handleSearch = function(e) {
         e.preventDefault();
-        let keyword = $searchBox.value.toLowerCase();
+        const keyword = $searchBox.value.toLowerCase();
 
-        let narrowedDownFilters = longFiltersArray.filter(filter => {
-            let filterLabel = filter.childNodes[0];
-            let filterInput = filterLabel.childNodes[0];
+        const narrowedDownFilters = longFiltersArray.filter(filter => {
+
+            if(filter.childNodes.length === 0) {
+                return false;
+            }
+
+            const filterLabel = filter.childNodes[0];
+            const filterInput = filterLabel.childNodes[0];
 
             // Keep the filter if it matches the users keyword, or if the filter is selected.
-            return filter.innerText.toLowerCase().includes(keyword) || filterInput.checked;
+            return filterLabel.innerText.toLowerCase().indexOf(keyword) != -1 || filterInput.checked;
         });
 
-        $longFiltersList.replaceChildren(...narrowedDownFilters);
+        /* IE11 compatible method to remove children without affecting the JS APIs. 
+           Using $longFiltersList.innerHTML = ''; causes issues on IE11.
+        */
+        while ($longFiltersList.firstChild) {
+            $longFiltersList.removeChild($longFiltersList.firstChild);
+        }
+
+        for(const filter of narrowedDownFilters) {
+            $longFiltersList.appendChild(filter);
+        }
+
     }
 
-    let disableSearchSubmit = function(e) {
+    const disableSearchSubmit = function(e) {
         if(e.key === "Enter") {
             handleSearch(e);
         }

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -85,7 +85,7 @@ export default function () {
 
     // Prevents the whole form from submitting when pressing "Enter" on search filter box
     const disableSearchSubmit = function(e) {
-        if(e.key === "Enter") {
+        if(e.key === "Enter" && e.target.id === $searchBox.id) {
             handleSearch(e);
         }
     }

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -27,8 +27,14 @@ export default function () {
     $searchLabel.setAttribute('for', searchId);
     $searchLabel.setAttribute('class', 'long-filters__search-label');
 
+    let $searchHelperText = document.createElement('p');
+    $searchHelperText.innerText = 'Filters that contain the text you enter will be displayed. Filters you have checked will always be shown.';
+    $searchHelperText.id = 'long-filters-helper-text';
+    $searchBox.setAttribute('aria-describedby', 'long-filters-helper-text');
+
     $searchDiv.appendChild($searchLabel);
     $searchDiv.appendChild($searchBox);
+    $searchDiv.appendChild($searchHelperText);
 
     const $filterCount = document.createElement('p');
     $filterCount.id = 'long-filters-count';

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -9,7 +9,7 @@ export default function () {
     const $longFiltersLegend = document.querySelector('[data-id="long-filters-legend"]');
     const $longFiltersFieldset = document.querySelector('[data-id="long-filters-fieldset"]');
 
-    if(!$longFiltersContainer || !$longFiltersListItems || !$longFiltersList || !$longFiltersLegend || !$longFiltersFieldset) {
+    if(!$parentForm || !$longFiltersContainer || !$longFiltersListItems || !$longFiltersList || !$longFiltersLegend || !$longFiltersFieldset) {
         return;
     }
 

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -78,7 +78,7 @@ export default function () {
         }
 
         let narrowedFiltersLength = narrowedDownFilters.length;
-        let longFiltersCountText = `Showing ${narrowedFiltersLength} out of ${totalFiltersLength} filters`;
+        longFiltersCountText = `Showing ${narrowedFiltersLength} out of ${totalFiltersLength} filters`;
         $filterCount.innerText = longFiltersCountText;
 
     }

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -1,0 +1,53 @@
+export default function () {
+    let $parentForm = document.querySelector('[data-id="long-filter-form"]');
+
+    let $longFiltersContainer = document.querySelector('[data-id="long-filters-container"]');
+
+    let $longFiltersList = document.querySelector('[data-id="long-filters-list"]');
+    let $longFiltersListItems = document.querySelectorAll('[data-class="long-filters-list-item"]');
+
+    if(!$longFiltersContainer || !$longFiltersListItems || !$longFiltersList) {
+        return;
+    }
+
+    let longFiltersArray = [...$longFiltersListItems];
+
+    let $searchDiv = document.createElement('div');
+    let $searchBox = document.createElement('input');
+    let searchId = 'long-filters-search-box';
+    $searchBox.id = searchId;
+    let $searchLabel = document.createElement('label');
+    $searchLabel.innerText = "Find filters by keyword";
+    $searchLabel.setAttribute('for', searchId);
+    let $searchButton = document.createElement('button');
+    $searchButton.innerText = 'Search all filters';
+
+    $searchDiv.appendChild($searchLabel);
+    $searchDiv.appendChild($searchBox);
+    $searchDiv.appendChild($searchButton);
+
+
+    $longFiltersContainer.insertBefore($searchDiv, $longFiltersContainer.childNodes[0]);
+
+
+    let handleSearch = function(e) {
+        e.preventDefault();
+        let keyword = $searchBox.value.toLowerCase();
+
+        let narrowedDownFilters = longFiltersArray.filter(filter => {
+            return filter.innerText.toLowerCase().includes(keyword);
+        });
+
+        $longFiltersList.replaceChildren(...narrowedDownFilters);
+    }
+
+    let disableSearchSubmit = function(e) {
+        if(e.key === "Enter") {
+            handleSearch(e);
+        }
+    }
+
+    $searchButton.addEventListener('click', handleSearch);
+    $parentForm.addEventListener('keypress', disableSearchSubmit)
+
+}

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -83,6 +83,7 @@ export default function () {
 
     }
 
+    // Prevents the whole form from submitting when pressing "Enter" on search filter box
     const disableSearchSubmit = function(e) {
         if(e.key === "Enter") {
             handleSearch(e);

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -13,14 +13,19 @@ export default function () {
     let longFiltersArray = [...$longFiltersListItems];
 
     let $searchDiv = document.createElement('div');
+    $searchDiv.setAttribute('class', 'long-filters__search');
     let $searchBox = document.createElement('input');
+    $searchBox.setAttribute('class', 'long-filters__search-box');
     let searchId = 'long-filters-search-box';
     $searchBox.id = searchId;
     let $searchLabel = document.createElement('label');
-    $searchLabel.innerText = "Find filters by keyword";
+    $searchLabel.innerText = "Narrow down filters";
     $searchLabel.setAttribute('for', searchId);
+    $searchLabel.setAttribute('class', 'long-filters__search-label');
+
     let $searchButton = document.createElement('button');
-    $searchButton.innerText = 'Search all filters';
+    $searchButton.innerText = 'Search';
+    $searchButton.setAttribute('class', 'long-filters__search-button');
 
     $searchDiv.appendChild($searchLabel);
     $searchDiv.appendChild($searchBox);
@@ -35,7 +40,11 @@ export default function () {
         let keyword = $searchBox.value.toLowerCase();
 
         let narrowedDownFilters = longFiltersArray.filter(filter => {
-            return filter.innerText.toLowerCase().includes(keyword);
+            let filterLabel = filter.childNodes[0];
+            let filterInput = filterLabel.childNodes[0];
+
+            // Keep the filter if it matches the users keyword, or if the filter is selected.
+            return filter.innerText.toLowerCase().includes(keyword) || filterInput.checked;
         });
 
         $longFiltersList.replaceChildren(...narrowedDownFilters);
@@ -48,6 +57,7 @@ export default function () {
     }
 
     $searchButton.addEventListener('click', handleSearch);
+    $searchBox.addEventListener('keyup', handleSearch);
     $parentForm.addEventListener('keypress', disableSearchSubmit)
 
 }

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -28,7 +28,7 @@ export default function () {
     $searchLabel.setAttribute('class', 'long-filters__search-label');
 
     let $searchHelperText = document.createElement('p');
-    $searchHelperText.innerText = 'Filters that contain the text you enter will be displayed. Filters you have checked will always be shown.';
+    $searchHelperText.innerText = 'Enter text to refine your filters. Already selected filters will remain active.';
     $searchHelperText.id = 'long-filters-helper-text';
     $searchBox.setAttribute('aria-describedby', 'long-filters-helper-text');
 
@@ -42,7 +42,7 @@ export default function () {
     $longFiltersFieldset.setAttribute('aria-describedby', 'long-filters-count');
 
     const totalFiltersLength = longFiltersArray.length;
-    let longFiltersCountText = `Showing ${totalFiltersLength} out of ${totalFiltersLength} filters`;
+    let longFiltersCountText = `Showing ${totalFiltersLength} of ${totalFiltersLength} filters`;
     $filterCount.innerText = longFiltersCountText;
 
     $longFiltersFieldset.insertBefore($filterCount, $longFiltersFieldset.childNodes[2]);

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -6,7 +6,10 @@ export default function () {
     const $longFiltersList = document.querySelector('[data-id="long-filters-list"]');
     const $longFiltersListItems = document.querySelectorAll('[data-class="long-filters-list-item"]');
 
-    if(!$longFiltersContainer || !$longFiltersListItems || !$longFiltersList) {
+    const $longFiltersLegend = document.querySelector('[data-id="long-filters-legend"]');
+    const $longFiltersFieldset = document.querySelector('[data-id="long-filters-fieldset"]');
+
+    if(!$longFiltersContainer || !$longFiltersListItems || !$longFiltersList || !$longFiltersLegend || !$longFiltersFieldset) {
         return;
     }
 
@@ -16,6 +19,7 @@ export default function () {
     $searchDiv.setAttribute('class', 'long-filters__search');
     const $searchBox = document.createElement('input');
     $searchBox.setAttribute('class', 'long-filters__search-box');
+    $searchBox.setAttribute('type', 'text');
     const searchId = 'long-filters-search-box';
     $searchBox.id = searchId;
     const $searchLabel = document.createElement('label');
@@ -23,17 +27,21 @@ export default function () {
     $searchLabel.setAttribute('for', searchId);
     $searchLabel.setAttribute('class', 'long-filters__search-label');
 
-    const $searchButton = document.createElement('button');
-    $searchButton.innerText = 'Search';
-    $searchButton.setAttribute('class', 'long-filters__search-button');
-
     $searchDiv.appendChild($searchLabel);
     $searchDiv.appendChild($searchBox);
-    $searchDiv.appendChild($searchButton);
 
+    const $filterCount = document.createElement('p');
+    $filterCount.id = 'long-filters-count';
+    $filterCount.setAttribute('class', 'long-filters__count');
+    $longFiltersFieldset.setAttribute('aria-describedby', 'long-filters-count');
+
+    const totalFiltersLength = longFiltersArray.length;
+    let longFiltersCountText = `Showing ${totalFiltersLength} out of ${totalFiltersLength} filters`;
+    $filterCount.innerText = longFiltersCountText;
+
+    $longFiltersFieldset.insertBefore($filterCount, $longFiltersFieldset.childNodes[2]);
 
     $longFiltersContainer.insertBefore($searchDiv, $longFiltersContainer.childNodes[0]);
-
 
     const handleSearch = function(e) {
         e.preventDefault();
@@ -63,6 +71,10 @@ export default function () {
             $longFiltersList.appendChild(filter);
         }
 
+        let narrowedFiltersLength = narrowedDownFilters.length;
+        let longFiltersCountText = `Showing ${narrowedFiltersLength} out of ${totalFiltersLength} filters`;
+        $filterCount.innerText = longFiltersCountText;
+
     }
 
     const disableSearchSubmit = function(e) {
@@ -71,7 +83,6 @@ export default function () {
         }
     }
 
-    $searchButton.addEventListener('click', handleSearch);
     $searchBox.addEventListener('keyup', handleSearch);
     $parentForm.addEventListener('keypress', disableSearchSubmit)
 

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -19,7 +19,7 @@ export default function () {
     $searchDiv.setAttribute('class', 'long-filters__search');
     const $searchBox = document.createElement('input');
     $searchBox.setAttribute('class', 'long-filters__search-box');
-    $searchBox.setAttribute('type', 'text');
+    $searchBox.setAttribute('type', 'search');
     const searchId = 'long-filters-search-box';
     $searchBox.id = searchId;
     const $searchLabel = document.createElement('label');

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -17,8 +17,8 @@
 
 
             <div class="long-filters__filters" data-id="long-filters-container">
-                <fieldset>
-                    <legend class="sr-only">Filters</legend>
+                <fieldset data-id="long-filters-fieldset">
+                    <legend class="sr-only" data-id="long-filters-legend">Filters</legend>
                     <ul class="long-filters__filters-list" data-id="long-filters-list">
                         {% for option in bound_field %}
                             <li class="long-filters__filters-list-item" data-class="long-filters-list-item">{{ option }}</li>

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -15,19 +15,19 @@
                 <a href="{% url 'search-catalogue' %}?{{ request.GET.urlencode }}" >Cancel and return to results</a>
             </div>
 
-            <div class="long-filters__form">
-                <div class="long-filters__form-filters" data-id="long-filters-container">
-                    <ul class="long-filters__form-filters-list" data-id="long-filters-list">
-                        {% for option in bound_field %}
-                            <li class="long-filters__form-filters-list-item" data-class="long-filters-list-item">{{ option }}</li>
-                        {% endfor %}
-                    </ul>
-                </div>
 
-                {% for hidden_field in form.hidden_fields %}
-                    {{ hidden_field }}
-                {% endfor %}
+            <div class="long-filters__filters" data-id="long-filters-container">
+                <ul class="long-filters__filters-list" data-id="long-filters-list">
+                    {% for option in bound_field %}
+                        <li class="long-filters__filters-list-item" data-class="long-filters-list-item">{{ option }}</li>
+                    {% endfor %}
+                </ul>
             </div>
+
+            {% for hidden_field in form.hidden_fields %}
+                {{ hidden_field }}
+            {% endfor %}
+
             <div class="long-filters__submit-section">
                 <input type="submit" value="Apply filters" class="search-filters__submit">
             </div>

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -7,7 +7,7 @@
 {% block content %}
     <div class="long-filters">
         <h1 class="long-filters__heading">Select filters to apply to your results</h1>
-        <form method="get" action="{% url 'search-catalogue' %}" >
+        <form method="get" action="{% url 'search-catalogue' %}" data-id="long-filter-form">
             {% prepare_form_for_partial_render form field_name %}
 
             <div class="long-filters__options">
@@ -16,10 +16,10 @@
             </div>
 
             <div class="long-filters__form">
-                <div class="long-filters__form-filters">
-                    <ul class="long-filters__form-filters-list">
+                <div class="long-filters__form-filters" data-id="long-filters-container">
+                    <ul class="long-filters__form-filters-list" data-id="long-filters-list">
                         {% for option in bound_field %}
-                            <li class="long-filters__form-filters-list-item">{{ option }}</li>
+                            <li class="long-filters__form-filters-list-item" data-class="long-filters-list-item">{{ option }}</li>
                         {% endfor %}
                     </ul>
                 </div>
@@ -33,4 +33,8 @@
             </div>
         </form>
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'scripts/catalogue_search.js' %}"></script>
 {% endblock %}

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -17,11 +17,14 @@
 
 
             <div class="long-filters__filters" data-id="long-filters-container">
-                <ul class="long-filters__filters-list" data-id="long-filters-list">
-                    {% for option in bound_field %}
-                        <li class="long-filters__filters-list-item" data-class="long-filters-list-item">{{ option }}</li>
-                    {% endfor %}
-                </ul>
+                <fieldset>
+                    <legend class="sr-only">Filters</legend>
+                    <ul class="long-filters__filters-list" data-id="long-filters-list">
+                        {% for option in bound_field %}
+                            <li class="long-filters__filters-list-item" data-class="long-filters-list-item">{{ option }}</li>
+                        {% endfor %}
+                    </ul>
+                </fieldset>
             </div>
 
             {% for hidden_field in form.hidden_fields %}


### PR DESCRIPTION
Hi @JamesWChan 

Would you be able to merge this PR?

It relates to https://national-archives.atlassian.net/browse/DF-210

It adds a search component to the 'long filters' page on Search, which allows the list of filters to be narrowed down via a keyword. It works by:

- Grabbing the NodeList of filter`<li>` elements
- Converting the list into an Array
- Running `filter()` on this array to grab the narrowed down filters
- Rendering these narrowed down filters in the DOM

It will also always show any filters that the user has checked, so that they don't have to delete their keyword and then scroll through all the filters to see which ones are checked.

Accessibility wise, initially we were going to use `aria-live='polite'` to always update users on how many filters were being shown. However it was conflicting with the users' keyword being read out. The screen reader would try to read out how many filters were showing, but then it would cut out and read out the keyword the user had typed instead. Therefore, we are using `ariadescribed-by` on the fieldset to describe how many filters are remaining.

Access the component here: http://localhost:8000/search/catalogue/long-filter-chooser/collection/?q=&per_page=20&sort_order=asc&group=tna

It's been checked on Chrome, Firefox, IE11 and on mobile.

Thanks :+1:

<img width="1378" alt="image" src="https://user-images.githubusercontent.com/8880610/168588166-cdf9095d-564d-40fa-a1d2-488d1563baff.png">
