### PR TITLE
CHORE: Test configuration tweaks

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -26,3 +26,5 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 IMAGE_VIEWER_REQUIRE_LOGIN = False
 RECORD_DETAIL_REQUIRE_LOGIN = False
 SEARCH_VIEWS_REQUIRE_LOGIN = False
+
+KONG_CLIENT_BASE_URL = "https://kong.test"

--- a/etna/ciim/tests/test_models.py
+++ b/etna/ciim/tests/test_models.py
@@ -88,9 +88,6 @@ class SearchManagerFilterTest(TestCase):
             results[1]
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class SearchManagerKongCount(TestCase):
     def setUp(self):
         self.manager = APIManager("records.Record")
@@ -102,9 +99,6 @@ class SearchManagerKongCount(TestCase):
         )
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class KongExceptionTest(TestCase):
     def setUp(self):
         self.manager = APIManager("records.Record")
@@ -121,9 +115,6 @@ class KongExceptionTest(TestCase):
             self.manager.fetch(iaid="C140")
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class ModelTranslationTest(TestCase):
     @responses.activate
     def setUp(self):

--- a/etna/collections/tests/test_views.py
+++ b/etna/collections/tests/test_views.py
@@ -2,7 +2,6 @@ import json
 
 from http import HTTPStatus
 
-from django.test import override_settings
 from django.urls import reverse
 
 from wagtail.core.models import Site
@@ -15,9 +14,6 @@ from ...ciim.tests.factories import create_record, create_response
 from ..models import ExplorerIndexPage, ResultsPage, TopicExplorerPage
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class TestRecordChooseView(WagtailPageTests):
     def setUp(self):
         super().setUp()

--- a/etna/records/tests/test_blocks.py
+++ b/etna/records/tests/test_blocks.py
@@ -1,6 +1,5 @@
 import json
 
-from django.test import override_settings
 from django.urls import reverse
 
 from wagtail.core.models import Site
@@ -13,9 +12,6 @@ from ...ciim.tests.factories import create_record, create_response
 from ...insights.models import InsightsIndexPage, InsightsPage
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class TestFeaturedRecordBlockIntegration(WagtailPageTests):
     def setUp(self):
         super().setUp()

--- a/etna/records/tests/test_views.py
+++ b/etna/records/tests/test_views.py
@@ -4,7 +4,7 @@ import unittest
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from wagtail.core.models import Group
 from wagtail.tests.utils import WagtailTestUtils
@@ -16,9 +16,6 @@ from ...ciim.tests.factories import create_media, create_record, create_response
 User = get_user_model()
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class TestRecordDisambiguationView(TestCase):
     @responses.activate
     def test_no_matches_respond_with_404(self):
@@ -86,9 +83,6 @@ class TestRecordDisambiguationView(TestCase):
         self.assertTemplateUsed(response, "records/record_detail.html")
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class TestRecordView(TestCase):
     @responses.activate
     def test_no_matches_respond_with_404(self):
@@ -194,9 +188,6 @@ class TestRecordView(TestCase):
         self.assertTemplateUsed(response, "includes/records/image-viewer-panel.html")
 
 
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class TestDataLayerRecordDetail(WagtailTestUtils, TestCase):
     @responses.activate
     def test_datalayer_level1(self):
@@ -382,9 +373,6 @@ class TestDataLayerRecordDetail(WagtailTestUtils, TestCase):
 @unittest.skip(
     "Kong open beta API does not support media. Re-enable/update once media is available."
 )
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
-)
 class TestImageServeView(TestCase):
     def test_no_location_404s(self):
         response = self.client.get("/records/media/")
@@ -423,9 +411,6 @@ class TestImageServeView(TestCase):
 
 @unittest.skip(
     "Kong open beta API does not support media. Re-enable/update once media is available."
-)
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
 )
 class TestImageBrowseView(TestCase):
     @responses.activate
@@ -497,9 +482,6 @@ class TestImageBrowseView(TestCase):
 
 @unittest.skip(
     "Kong open beta API does not support media. Re-enable/update once media is available."
-)
-@override_settings(
-    KONG_CLIENT_BASE_URL="https://kong.test",
 )
 class TestImageViewerView(TestCase):
     def setUp(self):

--- a/fabfile.py
+++ b/fabfile.py
@@ -134,7 +134,7 @@ def format(c):
 
 
 @task
-def test(c, lint=False):
+def test(c, lint=False, parallel=False):
     """
     Run python tests in the web container
     """
@@ -147,7 +147,10 @@ def test(c, lint=False):
         print("Checking flake8 compliance...")
         web_exec("flake8 etna config")
         print("Running Django tests...")
-    web_exec("python manage.py test --parallel")
+    cmd = "python manage.py test"
+    if parallel:
+        cmd += " --parallel"
+    web_exec(cmd)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Test code is very often difficult enough to understand, so the more we can do to centralise test configuration and simplify the test module code, the better.

Essentially, we don't want our unit tests to ever be making live requests to Kong - so, it makes sense that this configuration is always set when testing.