### PR TITLE
DF-253: Use {% record_url %} everywhere for record links

### DIFF
--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -1,3 +1,4 @@
+{% load records_tags %}
 {% load wagtailimages_tags %}
 
 {% image teaser_image fill-288x292 as teaser_image_small %}
@@ -7,7 +8,7 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% url 'details-page-machine-readable' iaid=record.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record.title }}">
+        <a href="{% record_url record %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record.title }}">
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -1,8 +1,9 @@
+{% load records_tags %}
 {% load wagtailimages_tags %}
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% url 'details-page-machine-readable' iaid=record.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}">
+        <a href="{% record_url record %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}">
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
@@ -18,7 +19,7 @@
             {% image teaser_image fill-348x352 as teaser_image_large %}
             {% image teaser_image fill-543x549 as teaser_image_extra_large %}
 
-            <a href="{% url 'details-page-machine-readable' iaid=record.iaid %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}" aria-hidden="true" tabindex="-1">
+            <a href="{% record_url record %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}" aria-hidden="true" tabindex="-1">
                 <div class="card-group-record-summary__image">
                     <picture>
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -18,7 +18,7 @@
                 {% else %}
                     <li class="hierarchy-global__list-item">
                         <span class="hierarchy-global__reference">{{ item.reference_number }}</span>
-                        <a href="{% url 'details-page-human-readable' item.reference_number %}"  data-link="{{ forloop.counter0 }}: {{ item.reference_number }}" class="link--bold">
+                        <a href="{% record_url item %}"  data-link="{{ forloop.counter0 }}: {{ item.reference_number }}" class="link--bold">
                             {{ item.title }}
                         </a>
                     </li>

--- a/templates/includes/records/hierarchy-local.html
+++ b/templates/includes/records/hierarchy-local.html
@@ -8,7 +8,7 @@
                     <p class="hierarchy-local__nav-item">
                         <span class="hierarchy-local__nav-indicator hierarchy-local__nav-indicator--left"></span>
                         <span class="hierarchy-local__nav-label">{{ 'previous_record'|as_label }}</span>
-                        <a href="{% url 'details-page-machine-readable' page.previous_record.iaid %}" data-link="Previous" class="link--bold"><span class="sr-only">{{ 'previous_record'|as_label }}</span> {{ page.previous_record.iaid }}</a>
+                        <a href="{% record_url page.previous_record %}" data-link="Previous" class="link--bold"><span class="sr-only">{{ 'previous_record'|as_label }}</span> {{ page.previous_record.iaid }}</a>
                     </p>
                 {% endif %}
             </div>
@@ -16,19 +16,12 @@
                 <p class="hierarchy-local__nav-item">
                     <span class="hierarchy-local__nav-indicator hierarchy-local__nav-indicator--up"></span>
                     <span class="hierarchy-local__nav-label">{{ 'parent'|as_label }}</span>
-                    {% if page.parent.reference_number %}
+
                     <span class="hierarchy-local__nav-link-span">
-                        <a href="{% url 'details-page-human-readable' page.parent.reference_number %}" data-link="Series level" class="link--bold">
+                        <a href="{% record_url page.parent %}" data-link="Series level" class="link--bold">
                             <span class="sr-only">{{ 'parent'|as_label }}</span> {{ page.parent.title }}
                         </a>
                     </span>
-                    {% elif page.parent.iaid %}
-                    <span class="hierarchy-local__nav-link-span">
-                        <a href="{% url 'details-page-machine-readable' page.parent.iaid %}" data-link="Series level" class="link--bold">
-                            <span class="sr-only">{{ 'parent'|as_label }}</span> {{ page.parent.title }}
-                        </a>
-                    </span>
-                    {% endif %}
                 </p>
             </div>
             <div class="col-4 col-md-2">
@@ -36,7 +29,7 @@
                     <p class="hierarchy-local__nav-item">
                         <span class="hierarchy-local__nav-indicator hierarchy-local__nav-indicator--right"></span>
                         <span class="hierarchy-local__nav-label">{{ 'next_record'|as_label }}</span>
-                        <a href="{% url 'details-page-machine-readable' page.next_record.iaid %}" data-link="Next" class="link--bold"><span class="sr-only">{{ 'next_record'|as_label }}</span> {{ page.next_record.iaid }}</a>
+                        <a href="{% record_url page.next_record %}" data-link="Next" class="link--bold"><span class="sr-only">{{ 'next_record'|as_label }}</span> {{ page.next_record.iaid }}</a>
                     </p>
                 {% endif %}
             </div>

--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -32,7 +32,7 @@
                             {% if related_material.links %}
                                 <ul>
                                     {% for link in related_material.links %}
-                                        <li><a href="{% url 'details-page-machine-readable' link.iaid %}">{{ link.text }}</a></li>
+                                        <li><a href="{% record_url link %}">{{ link.text }}</a></li>
                                     {% endfor %}
                                 </ul>
                             {% endif %}

--- a/templates/includes/records/record-related-records.html
+++ b/templates/includes/records/record-related-records.html
@@ -1,10 +1,12 @@
+{% load records_tags %}
+
 <div class="details-related-records">
     <p>You might be interested in these records in our archives as they may have meaningful or useful associations with this one.</p>
     <ul class="details-related-records__list" id=“analytics-related-records”>
         {# limit output to three related records #}
         {% for record in page.related_records|slice:":3" %}
             <li>
-                <a href="{% url 'details-page-machine-readable' record.iaid %}" data-link="{{ record.title }}">{{ record.title }}</a>
+                <a href="{% record_url record %}" data-link="{{ record.title }}">{{ record.title }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/templates/insights/blocks/featured_record.html
+++ b/templates/insights/blocks/featured_record.html
@@ -15,7 +15,7 @@
             {% endif %}
 
             <h4 class="featured-record__standfirst">{{ value.title }}</h4>
-            
+
             {% if value.record.title %}
                 <p class="featured-record__title"><span class="sr-only">{{ 'title'|as_label }}:</span> {{ value.record.title }}</p>
             {% endif %}
@@ -30,12 +30,8 @@
                     </p>
                 {% endif %}
             </div>
-            
-            {% if value.record.reference_number %}
-                <a class="tna-button--dark" href="{% url 'details-page-human-readable' value.record.reference_number %}" data-link="View in the catalogue">View <span class="sr-only">{{ value.record.title }}</span> in the catalogue</a>
-            {% elif value.record.iaid %}
-                <a class="tna-button--dark" href="{% url 'details-page-machine-readable' value.record.iaid %}" data-link="View in the catalogue">View <span class="sr-only">{{ value.record.title }}</span> in the catalogue</a>
-            {% endif %}
+
+            <a class="tna-button--dark" href="{% record_url value.record %}" data-link="View in the catalogue">View <span class="sr-only">{{ value.record.title }}</span> in the catalogue</a>
         </div>
     </div>
 </div>

--- a/templates/records/image-browse.html
+++ b/templates/records/image-browse.html
@@ -2,6 +2,7 @@
 
 {% load static %}
 {% load datalayer_tags %}
+{% load records_tags %}
 
 {% block extra_gtm_js %}
     {% image_browse_datalayer as datalayer %}
@@ -21,7 +22,7 @@
                 </h1>
             </div>
             <div class="image-browse__details_navigation">
-                <a href="{% url 'details-page-human-readable' page.reference_number %}">Record details</a>
+                <a href="{% record_url page %}">Record details</a>
             </div>
         </div>
         <ul class="image-browse__listing">

--- a/templates/records/image-viewer.html
+++ b/templates/records/image-viewer.html
@@ -1,4 +1,5 @@
 {% extends 'base-images.html' %}
+{% load records_tags %}
 {% load static %}
 
 {% block content %}
@@ -26,7 +27,7 @@
 
                     <ul>
                         <li><a href="{% url 'image-browse' page.iaid %}">All {{ images_count }} images</a></li>
-                        <li><a href="{% url 'details-page-machine-readable' page.iaid %}">Record details</a></li>
+                        <li><a href="{% record_url page %}">Record details</a></li>
                     </ul>
                 </nav>
             </div>


### PR DESCRIPTION
This is an extension of the work started by @AshTNA in #340, and a pre-requisite for one of the things we're looking to try out ahead of Insights launch.