### PR TITLE
DF-319: Conditionally direct users to Discovery to view editor-selected records

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -108,6 +108,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "wagtail.contrib.settings.context_processors.settings",
+                "etna.core.context_processors.feature_flags",
             ],
         },
     },

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -348,3 +348,9 @@ except ValueError:
 CACHE_CONTROL_STALE_WHILE_REVALIDATE = int(
     os.getenv("CACHE_CONTROL_STALE_WHILE_REVALIDATE", 30)
 )
+
+# Feature flags: special boolean settings that allow features to be toggled on/off in
+# different environments, and are loaded into templates using a custom context processor.
+FEATURE_RECORD_LINKS_GO_TO_DISCOVERY = strtobool(
+    os.getenv("FEATURE_RECORD_LINKS_GO_TO_DISCOVERY", "False")
+)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -350,8 +350,14 @@ CACHE_CONTROL_STALE_WHILE_REVALIDATE = int(
     os.getenv("CACHE_CONTROL_STALE_WHILE_REVALIDATE", 30)
 )
 
-# Feature flags: special boolean settings that allow features to be toggled on/off in
-# different environments, and are loaded into templates using a custom context processor.
+# -----------------------------------------------------------------------------
+# Feature flags
+# -----------------------------------------------------------------------------
+
+# Special boolean settings prefixed with 'FEATURE_', that are automatically
+# injected into template contexts using a custom context processor - allowing
+# conditional logic to be added to both Python and template code
+
 FEATURE_RECORD_LINKS_GO_TO_DISCOVERY = strtobool(
     os.getenv("FEATURE_RECORD_LINKS_GO_TO_DISCOVERY", "False")
 )

--- a/etna/core/context_processors.py
+++ b/etna/core/context_processors.py
@@ -2,6 +2,10 @@ from django.conf import settings
 
 
 def feature_flags(request):
+    """
+    Makes any settings with the "FEATURE_" prefix available template contexts,
+    allowing conditional logic to be added to both Python and template code.
+    """
     return {
         key: value
         for key, value in settings.__dict__.items()

--- a/etna/core/context_processors.py
+++ b/etna/core/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+def feature_flags(request):
+    return {
+        key: value
+        for key, value in settings.__dict__.items()
+        if key.startswith("FEATURE_")
+    }

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Union
 
 from django import template
+from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 
 from ..field_labels import FIELD_LABELS
@@ -10,7 +11,9 @@ register = template.Library()
 
 
 @register.simple_tag
-def record_url(record: Union[Record, Dict[str, Any]]) -> str:
+def record_url(
+    record: Union[Record, Dict[str, Any]], is_editorial: bool = False
+) -> str:
     """
     Return the URL for the provided `record` dict; which could either be a
     full/transformed result from the fetch() endpoint, OR a raw result from
@@ -18,8 +21,9 @@ def record_url(record: Union[Record, Dict[str, Any]]) -> str:
     Handling of Iaid as priority to allow Iaid in disambiguation pages when
     returning more than one record
     """
-
     if iaid := record.get("iaid"):
+        if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY:
+            return f"https://discovery.nationalarchives.gov.uk/details/r/{iaid}"
         try:
             return reverse("details-page-machine-readable", kwargs={"iaid": iaid})
         except NoReverseMatch:

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -39,7 +39,7 @@ def record_url(
         return url
     try:
         # Assume `record` is an un-transformed search result
-        return record_url(record["_source"]["@template"]["details"])
+        return record_url(record["_source"]["@template"]["details"], is_editorial)
     except KeyError:
         return ""
 

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -8,7 +8,7 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record.title }}">
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record.title }}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
@@ -16,6 +16,7 @@
                 </span>
                 {% endif %}
                 {{ record.title }}
+                {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %}<span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>
         <div class="card-group-record-summary__body">

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -3,7 +3,7 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}">
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
@@ -11,6 +11,7 @@
                 </span>
                 {% endif %}
                 {{ record.title }}
+                {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>
         {% if teaser_image %}
@@ -19,7 +20,7 @@
             {% image teaser_image fill-348x352 as teaser_image_large %}
             {% image teaser_image fill-543x549 as teaser_image_extra_large %}
 
-            <a href="{% record_url record %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}" aria-hidden="true" tabindex="-1">
+            <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}" aria-hidden="true" tabindex="-1"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
                 <div class="card-group-record-summary__image">
                     <picture>
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
@@ -28,6 +29,7 @@
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
                         <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-record-summary__image-fallback">
                     </picture>
+                    {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
                 </div>
             </a>
         {% endif %}

--- a/templates/insights/blocks/featured_record.html
+++ b/templates/insights/blocks/featured_record.html
@@ -31,7 +31,7 @@
                 {% endif %}
             </div>
 
-            <a class="tna-button--dark" href="{% record_url value.record %}" data-link="View in the catalogue">View <span class="sr-only">{{ value.record.title }}</span> in the catalogue</a>
+            <a class="tna-button--dark" href="{% record_url value.record is_editorial=True %}" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>View <span class="sr-only">{{ value.record.title }}</span> in the catalogue{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
         </div>
     </div>
 </div>

--- a/templates/insights/blocks/featured_records.html
+++ b/templates/insights/blocks/featured_records.html
@@ -14,8 +14,9 @@
                 {% for item in value.items %}
                     <div class="featured-records__list-item">
                         <dt>
-                            <a class="featured-records__link" href="{% record_url item.record %}" data-link="{{ item.title }}">
+                            <a class="featured-records__link" href="{% record_url item.record is_editorial=True %}" data-link="{{ item.title }}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
                                 <h4 class="featured-records__link-heading">{{ item.title }}</h4>
+                                {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
                             </a>
                         </dt>
                         <dd class="featured-records__list-item-description">{{ item.record.title|striptags }}</dd>


### PR DESCRIPTION
Relates to: https://national-archives.atlassian.net/browse/DF-319

Allows us to toggle whether record links in editorial content should link off to discovery OR be rendered by the in-progress record detail view from this project.

### To test

1. Find an Insights page that uses the "Featured Record" block (Alice Hawkins worked for me) and view it. The link to the record should display as before, linking to the same-site URL.
2.  Add ```FEATURE_RECORD_LINKS_GO_TO_DISCOVERY = True``` to `config/settings/dev.py` and save.
3. Refresh the Insights page.. the record should now be rendered with a link to view the record on discovery, instead of on the same site.