### PR TITLE
Add padding right to prevent heading text from overlapping icons on mobile

### DIFF
--- a/sass/includes/_section-separator.scss
+++ b/sass/includes/_section-separator.scss
@@ -12,13 +12,13 @@
         padding-top: 2rem;
         display: inline-block;
         background: transparent;
-        padding-right: 3rem;
 
         @media screen and (max-width: $screen__md) {
           display: block;
           font-size: 2rem;
           border-bottom: 0.25rem solid $color__grey-4;
           background: url($fa_chevron_down) no-repeat right bottom/2rem;
+          padding-right: 3rem;
           &:hover {
             cursor: pointer;
           }

--- a/sass/includes/_section-separator.scss
+++ b/sass/includes/_section-separator.scss
@@ -12,6 +12,7 @@
         padding-top: 2rem;
         display: inline-block;
         background: transparent;
+        padding-right: 3rem;
 
         @media screen and (max-width: $screen__md) {
           display: block;

--- a/sass/includes/_section-separator.scss
+++ b/sass/includes/_section-separator.scss
@@ -17,7 +17,7 @@
           display: block;
           font-size: 2rem;
           border-bottom: 0.25rem solid $color__grey-4;
-          background: url($fa_chevron_down) no-repeat right bottom/2rem;
+          background: url($fa_chevron_down) no-repeat right 90%/2rem;
           padding-right: 3rem;
           &:hover {
             cursor: pointer;
@@ -27,7 +27,7 @@
           }
 
           &[aria-expanded="true"] {
-            background: url($fa_chevron_up) no-repeat right bottom/2rem;
+            background: url($fa_chevron_up) no-repeat right 95%/2rem;
           }
         }
       }


### PR DESCRIPTION
Hi @matt-blair,

Would it be possible to merge this PR? It's just a small one that adds some `padding-right` to the Insights headings to prevent the heading text from overlapping the mobile icons. Thank you!