### PR TITLE
DF-328: Fix 'all results' record urls

### DIFF
--- a/etna/search/templatetags/search_tags.py
+++ b/etna/search/templatetags/search_tags.py
@@ -87,21 +87,6 @@ def interpretive_detail(record: dict, key: str) -> str:
 
 
 @register.filter
-def interpretive_url(record: dict) -> str:
-    """Fetch a source Url from an interpretive record template.
-
-    Django templates don't allow access to keys or attributes prefixed with @
-
-    https://docs.djangoproject.com/en/4.0/ref/templates/language/#variables
-    """
-
-    try:
-        return record["_source"]["@template"]["details"]["sourceUrl"]
-    except KeyError:
-        return ""
-
-
-@register.filter
 def record_score(record) -> str:
     """Output a record's score.
 

--- a/templates/search/blocks/featured-search__interpretive-card.html
+++ b/templates/search/blocks/featured-search__interpretive-card.html
@@ -1,9 +1,10 @@
+{% load records_tags %}
 {% load search_tags %}
 <div class="featured-search__interpretive-results-section">
     <h2 class="featured-search__heading">{{ bucket.label }}</h2>
     {% for record in bucket.results|slice:":1" %}
         <div>
-            <a href="{{ record|interpretive_url }}" aria-hidden="true" tabindex="-1" class="featured-search__interpretive-card-link">
+            <a href={% record_url record %}" aria-hidden="true" tabindex="-1" class="featured-search__interpretive-card-link">
                 <div>
                     <picture class="featured-search__interpretive-card-image">
                         <source media="(max-width: 768px)" srcset="https://via.placeholder.com/508x304">
@@ -15,7 +16,7 @@
                 </div>
             </a>
                 <div>
-                    <a href="{{ record|interpretive_url }}" class="featured-search__results-link">
+                    <a href={% record_url record %}" class="featured-search__results-link">
                         <h3 class="featured-search__heading">
                             {{ record|record_detail:"summaryTitle"|striptags }}
                         </h3>

--- a/templates/search/blocks/featured-search__record-creator.html
+++ b/templates/search/blocks/featured-search__record-creator.html
@@ -1,3 +1,4 @@
+{% load records_tags %}
 {% load search_tags %}
 <div class="featured-search__results-block">
     <h2 class="featured-search__heading">{{ bucket.label }}</h2>
@@ -5,13 +6,13 @@
     {% for record in bucket.results|slice:":1" %}
         <div class="featured-search__record-creator">
             <div>
-                <a href="#" aria-hidden="true" tabindex="-1" class="featured-search__card-link">
+                <a href="{% record_url record %}" aria-hidden="true" tabindex="-1" class="featured-search__card-link">
                     <div>
                         <img src="https://via.placeholder.com/565x400" alt="" class="featured-search__record-creator-image">
                     </div>
                 </a>
             </div>
-            <h3 class="featured-search__results-heading"><a href="#" class="featured-search__results-link">{{record|record_detail:"summaryTitle"|striptags }}</a></h3>
+            <h3 class="featured-search__results-heading"><a href="{% record_url record %}" class="featured-search__results-link">{{record|record_detail:"summaryTitle"|striptags }}</a></h3>
         </div>
     {% endfor %}
 

--- a/templates/search/blocks/featured-search__results-block.html
+++ b/templates/search/blocks/featured-search__results-block.html
@@ -1,10 +1,11 @@
+{% load records_tags %}
 {% load search_tags %}
 <div class="featured-search__results-block">
     <h2 class="featured-search__heading">{{ bucket.label }}</h2>
     <ul class="featured-search__results-list">
         {% for record in bucket.results %}
             <li class="featured-search__results-list-item">
-                <a href="/details/" class="featured-search__results-link">
+                <a href="{% record_url record %}" class="featured-search__results-link">
                     <h3 class="featured-search__results-heading">
                         {{ record|record_detail:"summaryTitle"|striptags }}
                     </h3>


### PR DESCRIPTION
As outlined in https://national-archives.atlassian.net/browse/DF-328, some places were missed when we introduced the `{% record_url %}` tag. This PR updates the includes used in the [All Results](https://develop-sr3snxi-rasrzs7pi6sd4.uk-1.platformsh.site/search/featured/) view, so that results link to working URLs.