### PR TITLE
UN-213: Front end tweaks

### DIFF
--- a/sass/includes/_featured-insight.scss
+++ b/sass/includes/_featured-insight.scss
@@ -32,12 +32,11 @@
 
     @media (max-width: $screen__md) {
         display: block;
-        &__image, &__description {
+        &__description, &__image{
             width: 100%;
-
-            img {
-                width: 100%;
-            }
+        }
+        &__image {
+            height: 21.875rem;
         }
     }
 }

--- a/sass/includes/_featured-insight.scss
+++ b/sass/includes/_featured-insight.scss
@@ -4,6 +4,10 @@
 
     &__image {
         width: 50%;
+
+        figure {
+            margin-bottom: 0;
+        }
     }
 
     &__description {

--- a/sass/includes/_hero-image.scss
+++ b/sass/includes/_hero-image.scss
@@ -2,6 +2,12 @@
   width: 100%;
 
   &__figcaption {
-    text-align: center;
+    background-color: $color__grey-5;
+    padding: 1rem;
+    border-bottom: 0.1875rem solid $color__grey-7;
+
+    p {
+      margin-bottom: 0;
+    }
   }
 }

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -50,7 +50,6 @@
   }
 
   &__description {
-    font-size: 1.2rem;
     text-align: left;
   }
 
@@ -60,7 +59,6 @@
 
   &__transcript {
     background-color: $color__dark;
-    font-size: 1.2rem;
     margin-top: 2rem;
     padding: 1rem;
 

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -2,6 +2,10 @@
   min-height: 37.5rem;
   position: relative;
 
+  &__audio-container, &__video-container {
+    text-align: center;
+  }
+
   &__overlay {
     background-color: $color__black;
     opacity: 0.8;
@@ -13,7 +17,6 @@
   &__content-panel {
     padding: 3rem 0;
     position: relative;
-    text-align: center;
     z-index: 999;
   }
 

--- a/sass/includes/_quote.scss
+++ b/sass/includes/_quote.scss
@@ -2,7 +2,7 @@
   &__container {
     background-color: $color__grey-5;
     padding: 2rem;
-    margin: 4rem 0;
+    margin: 3rem 0;
     max-width: 100%;
   }
 

--- a/sass/includes/_quote.scss
+++ b/sass/includes/_quote.scss
@@ -7,8 +7,8 @@
   }
 
   &__text {
-    font-family: $font__supria-sans;
-    font-size: 2rem;
+    font-family: $font__open-sans;
+    font-size: 1.25rem;
     font-style: italic;
   }
 

--- a/sass/includes/_section-image.scss
+++ b/sass/includes/_section-image.scss
@@ -1,5 +1,11 @@
 .section-image {
+    margin-bottom: 2rem;
+
     img {
         width: 100%;
+    }
+
+    figure, p {
+        margin-bottom: 0;
     }
 }

--- a/sass/includes/_section-image.scss
+++ b/sass/includes/_section-image.scss
@@ -8,4 +8,10 @@
     figure, p {
         margin-bottom: 0;
     }
+
+    figcaption {
+        background-color: $color__grey-5;
+        padding: 1rem;
+        border-bottom: 0.1875rem solid $color__grey-7;
+    }
 }

--- a/templates/insights/blocks/featured_record.html
+++ b/templates/insights/blocks/featured_record.html
@@ -6,7 +6,7 @@
 <div class="featured-record" data-container-name="featured-record">
     <div class="container">
         <{{ heading_level }} class="featured-record__heading">
-            Discover our records
+            Record details
         </{{ heading_level }}>
 
         <div class="featured-record__content">

--- a/templates/insights/blocks/featured_records.html
+++ b/templates/insights/blocks/featured_records.html
@@ -1,7 +1,7 @@
 {% load records_tags %}
 <div class="featured-records">
     <div class="container">
-        <{{ heading_level }} class="featured-records__heading">Discover our records</{{ heading_level }}>
+        <{{ heading_level }} class="featured-records__heading">Record details</{{ heading_level }}>
 
         <div class="featured-records__content">
             {% if value.introduction %}

--- a/templates/insights/insights_index_page.html
+++ b/templates/insights/insights_index_page.html
@@ -15,32 +15,8 @@
     <div class="container">
         <div class="featured-insight">
             {% if page.featured_insight.hero_image %}
-                <div class="featured-insight__image">
-                    {% if page.featured_insight.hero_image_caption %}
-                    <figure>
-                    {% endif %}
-                    <picture>
-                        {% image page.featured_insight.hero_image fill-412x361 as hero %}
-                        <source media="(max-width: 480px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-510x351 as hero %}
-                        <source media="(max-width: 640px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-510x304 as hero %}
-                        <source media="(max-width: 768px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-345x495 as hero %}
-                        <source media="(max-width: 991px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-555x367 as hero %}
-                        <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
-                        {% if page.featured_insight.hero_image_decorative %}
-                            <img src="{{ hero.url }}" alt="" />
-                        {% else %}
-                            <img src="{{ hero.url }}" alt="{{page.featured_insight.hero_image_alt_text}}" />
-                        {% endif %}
-                    </picture>
-                    {% if page.featured_insight.hero_image_caption %}
-                        <figcaption class="hero-image__figcaption">{{ page.featured_insight.hero_image_caption|richtext }}</figcaption>
-                    </figure>
-                    {% endif %}
-                </div>
+                {% image page.featured_insight.hero_image fill-800x1000-c100 as hero %}
+                <div class="featured-insight__image" style="background: url('{{ hero.url }}') no-repeat; {{ hero.background_position_style }}"></div>
             {% endif %}
 
             <div class="featured-insight__description">


### PR DESCRIPTION
Hi @matt-blair,

Would it be possible to have a look at this PR? It implements some Insights tweaks that were requested by the team. It's mostly just CSS changes but I have changed the implementation of the featured insights image to be a `<div>` with a background as opposed to using the `<picture>` element with several `<source>`s. I did this because the `<picture>` implementation was dependent on explicitly defining image dimensions in pixels and I don't think it responds well depending on the screen size. I found going with the `<div>` with a background approach was more responsive (happy to have a call to demo and explain this further, it's a bit tricky to explain over text). Thank you 👍 