### PR TITLE
DF-222: Redesign header navigation to be a hamburger menu on mobile

### DIFF
--- a/sass/includes/search/_global-search.scss
+++ b/sass/includes/search/_global-search.scss
@@ -86,6 +86,11 @@
       background-size: 45px;
       background-position-x: -3px;
     }
+
+    &-text {
+      display: inline-block;
+      height: 75%;
+    }
   }
 
   &__paragraph {

--- a/scripts/src/modules/search/global-search.js
+++ b/scripts/src/modules/search/global-search.js
@@ -7,7 +7,7 @@ export default function () {
     }
 
     $gsFallbackLink.outerHTML = `<button aria-expanded="false" aria-controls="gs-component" aria-label="Show/hide global search" type="button" id="gs-show-hide" class="global-search__button">
-        Search
+        <span class="global-search__button-text">Search</span>
     </button>`;
 
     let $gsToggleButton = document.querySelector('#gs-show-hide');


### PR DESCRIPTION
Hi @matt-blair,

Would it be possible to have a look at this PR? It's just a very small change to make the text for the search tab behave consistently when it's a `<button>` and when it's an `<a>` tag. Thank you 👍 