### PR TITLE
Making login-status consistent with sso app

### DIFF
--- a/templates/includes/login-status.html
+++ b/templates/includes/login-status.html
@@ -1,7 +1,9 @@
 <div class="login-status" role="region" aria-labelledby="authentication_link">
     {% if request.user.is_authenticated %}
-        <a href="{% url 'account_logout' %}" class="login-status__link" id="authentication_link">Sign out</a>
+        <a href="https://tna-account-management-poc.torchbox.dev/" class="login-status__link">My account</a>
+        <a href="{% url 'account_logout' %}" class="login-status__link" id="authentication_link">Logout</a>
     {% else %}
-        <a href="{% url 'account_login' %}" class="login-status__link" id="authentication_link">Sign in</a>
+        <a href="{% url 'account_login' %}" class="login-status__link" id="authentication_link">Login</a>
+        <a href="{% url 'account_register' %}" class="login-status__link">Register</a>
     {% endif %}
 </div>


### PR DESCRIPTION
This MR adds a "My account" link to the login include and makes the labelling consistent with the sso django app:

Sign in -> Login, and Sign out -> Logout