### PR TITLE
Fix hamburger menu and search button toggle behaviour

### DIFF
--- a/scripts/src/modules/hamburger-menu.js
+++ b/scripts/src/modules/hamburger-menu.js
@@ -8,6 +8,7 @@ export default function () {
     );
     let $searchListItem = document.querySelector("#js-site-menu-search");
     let $globalSearchButton = document.querySelector("#gs-show-hide");
+    let $globalSearch = document.querySelector("#gs-component");
     if (!$headerMenu || !$headerMenuList || !$searchListItem) {
         return;
     }
@@ -87,6 +88,12 @@ export default function () {
 
         for (let i = 0; i < $headerElementsToHide.length; i++) {
             $headerElementsToHide[i].hidden = !$headerElementsToHide[i].hidden;
+        }
+
+        // Hide global search component when the navigation menu is expanded
+        if($globalSearch && $globalSearchButton) {
+            $globalSearch.hidden = true;
+            $globalSearchButton.setAttribute("aria-expanded", "false");
         }
     });
 

--- a/scripts/src/modules/search/global-search.js
+++ b/scripts/src/modules/search/global-search.js
@@ -1,4 +1,5 @@
 export default function () {
+    const $headerElementsToHide = document.querySelectorAll('[data-isSearch="false"]');
     let $gsFallbackLink = document.querySelector("a[data-id='search-nav-link']");
     let $main = document.querySelector('main');
 
@@ -37,9 +38,18 @@ export default function () {
     $main.insertBefore($globalSearchComponent, $main.childNodes[0]); //IE11 compatible prepend
 
     $gsToggleButton.addEventListener('click', function(e) {
+        const $showHideButton = document.querySelector('.header__show-hide-button');
         let ariaExpanded = $gsToggleButton.getAttribute('aria-expanded') == 'true';
         $gsToggleButton.setAttribute('aria-expanded', !ariaExpanded);
 
         $globalSearchComponent.hidden = !$globalSearchComponent.hidden;
+
+        // Hide navigation menu when global search component is expanded
+        if($headerElementsToHide && $showHideButton) {
+            for (let i = 0; i < $headerElementsToHide.length; i++) {
+                $headerElementsToHide[i].hidden = true;
+            }
+            $showHideButton.setAttribute("aria-expanded", "false");
+        }
     })
 }

--- a/scripts/src/modules/search/global-search.js
+++ b/scripts/src/modules/search/global-search.js
@@ -45,7 +45,7 @@ export default function () {
         $globalSearchComponent.hidden = !$globalSearchComponent.hidden;
 
         // Hide navigation menu when global search component is expanded
-        if($headerElementsToHide && $showHideButton) {
+        if(window.innerWidth < 768 && $headerElementsToHide && $showHideButton) {
             for (let i = 0; i < $headerElementsToHide.length; i++) {
                 $headerElementsToHide[i].hidden = true;
             }


### PR DESCRIPTION
Hi @gtvj,

Would it be possible to have a look at this PR? It's makes a small change to how the hamburger menu and search buttons behave (requested by Simon). Currently, both the menu and search component can be open at the same time. This PR modifies the button behaviour so that if the hamburger menu is clicked when the search component is open, the search component will minimise, and vice versa. Thank you 👍 