### PR TITLE
CHORE: Remove redundant elasticsearch service from platform.sh config

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -28,7 +28,6 @@ disk: 2048
 # side is in the form <service name>:<endpoint name>.
 relationships:
     db: 'db:postgresql'
-    elasticsearch: 'search:elasticsearch'
     redis: "redis:redis"
 
 

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -18,7 +18,3 @@
 "https://www.{default}/":
     type: redirect
     to: "https://{default}/"
-
-"https://es.{default}":
-    type: upstream
-    upstream: search:elasticsearch

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -1,9 +1,3 @@
-search:
-    type: elasticsearch:7.7
-    disk: 256
-    configuration:
-        authentication:
-            enabled: true
 db:
     type: postgresql:12
     disk: 256


### PR DESCRIPTION
We stopped using ES in the application a while ago, but we didn't want to play around with platform.sh config at the time, as we weren't entirely sure what the impact would be on other environments.

These changes were successfully applied to the `auth0-integration` environment, which appears to have worked safely, without impacting any other environments.