### PR TITLE
DF-301: Add 'Go to the current National Archives website' link to header

### DIFF
--- a/sass/includes/_global.scss
+++ b/sass/includes/_global.scss
@@ -41,3 +41,20 @@ mark {
   background-color: inherit;
   color: inherit;
 }
+
+.global-tna-link {
+  text-align: right;
+
+  &__link {
+    display: inline-block;
+    text-decoration: none;
+    background: url(/static/images/icons/open-in-new-tab.svg) no-repeat;
+    background-position-x: 97.5%;
+    background-position-y: 40%;
+    padding: 0.5rem 3rem 0.5rem 1rem;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -2,6 +2,12 @@
 
 {% include 'includes/login-status.html' %}
 
+<div class="global-tna-link tna-bg--dark">
+  <a href="https://www.nationalarchives.gov.uk/" target="_blank" class="global-tna-link__link">
+    Go to the current National Archives website <span class="sr-only">Opens in a new tab</span>
+  </a>
+</div>
+
 <header class="header">
     <div class="header__logo-holder">
       <a href="/" class="header__logo-link"

--- a/templates/static/images/icons/open-in-new-tab.svg
+++ b/templates/static/images/icons/open-in-new-tab.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="#fff" width="24" height="24" viewBox="0 0 24 24"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"/></svg>


### PR DESCRIPTION
Hi @matt-blair,

Would it be possible to have a look at this PR? It just adds a link to The National Archives website above the header. I've tested this in Chrome, Firefox, Safari, Edge, and IE11 with no issues and I've attached a screenshot below for an example:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/29227105/177039354-2855f821-1926-4361-aef7-e4ac38808539.png">

Thank you 👍 