### PR TITLE
Highlight card changes

### DIFF
--- a/etna/collections/tests/test_models.py
+++ b/etna/collections/tests/test_models.py
@@ -185,7 +185,6 @@ class TestRecordDescriptionOverride(TestCase):
 
         response = self.client.get("/results-page/")
 
-        self.assertNotContains(response, "This is the description from Kong")
         self.assertContains(response, "This is the overridden description")
 
 

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -20,7 +20,7 @@
             </p>
         </a>
         <div class="card-group-record-summary__body">
-            <p>{{ record.description | striptags | escape }}</p>
+            <p>{{ record.description|striptags }}</p>
         </div>
     </div>
 </li>

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -8,7 +8,7 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|escape record.title|striptags|escape %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|safe record.title|striptags %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -8,19 +8,19 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{{ record.title }}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|safe record.title|striptags|linebreaks %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
                     {{ record.reference_number }} -
                 </span>
                 {% endif %}
-                {{ record.title }}
+                {% firstof description_override|safe record.title|striptags %}
                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %}<span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>
         <div class="card-group-record-summary__body">
-            <p>{{ description_override|default:record.description|striptags|truncatewords:40 }}</p>
+            <p>{{ record.description | striptags | escape }}</p>
         </div>
     </div>
 </li>

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -8,7 +8,7 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|safe record.title|striptags|linebreaks %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|escape record.title|striptags|escape %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -10,7 +10,7 @@
                     {{ record.reference_number }} -
                 </span>
                 {% endif %}
-                {{ record.title }}
+                {% firstof description_override|safe record.title|striptags %}
                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>
@@ -33,6 +33,6 @@
                 </div>
             </a>
         {% endif %}
-        <p class="card-group-record-summary__body">{{ description_override|default:record.description|safe }}</p>
+        <p class="card-group-record-summary__body">{{ record.description|striptags|escape|truncatewords:20 }}</p>
     </div>
 </li>

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -3,7 +3,7 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{% firstof description_override|safe record.title|striptags %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
@@ -20,7 +20,7 @@
             {% image teaser_image fill-348x352 as teaser_image_large %}
             {% image teaser_image fill-543x549 as teaser_image_extra_large %}
 
-            <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.title }}" aria-hidden="true" tabindex="-1"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+            <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{{ record.description|striptags|escape|truncatewords:20 }}" aria-hidden="true" tabindex="-1"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
                 <div class="card-group-record-summary__image">
                     <picture>
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">


### PR DESCRIPTION
Changes include:

- Swapping the order of catalogue data for Wagtail supplied data
- Swapping record.title (which does not seem to return anything) for
  record.description and truncating it to different word lengths
  depending on whether it is before or after the image
- Using striptags to prevent the XML from appearing