### PR TITLE
UN-213: Frontend tweaks

### DIFF
--- a/sass/includes/_featured-insight.scss
+++ b/sass/includes/_featured-insight.scss
@@ -2,11 +2,23 @@
     display: flex;
     margin-bottom: 4rem;
 
-    &__image {
+    &__image-link {
+        display: inline-block;
         width: 50%;
+        z-index: 999;
+
+        img {
+            height: 100%;
+            width: 100%;
+            object-fit: cover;
+        }
 
         figure {
             margin-bottom: 0;
+        }
+
+        &:hover {
+            outline: 0.3125rem solid $color__dark;
         }
     }
 
@@ -14,7 +26,6 @@
         background-color: #FFCC00;
         padding: 2rem 4rem 2rem 2rem;
         width: 50%;
-        height: 100%;
 
         p {
             margin-top: 2rem;
@@ -22,7 +33,7 @@
     }
 
     &__heading {
-        border-bottom: 2px solid $color__dark;
+        border-bottom: 0.125rem solid $color__dark;
 
         small {
             display: block;
@@ -30,13 +41,26 @@
         }
     }
 
-    @media (max-width: $screen__md) {
+    @media only screen and (max-width: $screen__md) {
         display: block;
-        &__description, &__image{
+        &__description, &__image-link {
             width: 100%;
         }
-        &__image {
-            height: 21.875rem;
+        &__image-link {
+            img {
+                width: 100%;
+            }
+        }
+    }
+
+    // IE11 styles
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+        &__image-link {
+            display: none;
+        }
+
+        &__description {
+            width: 100%;
         }
     }
 }

--- a/sass/includes/_featured-record.scss
+++ b/sass/includes/_featured-record.scss
@@ -1,33 +1,42 @@
 .featured-record {
-    &__heading {
-        color: $color__dark;
-        background-color: $color__yellow_2;
-        margin-bottom: 0;
-        padding: 1rem 0 1rem 1rem;
-        font-weight: 400;
-        font-size: 2rem;
-        font-family: $font__supria-sans;
-    }
+  margin: 2rem 0;
 
-    &__content {
-      border: 3px solid $color__grey-7;
-      padding: 1rem;
-      border-top: none;
-      text-align: center;
-    }
-
-    &__standfirst {
+  &__heading {
       color: $color__dark;
-      font-family: $font__supria-sans;
-      font-size: 1.4rem;
-    }
-
-    &__metadata {
-        display: flex;
-        justify-content: space-evenly;
-    }
-  
-    p:last-child {
+      background-color: $color__yellow_2;
       margin-bottom: 0;
+      padding: 1rem 0 1rem 1rem;
+      font-weight: 400;
+      font-size: 2rem;
+      font-family: $font__supria-sans;
+  }
+
+  &__content {
+    border: 3px solid $color__grey-7;
+    padding: 1rem;
+    border-top: none;
+    text-align: center;
+
+    figcaption {
+      background-color: $color__grey-5;
+      padding: 1rem;
+      border-bottom: 0.1875rem solid $color__grey-7;
+      text-align: left;
     }
+  }
+
+  &__standfirst {
+    color: $color__dark;
+    font-family: $font__supria-sans;
+    font-size: 1.4rem;
+  }
+
+  &__metadata {
+      display: flex;
+      justify-content: space-evenly;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/sass/includes/_featured-record.scss
+++ b/sass/includes/_featured-record.scss
@@ -12,7 +12,7 @@
   }
 
   &__content {
-    border: 3px solid $color__grey-7;
+    border: 0.1875rem solid $color__grey-7;
     padding: 1rem;
     border-top: none;
     text-align: center;

--- a/templates/insights/insights_index_page.html
+++ b/templates/insights/insights_index_page.html
@@ -15,8 +15,22 @@
     <div class="container">
         <div class="featured-insight">
             {% if page.featured_insight.hero_image %}
-                {% image page.featured_insight.hero_image fill-800x1000-c100 as hero %}
-                <div class="featured-insight__image" style="background: url('{{ hero.url }}') no-repeat; {{ hero.background_position_style }}"></div>
+                <a href="{% pageurl page.featured_insight %}" class="featured-insight__image-link" tabindex="-1" aria-hidden="true">
+                    <picture>
+                        {% image page.featured_insight.hero_image fill-500x400-c100 as hero %}
+                        <source media="(max-width: 768px)" srcset="{{ hero.url }}">
+                        {% image page.featured_insight.hero_image fill-500x500-c100 as hero %}
+                        <source media="(max-width: 991px)" srcset="{{ hero.url }}">
+                        {% image page.featured_insight.hero_image fill-1000x600-c100 as hero %}
+                        <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
+
+                        {% if page.featured_insight.hero_image_decorative %}
+                            <img src="{{ hero.url }}" alt="" />
+                        {% else %}
+                            <img src="{{ hero.url }}" alt="{{page.featured_insight.hero_image_alt_text}}" />
+                        {% endif %}
+                    </picture>
+                </a>
             {% endif %}
 
             <div class="featured-insight__description">


### PR DESCRIPTION
Hi @matt-blair,

Could you have a look at this PR? It primarily addresses the featured insight image issue we've been discussing (also, as the `object-fit` property is not supported in IE11, I've taken your suggestion of omitting the image and making the yellow textbox full width. Had a quick chat with Gwyn this morning about the approach and he was in agreement). It also updates the `featured-record` component with some more spacing and the new caption style when there is an image. I've tested in Chrome, Firefox, Safari, Edge, and IE11 and didn't spot any issues.

@gtvj - just tagging you because I was asked to make the featured insight image a link and you may want check the implementation. I've copied the card implementation for this and the image link will be ignored by screen readers (by applying `aria-hidden="true"`) and keyboard users (by removing it from the tab order using `tabindex="-1"`)

Thank you 👍 