### PR TITLE
Fix/insights fe fixes

### DIFF
--- a/sass/includes/_jumplinks.scss
+++ b/sass/includes/_jumplinks.scss
@@ -4,6 +4,12 @@
   padding: 2.5rem 0 0 1rem;
   height: 100vh;
   overflow: scroll;
+  -ms-overflow-style: none;  /* Hide jumplinks scrollbar on Internet Explorer 10+ and Edge */
+  scrollbar-width: none;  /* Hide jumplinks scrollbar on Firefox */
+
+  &::-webkit-scrollbar { 
+    display: none;  /* Hide jumplinks scrollbar on Safari and Chrome */
+  }
 
   &__heading {
     font-size: 2rem;

--- a/sass/includes/_jumplinks.scss
+++ b/sass/includes/_jumplinks.scss
@@ -4,11 +4,11 @@
   padding: 2.5rem 0 0 1rem;
   height: 100vh;
   overflow: scroll;
-  -ms-overflow-style: none;  /* Hide jumplinks scrollbar on Internet Explorer 10+ and Edge */
+  -ms-overflow-style: none;  /* Hide jumplinks scrollbar on Internet Explorer 11 */
   scrollbar-width: none;  /* Hide jumplinks scrollbar on Firefox */
 
   &::-webkit-scrollbar { 
-    display: none;  /* Hide jumplinks scrollbar on Safari and Chrome */
+    display: none;  /* Hide jumplinks scrollbar on Safari, Chrome, and Edge */
   }
 
   &__heading {

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -61,6 +61,14 @@
     background-color: $color__dark;
     margin-top: 2rem;
     padding: 1rem;
+    max-height: 30rem;
+    overflow: scroll;
+    -ms-overflow-style: none;  /* Hide transcript scrollbar on Internet Explorer 11 */
+    scrollbar-width: none;  /* Hide jumplinks scrollbar on Firefox */
+
+    &::-webkit-scrollbar { 
+      display: none;  /* Hide jumplinks scrollbar on Safari, Chrome, and Edge */
+    }
 
     details {
       text-align: left;
@@ -72,7 +80,7 @@
         }
       }
 
-      summary::marker {
+      summary::marker, summary::-webkit-details-marker {
         color: $color__white;
       }
     }

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -17,7 +17,7 @@
   &__content-panel {
     padding: 3rem 0;
     position: relative;
-    z-index: 999;
+    z-index: 998;
   }
 
   &__icon {

--- a/sass/includes/_media-embed.scss
+++ b/sass/includes/_media-embed.scss
@@ -94,6 +94,11 @@
   &__transcript-text {
     color: $color__white;
     margin-top: 2rem;
+
+    &:focus {
+      outline: 0.313rem solid $color__focus-blue-outline-dark-bg;
+      outline-offset: 0.313rem;
+    }
   }
 }
 

--- a/templates/media/blocks/media-block--audio.html
+++ b/templates/media/blocks/media-block--audio.html
@@ -35,7 +35,7 @@
         <summary>
             <h4 class="media-embed__transcript-heading">Transcript</h4>
         </summary>
-        <div class="media-embed__transcript-text">
+        <div class="media-embed__transcript-text" tabindex="0">
             {{ value.transcript|richtext }}
         </div>
     </details>


### PR DESCRIPTION
Hi @matt-blair,

Could you have a look at this PR? Just some more FE changes that have been requested:

- Adding a fixed height and `overflow: scroll` to transcripts (otherwise they display the full length of the transcript which can increase the length of the page quite a bit)
- Inserting the transcript into the tab order because IE11 keyboard users can't scroll through the transcript if it isn't focusable
- Hiding the scrollbar on elements that have `overflow: scroll` on them (this was causing vertical and horizontal scrollbars to appear unnecessarily)
- Reducing the `z-index` of the media component (e.g. podcasts) so that it doesn't overlap with the cookie consent banner

Happy to hop on a call and go through them in more detail if you'd like. Thank you 👍 