### PR TITLE
Header fixes (including UN-231)

### DIFF
--- a/sass/includes/_header.scss
+++ b/sass/includes/_header.scss
@@ -89,6 +89,7 @@
             text-decoration: none;
             font-size: 1rem;
             border: 0;
+            margin: 0 0.3125rem;
           }
 
           @media only screen and (max-width: $screen__md) {

--- a/sass/includes/_login-status.scss
+++ b/sass/includes/_login-status.scss
@@ -3,6 +3,7 @@
   border-bottom: 0.06rem dotted $color__grey-7;
   text-align: right;
   padding: 0.5rem 1rem 0.5rem 1rem;
+  display: none; // Temporarily hidden - check with Simon W when to remove this
 
   &__link {
     font-weight: bold;


### PR DESCRIPTION
Related ticket(s):
UN-231: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-231&assignee=5df0cc4447c6b30ec90c99de

## About these changes

Hi @sdwilkes,

This PR hides the login status above the header banner. I've also added a small fix for the navigation menu items (added some extra margin) as I noticed there wasn't enough space around the `li`'s for the focus styles (the 5px outline) to display fully (screenshots below). Thank you 👍 

Without extra margin:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/29227105/178982969-58fcccee-0810-4e77-b0de-9556f11a1635.png">

With extra margin:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/29227105/178983025-939ba8a6-890f-40c5-bfc1-db384b537011.png">


## Dear reviewer, I promise I have:

- [ x] Checked things thoroughly myself before handing over to you.
- [ x] Included the ticket number in the PR title to help us keep track of changes
- [ x] Ensured that my PR does not include any irrelevant commits.
- [ x] Waited for all CI jobs to pass before requesting a review.
- [ x] Added/updated tests and documentation where relevant.
