### PR TITLE
DF-54: Tweak platform.sh cache config to fix cookie consent

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -10,6 +10,8 @@
             - sessionid
             - csrftoken
             - messages
+            - csrftoken
+            - cookies_policy
         headers:
             - Accept
             - Vary


### PR DESCRIPTION
Related ticket(s):
- https://national-archives.atlassian.net/browse/DF-54

## About these changes

Tweak platform.sh cache settings so that GTM conditionally renders successfully.