### PR TITLE
Adjust spacing rule for featured links

### DIFF
--- a/sass/includes/_promoted-item.scss
+++ b/sass/includes/_promoted-item.scss
@@ -1,6 +1,6 @@
 .promoted-item {
   border: 0.1875rem solid $color__dark;
-  margin-top: 2rem;
+  margin: 2rem 0;
 
   &__heading {
     font-weight: 400;


### PR DESCRIPTION
Hi @matt-blair,

This PR amends the margin rule for featured links (called `promoted-item` in the codebase) to resolve a spacing issue (screenshots below). Would it be possible to merge if all's okay? Thank you 👍 

Without margin adjustment:

<img width="896" alt="image" src="https://user-images.githubusercontent.com/29227105/179968703-ee988c76-82e3-4722-a3aa-3e5724dcd581.png">

With margin adjustment:

<img width="869" alt="image" src="https://user-images.githubusercontent.com/29227105/179968758-329d74e6-9675-43c9-958e-125abed60cbf.png">

