### PR TITLE
CHORE: Add title_safe, description_safe and arrangement_safe properties to Record

### DIFF
--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -211,7 +211,9 @@ class Record(DataLayerMixin, APIModel):
 
     @cached_property
     def arrangement_safe(self) -> SafeString:
-        stripped = bleach.clean(self.arrangement, tage=["mark"], attributes=[], strip=True)
+        stripped = bleach.clean(
+            self.arrangement, tage=["mark"], attributes=[], strip=True
+        )
         return mark_safe(stripped)
 
     @cached_property
@@ -253,11 +255,10 @@ class Record(DataLayerMixin, APIModel):
                 return item.get("value", "")
         # Extract interpretive content as a last resort
         try:
-            content_text =  strip_tags(self.get("source.content"))
+            content_text = strip_tags(self.get("source.content"))
             return Truncator(content_text).words(50, truncate="...")
         except ValueExtractionError:
             return ""
-
 
     @cached_property
     def description(self) -> str:
@@ -267,7 +268,9 @@ class Record(DataLayerMixin, APIModel):
 
     @cached_property
     def description_safe(self) -> SafeString:
-        stripped = bleach.clean(self.description, tags=["mark"], attributes=[], strip=True)
+        stripped = bleach.clean(
+            self.description, tags=["mark"], attributes=[], strip=True
+        )
         return mark_safe(stripped)
 
     @cached_property

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -10,7 +10,9 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import strip_tags
 from django.utils.safestring import SafeString, mark_safe
+from django.utils.text import Truncator
 
 import bleach
 
@@ -249,7 +251,13 @@ class Record(DataLayerMixin, APIModel):
         for item in description_items:
             if item.get("type", "") == "description" or len(description_items) == 1:
                 return item.get("value", "")
-        return ""
+        # Extract interpretive content as a last resort
+        try:
+            content_text =  strip_tags(self.get("source.content"))
+            return Truncator(content_text).words(50, truncate="...")
+        except ValueExtractionError:
+            return ""
+
 
     @cached_property
     def description(self) -> str:


### PR DESCRIPTION
These methods return safe HTML strings with only `<mark>` tags left intact - allowing for safe output in templates.

Using the `safe_title` in `__str()__` should remove a lot of the dodgy html output we see in choosers