### PR TITLE
Add IDs to all forms that didn't have one

### DIFF
--- a/etna/media/templates/wagtailmedia/chooser/chooser.html
+++ b/etna/media/templates/wagtailmedia/chooser/chooser.html
@@ -7,7 +7,7 @@
 
 <div class="tab-content">
     <section id="search" class="{% if not uploadforms.audio.errors and not uploadforms.video.errors %}active {% endif %}nice-padding">
-        <form class="media-search search-bar" action="{% url 'wagtailmedia:chooser' %}" method="GET" novalidate>
+        <form class="media-search search-bar" action="{% url 'wagtailmedia:chooser' %}" method="GET" novalidate id="analytics-chooser">
             <ul class="fields">
                 {% for field in searchform %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}

--- a/templates/search/blocks/search_landing_hero.html
+++ b/templates/search/blocks/search_landing_hero.html
@@ -1,4 +1,4 @@
-<form action="/search/featured" method="GET">
+<form action="/search/featured" method="GET" id="analytics-search-landing-hero">
     <div class="search-landing-hero">
         <div class="search-landing-hero__container">
             <h1 class="search-landing-hero__heading">Search</h1>

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -7,7 +7,7 @@
 {% block content %}
     <div class="long-filters">
         <h1 class="long-filters__heading">Select filters to apply to your results</h1>
-        <form method="get" action="{% url 'search-catalogue' %}" data-id="long-filter-form">
+        <form method="get" action="{% url 'search-catalogue' %}" data-id="long-filter-form" id="analytics-long-filter-form">
             {% prepare_form_for_partial_render form field_name %}
 
             <div class="long-filters__options">

--- a/templates/search/website_search.html
+++ b/templates/search/website_search.html
@@ -5,7 +5,7 @@
 {% load static %}
 
 {% block content %}
-    <form method="get" data-id="search-form">
+    <form method="get" data-id="search-form" id="analytics-search-form">
         {% with type="Website" %}
             {% include './blocks/search_results_hero.html' %}
         {% endwith %}


### PR DESCRIPTION
This has been requested by the metrics team. Whereas I've ensured all
IDs are prefixed with `analytics-` I have not changed any existing IDs
since these might be included in existing reports etc.