### PR TITLE
Remove card group record summary body

### DIFF
--- a/etna/collections/tests/test_models.py
+++ b/etna/collections/tests/test_models.py
@@ -168,15 +168,6 @@ class TestRecordDescriptionOverride(TestCase):
         )
 
     @responses.activate
-    def test_description_from_kong_is_rendered(self):
-        self.results_page.records.create(record_iaid="C123456")
-        self.results_page.save()
-
-        response = self.client.get("/results-page/")
-
-        self.assertContains(response, "This is the description from Kong")
-
-    @responses.activate
     def test_override_description_is_rendered(self):
         self.results_page.records.create(
             record_iaid="C123456", description="This is the overridden description"

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -67,6 +67,7 @@
     list-style: none;
     display: inline-block;
     width: 100%;
+    margin-bottom: 2rem;
     &__image {
       @extend .tna-card__image;
       border: 0.0625rem solid $color__black;
@@ -95,11 +96,6 @@
       &:focus {
         outline-offset: .2rem;
       }
-    }
-
-    &__body {
-      margin-left: 0.5rem;
-      margin-top: 0.5rem;
     }
  
     &__heading {

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -19,8 +19,5 @@
                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %}<span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>
-        <div class="card-group-record-summary__body">
-            <p>{{ record.description|striptags }}</p>
-        </div>
     </div>
 </li>

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -33,6 +33,5 @@
                 </div>
             </a>
         {% endif %}
-        <p class="card-group-record-summary__body">{{ record.description|striptags|escape|truncatewords:20 }}</p>
     </div>
 </li>


### PR DESCRIPTION
Related ticket(s): https://national-archives.atlassian.net/browse/DF-106?atlOrigin=eyJpIjoiZWQzNTIyOTMwNDQ3NDQ3NTlhODdmNjRjNzczNWY3NTMiLCJwIjoiaiJ9

## About these changes

Remove catalogue description from below the thumbnail. As requested in the Jira ticket (see comment from SW on 25 July.

## How to check these changes

On highlights pages there should be no text below thumbnails and, where there is no image, there should only be a title. 

## Dear reviewer, I promise I have:

- [x] Checked things thoroughly myself before handing over to you.
- [x] Included the ticket number in the PR title to help us keep track of changes
- [x] Ensured that my PR does not include any irrelevant commits.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.
