### PR TITLE
Df 334 data layer updates

### DIFF
--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -325,7 +325,15 @@ class BaseSearchView(KongAPIMixin, FormView):
             data["customDimension9"] = self.form.cleaned_data.get("q", "")
         else:
             data["customDimension9"] = "*"
-        data["customMetric1"] = self.api_result["responses"][0]["hits"]["total"]["value"]
+        total_count = 0
+        try:
+            for bucket in self.api_result["responses"][1]["aggregations"]["catalogueSource"]["buckets"]:
+                total_count += bucket["doc_count"]
+            if total_count > 10000:
+                total_count = 10001
+        except:
+            print("error")
+        data["customMetric1"] = total_count
         try:
             data["customMetric2"] = len(self.get_api_filter_aggregations(self.form))-1
         except:

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -319,7 +319,7 @@ class BaseSearchView(KongAPIMixin, FormView):
         try:
             group = self.get_api_filter_aggregations(self.form)
             group = group[-1].replace("group:", "")
-            data["customDimension8"] = self.__class__.__name__.replace("SearchView"," Results: ") + group[-1].replace("group:", "")
+            data["customDimension8"] = self.__class__.__name__.replace("SearchView"," Results: ") + group
         except:
             data["customDimension8"] = ""
         if self.form.cleaned_data.get("q", ""):
@@ -329,11 +329,12 @@ class BaseSearchView(KongAPIMixin, FormView):
         total_count = 0
         try:
             if group == "creator":
-                result = self.api_result["responses"][1]["aggregations"]["group"][0]
+                result = self.api_result["responses"][1]["aggregations"]["group"]["buckets"][0]["doc_count"]
+                total_count = result
             else:
                 result = self.api_result["responses"][1]["aggregations"]["catalogueSource"]["buckets"]
-            for bucket in result:
-                total_count += bucket["doc_count"]
+                for bucket in result:
+                    total_count += bucket["doc_count"]
             if total_count > 10000:
                 total_count = 10001
         except:

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -318,6 +318,7 @@ class BaseSearchView(KongAPIMixin, FormView):
         data["customDimension3"] = self.__class__.__name__
         try:
             group = self.get_api_filter_aggregations(self.form)
+            group = group[-1].replace("group:", "")
             data["customDimension8"] = self.__class__.__name__.replace("SearchView"," Results: ") + group[-1].replace("group:", "")
         except:
             data["customDimension8"] = ""
@@ -327,12 +328,16 @@ class BaseSearchView(KongAPIMixin, FormView):
             data["customDimension9"] = "*"
         total_count = 0
         try:
-            for bucket in self.api_result["responses"][1]["aggregations"]["catalogueSource"]["buckets"]:
+            if group == "creator":
+                result = self.api_result["responses"][1]["aggregations"]["group"][0]
+            else:
+                result = self.api_result["responses"][1]["aggregations"]["catalogueSource"]["buckets"]
+            for bucket in result:
                 total_count += bucket["doc_count"]
             if total_count > 10000:
                 total_count = 10001
         except:
-            print("error")
+            pass
         data["customMetric1"] = total_count
         try:
             data["customMetric2"] = len(self.get_api_filter_aggregations(self.form))-1

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -188,6 +188,10 @@ class SearchLandingView(BucketsMixin, TemplateView):
     template_name = "search/search.html"
     bucket_list = CATALOGUE_BUCKETS
 
+    def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
+        data = {"customDimension7": "test"}
+        return data
+
     def get_context_data(self, **kwargs):
         # Make empty search to fetch aggregations
         self.api_result = Record.api.client.search(
@@ -564,29 +568,29 @@ class WebsiteSearchView(BucketsMixin, BaseFilteredSearchView):
         """
         slugs = [
             result["_source"]
-            .get("@template", {})
-            .get("details", {})
-            .get("sourceUrl", "")
-            .rstrip("/")
-            .split("/")
-            .pop()
+                .get("@template", {})
+                .get("details", {})
+                .get("sourceUrl", "")
+                .rstrip("/")
+                .split("/")
+                .pop()
             for result in page.object_list
         ]
         # filter by slug for performance boost
         insights_page_by_url = {
             page.get_url(self.request): page
             for page in InsightsPage.objects.live()
-            .filter(slug__in=slugs)
-            .defer("body")
-            .select_related("teaser_image")
+                .filter(slug__in=slugs)
+                .defer("body")
+                .select_related("teaser_image")
         }
         page_list = []
         for result in page.object_list:
             url = (
                 result["_source"]
-                .get("@template", {})
-                .get("details", {})
-                .get("sourceUrl", "")
+                    .get("@template", {})
+                    .get("details", {})
+                    .get("sourceUrl", "")
             )
             if source_page := insights_page_by_url.get(urlparse(url).path, ""):
                 result["source_page"] = source_page
@@ -604,27 +608,27 @@ class WebsiteSearchView(BucketsMixin, BaseFilteredSearchView):
         """
         slugs = [
             result["_source"]
-            .get("@template", {})
-            .get("details", {})
-            .get("sourceUrl", "")
-            .rstrip("/")
-            .split("/")
-            .pop()
+                .get("@template", {})
+                .get("details", {})
+                .get("sourceUrl", "")
+                .rstrip("/")
+                .split("/")
+                .pop()
             for result in page.object_list
         ]
         results_page_by_url = {
             page.get_url(self.request): page
             for page in ResultsPage.objects.live()
-            .filter(slug__in=slugs)
-            .select_related("teaser_image")
+                .filter(slug__in=slugs)
+                .select_related("teaser_image")
         }
         page_list = []
         for result in page.object_list:
             url = (
                 result["_source"]
-                .get("@template", {})
-                .get("details", {})
-                .get("sourceUrl", "")
+                    .get("@template", {})
+                    .get("details", {})
+                    .get("sourceUrl", "")
             )
             if source_page := results_page_by_url.get(urlparse(url).path, ""):
                 result["source_page"] = source_page

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -5,7 +5,7 @@
 {% load search_tags %}
 
 {% block extra_gtm_js %}
-    {% render_gtm_datalayer page %}
+    {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
 {% load static %}
 

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 
 {% load humanize %}
+{% load datalayer_tags %}
 {% load search_tags %}
+
+{% block extra_gtm_js %}
+    {% render_gtm_datalayer page %}
+{% endblock extra_gtm_js %}
 {% load static %}
 
 {% block content %}

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -1,12 +1,8 @@
 {% extends "base.html" %}
 
 {% load humanize %}
-{% load datalayer_tags %}
 {% load search_tags %}
 
-{% block extra_gtm_js %}
-    {% render_gtm_datalayer view %}
-{% endblock extra_gtm_js %}
 {% load static %}
 
 {% block content %}

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -5,7 +5,7 @@
 {% load search_tags %}
 
 {% block extra_gtm_js %}
-    {% render_gtm_datalayer page %}
+    {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
 {% load static %}
 

--- a/templates/search/catalogue_search_long_filter_chooser.html
+++ b/templates/search/catalogue_search_long_filter_chooser.html
@@ -1,7 +1,12 @@
 {% extends "base.html" %}
 
 {% load humanize %}
+{% load datalayer_tags %}
 {% load search_tags %}
+
+{% block extra_gtm_js %}
+    {% render_gtm_datalayer page %}
+{% endblock extra_gtm_js %}
 {% load static %}
 
 {% block content %}

--- a/templates/search/featured_search.html
+++ b/templates/search/featured_search.html
@@ -4,7 +4,7 @@
 {% load search_tags %}
 
 {% block extra_gtm_js %}
-    {% render_gtm_datalayer page %}
+    {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
 {% load humanize %}
 

--- a/templates/search/featured_search.html
+++ b/templates/search/featured_search.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 
+{% load datalayer_tags %}
 {% load search_tags %}
+
+{% block extra_gtm_js %}
+    {% render_gtm_datalayer page %}
+{% endblock extra_gtm_js %}
 {% load humanize %}
 
 {% block content %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 
+
 {% load search_tags %}
+{% load datalayer_tags %}
+
+{% block extra_gtm_js %}
+    {% render_gtm_datalayer page %}
+{% endblock extra_gtm_js %}
 {% load humanize %}
 
 {% block content %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
-
+{% load alert_tags datalayer_tags %}
 
 {% load search_tags %}
-{% load datalayer_tags %}
+
 
 {% block extra_gtm_js %}
-    {% render_gtm_datalayer page %}
+    {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
 {% load humanize %}
 

--- a/templates/search/website_search.html
+++ b/templates/search/website_search.html
@@ -4,7 +4,7 @@
 {% load search_tags %}
 
 {% block extra_gtm_js %}
-    {% render_gtm_datalayer page %}
+    {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
 {% load humanize %}
 {% load static %}

--- a/templates/search/website_search.html
+++ b/templates/search/website_search.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 
+{% load datalayer_tags %}
 {% load search_tags %}
+
+{% block extra_gtm_js %}
+    {% render_gtm_datalayer page %}
+{% endblock extra_gtm_js %}
 {% load humanize %}
 {% load static %}
 


### PR DESCRIPTION
Related ticket(s):
(https://national-archives.atlassian.net/browse/DF-334)

## About these changes

Added data layer functionality to the search pages.
The ticket requested I add them to the long filter search page but following discussion with Helen and Beth we decided this could be added at a later stage.
We also decided that it would return the amount up to 10000. This is due to a current disparity in results. e.g. search term "james" no filters returns 1,044,366 according to the bucket, but there is in fact more than that as shown in all the filters etc. Because of this we decided it would be best to show the exact number up to 10000. Beyond that, show 10001. This can be changed later if need be.

## How to check these changes

Type "dataLayer" into the Google Dev Tools console, and it should return an array. Inside said array, will be the customDimensions mentioned in the ticket.

## Dear reviewer, I promise I have:

- [ ] Checked things thoroughly myself before handing over to you.
- [ ] Included the ticket number in the PR title to help us keep track of changes
- [ ] Ensured that my PR does not include any irrelevant commits.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.
