### PR TITLE
DF-333:Added level to use OR operator

### DIFF
--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -96,7 +96,7 @@ def prepare_filter_aggregations(items: Optional[list]) -> Optional[str]:
     subst = " "
     field_list_to_prepare = ["heldBy"]
     filter_prepared_list = []
-    fields_using_or_operator = ["heldBy", "collection"]
+    fields_using_or_operator = ["heldBy", "collection", "level"]
 
     for item in items:
         field, value = item.split(":", 1)

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -5,12 +5,14 @@ from typing import Any, List
 from django.contrib.humanize.templatetags.humanize import intcomma
 
 
-def forDjango(cls):
+def forTemplate(cls):
+    # Enum class call in template raises error and abort with empty string
+    # setting do_not_call_in_templates = True skips the call portion
     cls.do_not_call_in_templates = True
     return cls
 
 
-@forDjango
+@forTemplate
 class BucketKeys(Enum):
     TNA = "tna"
     NONTNA = "nonTna"

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -14,7 +14,6 @@ def forTemplate(cls):
 
 @forTemplate
 class BucketKeys(Enum):
-    TNA = "tna"
     NONTNA = "nonTna"
 
 

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -1,7 +1,19 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, List
 
 from django.contrib.humanize.templatetags.humanize import intcomma
+
+
+def forDjango(cls):
+    cls.do_not_call_in_templates = True
+    return cls
+
+
+@forDjango
+class BucketKeys(Enum):
+    TNA = "tna"
+    NONTNA = "nonTna"
 
 
 @dataclass

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -392,6 +392,18 @@ class ClientSearchTest(SimpleTestCase):
         )
 
     @responses.activate
+    def test_with_filter_level(self):
+        self.client.search(filter_aggregations=["level:Item", "level:Piece"])
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "https://kong.test/data/search?"
+            "filterAggregations=level%3AItem%3Aor&"
+            "filterAggregations=level%3APiece%3Aor",
+        )
+
+    @responses.activate
     def test_with_filter_keyword(self):
         self.client.search(filter_keyword="filter keyword")
 

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -18,6 +18,7 @@ from ..ciim.constants import (
     FEATURED_BUCKETS,
     WEBSITE_BUCKETS,
     Bucket,
+    BucketKeys,
     BucketList,
 )
 from ..ciim.paginator import APIPaginator
@@ -502,6 +503,10 @@ class CatalogueSearchView(BucketsMixin, BaseFilteredSearchView):
     template_name = "search/catalogue_search.html"
     title_base = "Catalogue results"
 
+    def get_context_data(self, **kwargs):
+        kwargs["bucketkeys"] = BucketKeys
+        return super().get_context_data(**kwargs)
+
 
 class CatalogueSearchLongFilterView(BaseFilteredSearchView):
     api_method_name = "search"
@@ -636,6 +641,7 @@ class WebsiteSearchView(BucketsMixin, BaseFilteredSearchView):
         page.object_list = page_list
 
     def get_context_data(self, **kwargs):
+        kwargs["bucketkeys"] = BucketKeys
         context = super().get_context_data(**kwargs)
         if filter_aggregation := self.request.GET.get("group", ""):
             if filter_aggregation == "insight" and "page" in context:

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -54,7 +54,9 @@
 
             {% include "search/includes/filter.html" with field=form.topic %}
 
-            {% include "search/includes/filter.html" with field=form.level %}
+            {% if form.group.value != 'nonTna' %}
+                {% include "search/includes/filter.html" with field=form.level %}
+            {% endif %}
 
             {% include "search/includes/filter.html" with field=form.closure %}
 

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -54,7 +54,7 @@
 
             {% include "search/includes/filter.html" with field=form.topic %}
 
-            {% if form.group.value != 'nonTna' %}
+            {% if form.group.value != bucketkeys.NONTNA.value %}
                 {% include "search/includes/filter.html" with field=form.level %}
             {% endif %}
 
@@ -84,7 +84,7 @@
             </div>
             {% endif %}
 
-            {% if form.group.value == 'nonTna' %}
+            {% if form.group.value == bucketkeys.NONTNA.value %}
                 {% include "search/includes/filter.html" with field=form.held_by %}
                 {% include "search/includes/filter.html" with field=form.catalogue_source %}
             {% endif %}


### PR DESCRIPTION
Related ticket(s):
- https://national-archives.atlassian.net/browse/DF-333

## About these changes

- Added level field to use OR operator when performing search for Level filter.
- Level filter is hidden for “Records at other UK archives”

## How to check these changes
Under catalogue search select more than one level - example Item+Piece

## Dear reviewer, I promise I have:

- [x] Checked things thoroughly myself before handing over to you.
- [x] Included the ticket number in the PR title to help us keep track of changes
- [x] Ensured that my PR does not include any irrelevant commits.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.
