### PR TITLE
UN-303 private insights hidden from index

### DIFF
--- a/etna/insights/blocks.py
+++ b/etna/insights/blocks.py
@@ -185,7 +185,7 @@ class FeaturedCollectionBlock(SectionDepthAwareStructBlock):
     items = PageListBlock(
         "insights.InsightsPage",
         exclude_drafts=True,
-        exclude_private=False,
+        exclude_private=True,
         select_related=["teaser_image"],
         min_num=3,
         max_num=9,

--- a/etna/insights/models.py
+++ b/etna/insights/models.py
@@ -43,7 +43,7 @@ class InsightsIndexPage(TeaserImageMixin, BasePage):
 
     def get_context(self, request):
         context = super().get_context(request)
-        insights_pages = self.get_children().live().specific()
+        insights_pages = self.get_children().public().live().specific()
         context["insights_pages"] = insights_pages
         return context
 


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/UN-303

## About these changes

Made it so private pages do not get displayed in the insights index page, this can be used to allow for a "live" review of the page by sending the link and password to someone, but will not show to the public on the index page.
They will still be selectable on the page chooser, but when published/saved it will remove itself. I'd like to make it throw an error if they try to publish a draft/private page but not sure how to do this currently.

## How to check these changes

Set an insights page to "private" in the Wagtail CMS and see if it appears on the index page.

## Dear reviewer, I promise I have:

- [x] Checked things thoroughly myself before handing over to you.
- [x] Included the ticket number in the PR title to help us keep track of changes
- [x] Ensured that my PR does not include any irrelevant commits.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.
