### PR TITLE
DF-358-django-upgrade: Revert due to DF-404-search-filters-issue

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -56,17 +56,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "backports.zoneinfo"
-version = "0.2.1"
-description = "Backport of the standard library zoneinfo module"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-tzdata = ["tzdata"]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.9.3"
 description = "Screen-scraping library"
@@ -238,17 +227,16 @@ dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "im
 
 [[package]]
 name = "django"
-version = "4.0"
-description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
+version = "3.2.15"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.6"
 
 [package.dependencies]
-asgiref = ">=3.4.1,<4"
-"backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
+asgiref = ">=3.3.2,<4"
+pytz = "*"
 sqlparse = ">=0.2.2"
-tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
@@ -458,7 +446,7 @@ python-versions = "*"
 python-dateutil = ">=2.8.1"
 
 [package.extras]
-dev = ["twine", "markdown", "flake8", "wheel"]
+dev = ["wheel", "flake8", "markdown", "twine"]
 
 [[package]]
 name = "gunicorn"
@@ -487,10 +475,10 @@ six = ">=1.9"
 webencodings = "*"
 
 [package.extras]
-all = ["genshi", "chardet (>=2.2)", "lxml"]
-chardet = ["chardet (>=2.2)"]
-genshi = ["genshi"]
 lxml = ["lxml"]
+genshi = ["genshi"]
+chardet = ["chardet (>=2.2)"]
+all = ["lxml", "chardet (>=2.2)", "genshi"]
 
 [[package]]
 name = "idna"
@@ -1161,7 +1149,7 @@ executing = "*"
 pure-eval = "*"
 
 [package.extras]
-tests = ["pytest", "typeguard", "pygments", "littleutils", "cython"]
+tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
 
 [[package]]
 name = "tablib"
@@ -1195,7 +1183,7 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-docs = ["mkdocs (>=1.1,<1.2)", "mkdocs-material (>=6.2,<6.3)"]
+docs = ["mkdocs-material (>=6.2,<6.3)", "mkdocs (>=1.1,<1.2)"]
 
 [[package]]
 name = "text-unidecode"
@@ -1239,14 +1227,6 @@ description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
-
-[[package]]
-name = "tzdata"
-version = "2022.2"
-description = "Provider of IANA time zone data"
-category = "main"
-optional = false
-python-versions = ">=2"
 
 [[package]]
 name = "urllib3"
@@ -1392,9 +1372,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
-build = ["wheel", "twine"]
+test = ["pytest-cov", "pytest"]
 docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
+build = ["twine", "wheel"]
 
 [[package]]
 name = "xlsxwriter"
@@ -1427,7 +1407,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d443618328cf0e1b3654bfc50c858fc96fcbdfa0a221dd48e3748a64928efffe"
+content-hash = "7935013ffddd114c30f4671c91491d9f037264a439bdf8e7d4a8acca4f3b47f5"
 
 [metadata.files]
 anyascii = []
@@ -1436,7 +1416,6 @@ asgiref = []
 asttokens = []
 async-timeout = []
 backcall = []
-"backports.zoneinfo" = []
 beautifulsoup4 = []
 black = []
 bleach = []
@@ -1533,7 +1512,6 @@ toml = []
 tomli = []
 traitlets = []
 typing-extensions = []
-tzdata = []
 urllib3 = []
 wagtail = []
 wagtail-font-awesome-svg = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Dan Bentley <dan@numiko.com>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 gunicorn = "^20.1.0"
-Django = "4.0"
+Django = "~3.2"
 wagtail = "~3.0"
 platformshconfig = "^2.4.0"
 pyquery = "^1.4.3"


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-358 django-upgrade
https://national-archives.atlassian.net/browse/DF-404 search-filters

## About these changes

Restores django=4.0 to django=~3.2

code changes applied in 4.0 compiled for 3.2.15 without errors
from django.urls import re_path
from django.utils.translation import gettext_lazy as _

## How to check these changes

Apply Level search filter for Online records - results shown in same bucket.
Apply Search text on Online records - results shown in same bucket.
Admin Record Chooser
Admin Site Menu messages

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
