### PR TITLE
hiding the toggle when no search result returned

### DIFF
--- a/templates/search/blocks/no_results.html
+++ b/templates/search/blocks/no_results.html
@@ -1,6 +1,11 @@
 <!--no results message for All results-->
 <!-- need to add in logic to check the number of results, if 0 then display the message-->
 
+<!--if no search results hide toggle-->
+<style>
+    .search-buckets__toggle-button {display: none;}
+</style>
+
 <div class="no-results">
     <h2 class="featured-search__heading">We did not find any results for your search</h2>
     <p class="search-results__explainer">Some record descriptions are much less detailed than others, so you may not find what you are looking for using a simple keyword search.</p> 

--- a/templates/search/blocks/search_results_hero.html
+++ b/templates/search/blocks/search_results_hero.html
@@ -47,3 +47,5 @@
         </nav>
     {% endwith %}
 </div>
+
+


### PR DESCRIPTION
Related ticket(s):
- https://national-archives.atlassian.net/browse/DF-383

## About these changes

css change, hides toggle on no results

## How to check these changes

check toggle does not display when no results returned

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly myself before handing over to reviewer.
- [ ] Included the ticket number in the PR title to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
