### PR TITLE
UN-350:added HTTP_CACHE_ENABLED env to enable/disable cache

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -4,7 +4,7 @@
     type: upstream
     upstream: "app:http"
     cache:
-        enabled: true
+        enabled: ${{env.HTTP_CACHE_ENABLED}}
         default_ttl: 300
         cookies:
             - sessionid


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/UN-350

## About these changes

Turning server http cache on/off via `env.HTTP_CACHE_ENABLED`, to see if wagtail admin changes are reflected immediately to end user

## How to check these changes

Check if wagtail admin changes are reflected immediately to end user

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
