### PR TITLE
UN-368 Hidden private cards inside Insights pages

### DIFF
--- a/etna/insights/models.py
+++ b/etna/insights/models.py
@@ -153,7 +153,8 @@ class InsightsPage(
 
         # Identify 'other' live pages with tags in common
         tag_match_ids = (
-            InsightsPage.objects.live()
+            InsightsPage.objects.public()
+            .live()
             .not_page(self)
             .filter(tagged_items__tag_id__in=tag_ids)
             .values_list("id", flat=True)
@@ -181,7 +182,8 @@ class InsightsPage(
         similarqueryset = list(self.similar_items)
 
         latestqueryset = list(
-            InsightsPage.objects.live()
+            InsightsPage.objects.public()
+            .live()
             .not_page(self)
             .select_related("hero_image", "topic", "time_period")
             .order_by("-first_published_at")


### PR DESCRIPTION
Related ticket(s):
(https://national-archives.atlassian.net/browse/UN-368)

## About these changes

I have added the .public() attribute in the search for insights, inside the insights pages for the cards at the bottom (i.e. related pages and the most recent pages). This is to hide private insights pages, which we do not want the public to see.

## How to check these changes

Set a page to private (some already are private) and then go on an insights page, and see if you can see the card for the page.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
