### PR TITLE
UN-367 Changed layout of explorer pages' featured insight

### DIFF
--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -107,17 +107,16 @@ class TopicExplorerPage(AlertMixin, TeaserImageMixin, MetadataPageMixin, BasePag
     another CategoryPage (to allow the user to make a more fine-grained choice) or a
     single ResultsPage (to output the results of their selection).
     """
-
-    sub_heading = models.CharField(max_length=200, blank=False)
-    body = StreamField(TopicExplorerPageStreamBlock, blank=True, use_json_field=True)
     featured_insight = models.ForeignKey(
         "insights.InsightsPage", blank=True, null=True, on_delete=models.SET_NULL
     )
+    sub_heading = models.CharField(max_length=200, blank=False)
+    body = StreamField(TopicExplorerPageStreamBlock, blank=True, use_json_field=True)
 
     content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
-        FieldPanel("body"),
         FieldPanel("featured_insight"),
+        FieldPanel("body"),
     ]
     promote_panels = MetadataPageMixin.promote_panels + TeaserImageMixin.promote_panels
     settings_panels = BasePage.settings_panels + AlertMixin.settings_panels
@@ -201,18 +200,18 @@ class TimePeriodExplorerPage(AlertMixin, TeaserImageMixin, MetadataPageMixin, Ba
     """
 
     sub_heading = models.CharField(max_length=200, blank=False)
+    featured_insight = models.ForeignKey(
+        "insights.InsightsPage", blank=True, null=True, on_delete=models.SET_NULL
+    )
     body = StreamField(
         TimePeriodExplorerPageStreamBlock, blank=True, use_json_field=True
     )
     start_year = models.IntegerField(blank=False)
     end_year = models.IntegerField(blank=False)
-    featured_insight = models.ForeignKey(
-        "insights.InsightsPage", blank=True, null=True, on_delete=models.SET_NULL
-    )
     content_panels = BasePage.content_panels + [
         FieldPanel("sub_heading"),
-        FieldPanel("body"),
         FieldPanel("featured_insight"),
+        FieldPanel("body"),
         FieldPanel("start_year"),
         FieldPanel("end_year"),
     ]

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -107,6 +107,7 @@ class TopicExplorerPage(AlertMixin, TeaserImageMixin, MetadataPageMixin, BasePag
     another CategoryPage (to allow the user to make a more fine-grained choice) or a
     single ResultsPage (to output the results of their selection).
     """
+
     featured_insight = models.ForeignKey(
         "insights.InsightsPage", blank=True, null=True, on_delete=models.SET_NULL
     )

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -7,6 +7,43 @@
 {% endblock %}
 {% block content %}
     {% include 'includes/generic-intro.html' %}
+    {% if page.featured_insight %}
+        <div class="container">
+            <div class="featured-insight">
+                {% if page.featured_insight.hero_image %}
+                    <div class="featured-insight__image">
+                        <picture>
+                            {% image page.featured_insight.hero_image fill-412x361 as hero %}
+                            <source media="(max-width: 480px)" srcset="{{ hero.url }}">
+                            {% image page.featured_insight.hero_image fill-510x351 as hero %}
+                            <source media="(max-width: 640px)" srcset="{{ hero.url }}">
+                            {% image page.featured_insight.hero_image fill-510x304 as hero %}
+                            <source media="(max-width: 768px)" srcset="{{ hero.url }}">
+                            {% image page.featured_insight.hero_image fill-345x495 as hero %}
+                            <source media="(max-width: 991px)" srcset="{{ hero.url }}">
+                            {% image page.featured_insight.hero_image fill-555x367 as hero %}
+                            <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
+                            {% if page.featured_insight.hero_image_decorative %}
+                                <img src="{{ hero.url }}" alt="" />
+                            {% else %}
+                                <img src="{{ hero.url }}" alt="{{page.featured_insight.hero_image_alt_text}}" />
+                            {% endif %}
+                        </picture>
+                    </div>
+                {% endif %}
+
+                <div class="featured-insight__description">
+                    <h2 class="featured-insight__heading">
+                        <small>{% trans "Spotlight on" %}</small>
+                        {{ page.featured_insight.title }}
+                    </h2>
+                    <p>{{ page.featured_insight.sub_heading }}</p>
+                    <a class="tna-button--dark" href="{% pageurl page.featured_insight %}">Read</a>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     <div class="container" data-container-name="time-period-explorer" id="analytics-time-period-explorer">
         <div class="row">
             <div class="col-md-12">
@@ -28,42 +65,6 @@
         {% endif %}
 
     </div>
-{% if page.featured_insight %}
-    <div class="container">
-        <div class="featured-insight">
-            {% if page.featured_insight.hero_image %}
-                <div class="featured-insight__image">
-                    <picture>
-                        {% image page.featured_insight.hero_image fill-412x361 as hero %}
-                        <source media="(max-width: 480px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-510x351 as hero %}
-                        <source media="(max-width: 640px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-510x304 as hero %}
-                        <source media="(max-width: 768px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-345x495 as hero %}
-                        <source media="(max-width: 991px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-555x367 as hero %}
-                        <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
-                        {% if page.featured_insight.hero_image_decorative %}
-                            <img src="{{ hero.url }}" alt="" />
-                        {% else %}
-                            <img src="{{ hero.url }}" alt="{{page.featured_insight.hero_image_alt_text}}" />
-                        {% endif %}
-                    </picture>
-                </div>
-            {% endif %}
-
-            <div class="featured-insight__description">
-                <h2 class="featured-insight__heading">
-                    <small>{% trans "Spotlight on" %}</small>
-                    {{ page.featured_insight.title }}
-                </h2>
-                <p>{{ page.featured_insight.sub_heading }}</p>
-                <a class="tna-button--dark" href="{% pageurl page.featured_insight %}">Read</a>
-            </div>
-        </div>
-    </div>
-{% endif %}
 
 {% endblock %}
 

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -7,27 +7,6 @@
 {% endblock %}
 {% block content %}
     {% include 'includes/generic-intro.html' %}
-    <div class="container" data-container-name="topic-explorer" id="analytics-topic-explorer">
-        <div class="row">
-            <div class="col-md-12">
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
-            </div>
-        </div>
-
-    {% if FEATURE_RELATED_INSIGHTS_ON_EXPLORE_PAGES %}
-        <div class="row">
-            <div class="col-md-12">
-                 {% for insights_page in page.related_insights %}
-                     <li>
-                       <a href="{% pageurl insights_page %}">{{ insights_page.title }}</a>
-                     </li>
-                  {% endfor %}
-            </div>
-        </div>
-    {% endif %}
-    </div>
     {% if page.featured_insight %}
             <div class="container">
                 <div class="featured-insight">
@@ -63,6 +42,28 @@
             </div>
         </div>
     {% endif %}
+    
+    <div class="container" data-container-name="topic-explorer" id="analytics-topic-explorer">
+        <div class="row">
+            <div class="col-md-12">
+                {% for block in page.body %}
+                    {% include_block block %}
+                {% endfor %}
+            </div>
+        </div>
+
+    {% if FEATURE_RELATED_INSIGHTS_ON_EXPLORE_PAGES %}
+        <div class="row">
+            <div class="col-md-12">
+                 {% for insights_page in page.related_insights %}
+                     <li>
+                       <a href="{% pageurl insights_page %}">{{ insights_page.title }}</a>
+                     </li>
+                  {% endfor %}
+            </div>
+        </div>
+    {% endif %}
+    </div>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Related ticket(s):
(https://national-archives.atlassian.net/browse/UN-367)

## About these changes

Moved the position of the featured insight to be above the collection.

## How to check these changes

Check that featured insight is above "body" in the CMS, and in the HTML that the featured insight highlight is above the collection highlights. This needs to be checked in both the topic explorer, and time period explorer pages.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
