### PR TITLE
feature/DF-391-move-sort-by-filter

### DIFF
--- a/sass/includes/search/_search-sort-view.scss
+++ b/sass/includes/search/_search-sort-view.scss
@@ -41,6 +41,19 @@
 
     }
 
+    &__mobile {
+        padding-bottom:1em;
+        @media only screen and (min-width: $screen__md) {
+            display:none;
+        }
+    }
+
+    &__desktop {
+        @media only screen and (max-width: $screen__md) {
+            display:none;
+        }
+    }
+
     &__list {
         display: flex;
         align-items: center;

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -1,7 +1,7 @@
 {% load search_tags %}
 
 <div class="search-sort-view">
-    <form action='' method="GET" class="search-sort-view__form" data-id="sort-form" id="catalogue-sort-form">
+    <form action='' method="GET" class="search-sort-view__form search-sort-view__mobile" data-id="sort-form" id="catalogue-sort-form">
         <h2 class="search-sort-view__heading">
             <label for="{{form.sort_by.id_for_label}}">Sort by</label>
         </h2>

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -1,5 +1,18 @@
 {% load search_tags %}
 
+<div class="search-sort-view">
+    <form action='' method="GET" class="search-sort-view__form" data-id="sort-form" id="catalogue-sort-form">
+        <h2 class="search-sort-view__heading">
+            <label for="{{form.sort_by.id_for_label}}">Sort by</label>
+        </h2>
+        {{ form.sort_by.errors }}
+        {{ form.sort_by }}
+
+        {{ 'sort_by'|include_hidden_fields:form }}
+
+        <input type="submit" value="Update" class="search-sort-view__form-submit">
+    </form>
+</div>
 
 <div class="search-filters">
     <h2 class="sr-only">Edit filters</h2>

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -1,7 +1,7 @@
 {% load search_tags %}
 
 <div class="search-sort-view">
-    <form action='' method="GET" class="search-sort-view__form" data-id="sort-form" id="catalogue-sort-form">
+    <form action='' method="GET" class="search-sort-view__form search-sort-view__desktop" data-id="sort-form" id="catalogue-sort-form">
 
         <h2 class="search-sort-view__heading">
            <label for="{{form.sort_by.id_for_label}}">Sort by</label>


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-391

## About these changes

Moving the 'Sort by' element into the filters section on mobile view

## How to check these changes
Check that you can sort search results on both mobile and desktop views


## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly myself before handing over to reviewer.
- [ ] Included the ticket number in the PR title to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
