### PR TITLE
Df 373 add copy to long filters pages

### DIFF
--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -127,4 +127,11 @@
         font-family: $font__open-sans;
         font-size: 1.5rem;
     }
+
+    &__intro {
+        font-family: $font__open-sans;
+        font-size: 1rem;
+    }
+
+
 }

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -49,13 +49,28 @@ export default function () {
 
     $longFiltersContainer.insertBefore($searchDiv, $longFiltersContainer.childNodes[0]);
 
-    //create a const for the paragraph
+
+
+    //create a const for the intro paragraph for collections
     const $introCopy = document.createElement('p');
     $introCopy.setAttribute('class', 'long-filters__intro');
     $introCopy.innerText = 'Filter by collections of records, which are typically organised by government department and consist of many items.';
 
-    //append intro paragraph
-    $filterCount.appendChild($introCopy);
+    //create a const for the intro paragraph for Held by
+    const $introCopyheldby = document.createElement('p');
+    $introCopyheldby.setAttribute('class', 'long-filters__intro');
+    $introCopyheldby.innerText = 'Filter by holding archives and other organisations, for example local archives or record offices.';
+
+    //check to see if it is 'collections' results or 'held by' results that is being searched for.
+    if (window.location.href.indexOf("collection") != -1) {
+        console.log('collections');
+        //append intro paragraph
+        $filterCount.appendChild($introCopy);
+    }
+    if (window.location.href.indexOf("held_by") != -1) {
+        //console.log('held by');
+        $filterCount.appendChild($introCopyheldby);
+    }
 
     const handleSearch = function(e) {
         const keyword = $searchBox.value.toLowerCase();

--- a/scripts/src/modules/search/search-long-filters.js
+++ b/scripts/src/modules/search/search-long-filters.js
@@ -49,6 +49,14 @@ export default function () {
 
     $longFiltersContainer.insertBefore($searchDiv, $longFiltersContainer.childNodes[0]);
 
+    //create a const for the paragraph
+    const $introCopy = document.createElement('p');
+    $introCopy.setAttribute('class', 'long-filters__intro');
+    $introCopy.innerText = 'Filter by collections of records, which are typically organised by government department and consist of many items.';
+
+    //append intro paragraph
+    $filterCount.appendChild($introCopy);
+
     const handleSearch = function(e) {
         const keyword = $searchBox.value.toLowerCase();
 


### PR DESCRIPTION
Related ticket(s):

https://national-archives.atlassian.net/browse/DF-373

## About these changes

Long Filters page will now display and Intro paragraph depending on searching in 'Collections' or 'Held by'

## How to check these changes

Go to Long Filter page for collections and for held by, confirm that the intro paragraph is correct

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly myself before handing over to reviewer.
- [ ] Included the ticket number in the PR title to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
