### PR TITLE
UN-372 - Added feature to cards on Insights page, as it was only on Insights Index

### DIFF
--- a/scripts/src/insights.js
+++ b/scripts/src/insights.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     add_analytics_data_card_position('.record-embed-no-image');
     add_analytics_data_card_position('.card-group-secondary-nav > a');
     add_analytics_data_card_position('.card-group-secondary-nav__body > a');
+    add_analytics_data_card_position('.card-group-secondary-nav__heading > a');
     audio_tracking();
     video_tracking();
     add_unique_ids();


### PR DESCRIPTION
Related ticket(s):
(https://national-archives.atlassian.net/browse/UN-372)

## About these changes

As in the title

## How to check these changes

Check that data-card-position is on the text link (as well as image link) of Insights cards at the bottom of an Insights page.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
