### PR TITLE
DF-352:Keep search term in dropdown when changing buckets

### DIFF
--- a/templates/search/blocks/catalogue_search_buckets.html
+++ b/templates/search/blocks/catalogue_search_buckets.html
@@ -16,6 +16,10 @@
 
         <input type="submit" value="Update" class="search-sort-view__form-submit">
 
+        {% if form.q.value %}
+            {{form.q.as_hidden}}
+        {% endif %}
+
     </form>
 </div>
 <!-- end new form element-->


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-352

## About these changes

Fixes : When you change a bucket in the drop down, it doesn’t keep your original search term, it switches to a  * wildcard search.

## How to check these changes


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
