### PR TITLE
Changing to teaser images for the insight_featured relationship

### DIFF
--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -10,18 +10,18 @@
     {% if page.featured_insight %}
         <div class="container">
             <div class="featured-insight">
-                {% if page.featured_insight.hero_image %}
+                {% if page.featured_insight.teaser_image %}
                     <div class="featured-insight__image">
                         <picture>
-                            {% image page.featured_insight.hero_image fill-412x361 as hero %}
+                            {% image page.featured_insight.teaser_image fill-412x361 as hero %}
                             <source media="(max-width: 480px)" srcset="{{ hero.url }}">
-                            {% image page.featured_insight.hero_image fill-510x351 as hero %}
+                            {% image page.featured_insight.teaser_image fill-510x351 as hero %}
                             <source media="(max-width: 640px)" srcset="{{ hero.url }}">
-                            {% image page.featured_insight.hero_image fill-510x304 as hero %}
+                            {% image page.featured_insight.teaser_image fill-510x304 as hero %}
                             <source media="(max-width: 768px)" srcset="{{ hero.url }}">
-                            {% image page.featured_insight.hero_image fill-345x495 as hero %}
+                            {% image page.featured_insight.teaser_image fill-345x495 as hero %}
                             <source media="(max-width: 991px)" srcset="{{ hero.url }}">
-                            {% image page.featured_insight.hero_image fill-555x367 as hero %}
+                            {% image page.featured_insight.teaser_image fill-555x367 as hero %}
                             <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
                             {% if page.featured_insight.hero_image_decorative %}
                                 <img src="{{ hero.url }}" alt="" />

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -10,18 +10,18 @@
     {% if page.featured_insight %}
             <div class="container">
                 <div class="featured-insight">
-                    {% if page.featured_insight.hero_image %}
+                    {% if page.featured_insight.teaser_image %}
                         <div class="featured-insight__image">
                             <picture>
-                                {% image page.featured_insight.hero_image fill-412x361 as hero %}
+                                {% image page.featured_insight.teaser_image fill-412x361 as hero %}
                                 <source media="(max-width: 480px)" srcset="{{ hero.url }}">
-                                {% image page.featured_insight.hero_image fill-510x351 as hero %}
+                                {% image page.featured_insight.teaser_image fill-510x351 as hero %}
                                 <source media="(max-width: 640px)" srcset="{{ hero.url }}">
-                                {% image page.featured_insight.hero_image fill-510x304 as hero %}
+                                {% image page.featured_insight.teaser_image fill-510x304 as hero %}
                                 <source media="(max-width: 768px)" srcset="{{ hero.url }}">
-                                {% image page.featured_insight.hero_image fill-345x495 as hero %}
+                                {% image page.featured_insight.teaser_image fill-345x495 as hero %}
                                 <source media="(max-width: 991px)" srcset="{{ hero.url }}">
-                                {% image page.featured_insight.hero_image fill-555x367 as hero %}
+                                {% image page.featured_insight.teaser_image fill-555x367 as hero %}
                                 <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
                                 {% if page.featured_insight.hero_image_decorative %}
                                     <img src="{{ hero.url }}" alt="" />

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -42,11 +42,11 @@
             {% if page.featured_insight.hero_image %}
                 <a href="{% pageurl page.featured_insight %}" class="featured-insight__image-link" tabindex="-1" aria-hidden="true" data-component-name="Featured Insight: {{ page.featured_insight.title }}" data-link-type="Image" {% if page.featured_insight.first_published_at.date > page.new_label_end_date.date %}data-label = "New"{%endif%}>
                     <picture>
-                        {% image page.featured_insight.hero_image fill-500x400-c100 as hero %}
+                        {% image page.featured_insight.teaser_image fill-500x400-c100 as hero %}
                         <source media="(max-width: 768px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-500x500-c100 as hero %}
+                        {% image page.featured_insight.teaser_image fill-500x500-c100 as hero %}
                         <source media="(max-width: 991px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-1000x600-c100 as hero %}
+                        {% image page.featured_insight.teaser_image fill-1000x600-c100 as hero %}
                         <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
 
                         {% if page.featured_insight.hero_image_decorative %}

--- a/templates/insights/insights_index_page.html
+++ b/templates/insights/insights_index_page.html
@@ -20,11 +20,11 @@
             {% if page.featured_insight.hero_image %}
                 <a href="{% pageurl page.featured_insight %}" class="featured-insight__image-link" tabindex="-1" aria-hidden="true" data-component-name="Featured Insight: {{ page.featured_insight.title }}" data-link-type="Image" {% if page.featured_insight.first_published_at.date > page.new_label_end_date.date %}data-label = "New"{%endif%}>
                     <picture>
-                        {% image page.featured_insight.hero_image fill-500x400-c100 as hero %}
+                        {% image page.featured_insight.teaser_image fill-500x400-c100 as hero %}
                         <source media="(max-width: 768px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-500x500-c100 as hero %}
+                        {% image page.featured_insight.teaser_image fill-500x500-c100 as hero %}
                         <source media="(max-width: 991px)" srcset="{{ hero.url }}">
-                        {% image page.featured_insight.hero_image fill-1000x600-c100 as hero %}
+                        {% image page.featured_insight.teaser_image fill-1000x600-c100 as hero %}
                         <source media="(max-width: 1200px)" srcset="{{ hero.url }}">
 
                         {% if page.featured_insight.hero_image_decorative %}


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/UN-432

## About these changes

<- Use teaser images instead of hero images in the templates with featured_insight relationship  ->



## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
