### PR TITLE
DF-334: datalayer filter count update

### DIFF
--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -338,7 +338,7 @@ class BaseFilteredSearchView(BaseSearchView):
     default_sort_order: str = SortOrder.ASC.value
     default_display: str = Display.LIST.value
 
-    # create a _var to avoid repetitive call to self.get_context_data().get(<VAR) in get_datalayer_data() to extract value
+    # create a _var to avoid repetitive call to self.get_context_data().get(<VAR>) in get_datalayer_data() to extract value
     _custom_metric2 = 0
 
     dynamic_choice_fields = (

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -293,9 +293,7 @@ class BaseSearchView(SearchDataLayerMixin, KongAPIMixin, FormView):
     def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
         data = super().get_datalayer_data(request)
         if self.form.cleaned_data.get("group"):
-            custom_dimension8 = (
-                self.search_tab + ": " + self.form.cleaned_data.get("group")
-            )
+            custom_dimension8 = self.search_tab + ": " + self.form.cleaned_data.get("group")
         else:
             custom_dimension8 = self.search_tab + ": " + "none"
 

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -293,7 +293,9 @@ class BaseSearchView(SearchDataLayerMixin, KongAPIMixin, FormView):
     def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
         data = super().get_datalayer_data(request)
         if self.form.cleaned_data.get("group"):
-            custom_dimension8 = self.search_tab + ": " + self.form.cleaned_data.get("group")
+            custom_dimension8 = (
+                self.search_tab + ": " + self.form.cleaned_data.get("group")
+            )
         else:
             custom_dimension8 = self.search_tab + ": " + "none"
 


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-334

## About these changes

- Updates customMetric2 to reflect selected filters count across sum of all selected filter values

- provisions the same count as a context var to be used for Mobile UI

## How to check these changes

Verify count in customMetric2 of datalayer for selected filter count in desktop view.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
