### PR TITLE
DF-457:Alt tag amend

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -16,6 +16,8 @@ def forTemplate(cls):
 class BucketKeys(Enum):
     NONTNA = "nonTna"
     CREATOR = "creator"
+    INSIGHT = "insight"
+    HIGHLIGHT = "highlight"
 
 
 @forTemplate
@@ -99,8 +101,8 @@ WEBSITE_BUCKETS = BucketList(
     [
         Bucket(key="blog", label="Blog posts"),
         Bucket(key="researchGuide", label="Research Guides"),
-        Bucket(key="insight", label="Insights"),
-        Bucket(key="highlight", label="Highlights"),
+        Bucket(key=BucketKeys.INSIGHT.value, label="Insights"),
+        Bucket(key=BucketKeys.HIGHLIGHT.value, label="Highlights"),
         Bucket(key="audio", label="Audio"),
         Bucket(key="video", label="Video"),
     ]
@@ -113,7 +115,7 @@ FEATURED_BUCKETS = BucketList(
         Bucket(key="creator", label="Record creators"),
         Bucket(key="blog", label="Blogs"),
         Bucket(key="researchGuide", label="Research Guides"),
-        Bucket(key="insight", label="Stories from the collection"),
+        Bucket(key=BucketKeys.INSIGHT.value, label="Stories from the collection"),
     ]
 )
 

--- a/etna/search/templatetags/search_tags.py
+++ b/etna/search/templatetags/search_tags.py
@@ -218,3 +218,12 @@ def search_title(search_tab) -> str:
     elif search_tab == SearchTabs.WEBSITE.value:
         label = "Website search results"
     return label
+
+
+@register.simple_tag
+def extended_in_operator(lhs_operand, *rhs_operand_list) -> bool:
+    """
+    Input params are template tags
+    Returns True when rhs_operand_list contains lhs_operand value, False otherwise
+    """
+    return (lhs_operand in rhs_operand_list) or False

--- a/etna/search/tests/test_search_tags.py
+++ b/etna/search/tests/test_search_tags.py
@@ -1,6 +1,10 @@
 from django.test import RequestFactory, SimpleTestCase
 
-from ..templatetags.search_tags import query_string_exclude, query_string_include
+from ..templatetags.search_tags import (
+    extended_in_operator,
+    query_string_exclude,
+    query_string_include,
+)
 
 
 class QueryStringTest(SimpleTestCase):
@@ -57,3 +61,32 @@ class QueryStringExcludeTest(SimpleTestCase):
         result = query_string_exclude(context, "page", "1")
 
         self.assertEqual(result, "test=true")
+
+
+class TestExtendedInOperator(SimpleTestCase):
+    def test_extended_in_operator(self):
+        for label, value, expected in (
+            (
+                "test_match_notfound",
+                ("a", "b", "c"),
+                False,
+            ),
+            (
+                "test_match_found",
+                ("c", "b", "c"),
+                True,
+            ),
+            (
+                "test_none_found",
+                (None, "b", None),
+                True,
+            ),
+            (
+                "test_none_not_found",
+                (None, "b", "c"),
+                False,
+            ),
+        ):
+            with self.subTest(label):
+                result = extended_in_operator(value[0], value[1], value[2])
+                self.assertEqual(result, expected)

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -1,9 +1,13 @@
 {% load wagtailimages_tags %}
+{% load search_tags %}
 
-{% image record.source_page.teaser_image fill-288x172 as teaser_image_small %}
-{% image record.source_page.teaser_image fill-328x196 as teaser_image_medium %}
-{% image record.source_page.teaser_image fill-348x208 as teaser_image_large %}
-{% image record.source_page.teaser_image fill-508x304 as teaser_image_extra_large %}
+{% extended_in_operator buckets.current.key bucketkeys.INSIGHT.value bucketkeys.HIGHLIGHT.value as apply_teaser_image %}
+{% if apply_teaser_image %}
+    {% image record.source_page.teaser_image fill-288x172 as teaser_image_small %}
+    {% image record.source_page.teaser_image fill-328x196 as teaser_image_medium %}
+    {% image record.source_page.teaser_image fill-348x208 as teaser_image_large %}
+    {% image record.source_page.teaser_image fill-508x304 as teaser_image_extra_large %}
+{% endif %}
 
 {% comment %} TODO downloadable, and record variables {% endcomment %}
 {% load search_tags records_tags static %}
@@ -18,7 +22,7 @@
     {% endif %}
     <div class="search-results__list-card-content">
         <h4 class="search-results__list-card-heading">
-            {% if teaser_image_large.url %}
+            {% if apply_teaser_image %}
                 <div class="search-results__list-card-full-width-image">
                     <picture>
                         <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -25,7 +25,7 @@
                         <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
                         <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
                         <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                        <img src="{{ teaser_image_large.url }}">
+                        <img src="{{ teaser_image_large.url }}" alt="">
                     </picture>
                 </div>
             {% endif %}

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -24,7 +24,7 @@
                         </picture>
                     </div>
 
-                </div>
+            </div>
 
 
             <div class="col-md-9 order-md-1">
@@ -99,6 +99,8 @@
                 </a>
             </div>
             {% endif %}
+        </div>
+    </div>
 </li>
 
 

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -1,9 +1,13 @@
 {% load wagtailimages_tags %}
+{% load search_tags %}
 
-{% image record.source_page.teaser_image fill-288x172 as teaser_image_small %}
-{% image record.source_page.teaser_image fill-328x196 as teaser_image_medium %}
-{% image record.source_page.teaser_image fill-348x208 as teaser_image_large %}
-{% image record.source_page.teaser_image fill-508x304 as teaser_image_extra_large %}
+{% extended_in_operator buckets.current.key bucketkeys.INSIGHT.value bucketkeys.HIGHLIGHT.value as apply_teaser_image %}
+{% if apply_teaser_image %}
+    {% image record.source_page.teaser_image fill-288x172 as teaser_image_small %}
+    {% image record.source_page.teaser_image fill-328x196 as teaser_image_medium %}
+    {% image record.source_page.teaser_image fill-348x208 as teaser_image_large %}
+    {% image record.source_page.teaser_image fill-508x304 as teaser_image_extra_large %}
+{% endif %}
 
 {% comment %} TODO downloadable, and record variables {% endcomment %}
 {% load search_tags records_tags static %}
@@ -12,7 +16,7 @@
     <div class="search-results__list-card-content">
         <div class="row">
             <div class="col-md-3 order-md-2">
-
+                {% if apply_teaser_image %}
                     <div class="search-results__list-card-image">
                         <picture>
                             <source media="(max-width: 480px)" srcset="{{ teaser_image_small }}">
@@ -23,7 +27,7 @@
                             <img src="{{ teaser_image_large.url }}" alt="" class="card-group-secondary-nav__image-fallback"/>
                         </picture>
                     </div>
-
+                {% endif %}
             </div>
 
 

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -20,7 +20,7 @@
                             <source media="(max-width: 768px)" srcset="{{ teaser_image_medium }}">
                             <source media="(max-width: 991px)" srcset="{{ teaser_image_large }}">
                             <source media="(max-width: 1200px)" srcset="{{ teaser_image_large }}">
-                            <img src="{{ teaser_image_large.url }}" alt="{{ record|record_title}}" class="card-group-secondary-nav__image-fallback"/>
+                            <img src="{{ teaser_image_large.url }}" alt="" class="card-group-secondary-nav__image-fallback"/>
                         </picture>
                     </div>
 


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-457

## About these changes

- Fixed missing divs
- Removed problematic alt value, added alt without value to grid template
- Restore and Update condition for teaser image
- To look into further to refactor constants using bucket keys : created DF-470 (as mentioned in the DF-457 )to address this bit.

## How to check these changes
ALT value should not appear for any search results.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
