### PR TITLE
DF-502 : update to data-link-type for mobile search

### DIFF
--- a/scripts/src/modules/search/mobile-filter-expander-enhanced.js
+++ b/scripts/src/modules/search/mobile-filter-expander-enhanced.js
@@ -24,7 +24,7 @@ export default function() {
     $showHideButton.setAttribute('aria-expanded', false);
     $showHideButton.setAttribute('aria-controls', 'searchFilterContainer');
     $showHideButton.setAttribute('aria-label', 'Show or hide filters');
-    $showHideButton.setAttribute('data-link-type', 'Link');
+    $showHideButton.setAttribute('data-link-type', 'Mobile Button');
     $showHideButton.setAttribute('data-link', 'Show search filters');
     $showHideButton.hidden = true;
     $main.insertBefore($showHideButton, $searchGrid);


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-502

## About these changes

Changing the value of data-link-type on mobile search

## How to check these changes

Conduct a search, any search.
Press F12, or right-click and Inspect, and change to Mobile display using the Responsive design tool.
Right-click the Filter button and select Inspect - does the data-link-type = ”mobile button”?

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
