### PR TITLE
UN 466: Update font on the error pages

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -21,6 +21,15 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap"
             rel="stylesheet">
+
+        {# Adobe Fonts #}
+        <link rel="preconnect" href="https://use.typekit.net">
+        <link rel="stylesheet" href="https://use.typekit.net/hkj3kuz.css">
+
+        {# Favicon #}
+        <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+        <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+
         <script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';</script>
     </head>
 

--- a/templates/500.html
+++ b/templates/500.html
@@ -22,6 +22,14 @@
         {% if cookies_permitted %}
             {% include 'includes/gtm-script.html' %}
         {% endif %}
+
+        {# Adobe Fonts #}
+        <link rel="preconnect" href="https://use.typekit.net">
+        <link rel="stylesheet" href="https://use.typekit.net/hkj3kuz.css">
+
+        {# Favicon #}
+        <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+        <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
     </head>
     <body>
         {% if show_cookie_notice %}

--- a/templates/503.html
+++ b/templates/503.html
@@ -21,6 +21,15 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap"
             rel="stylesheet">
+
+        {# Adobe Fonts #}
+        <link rel="preconnect" href="https://use.typekit.net">
+        <link rel="stylesheet" href="https://use.typekit.net/hkj3kuz.css">
+    
+        {# Favicon #}
+        <link rel="shortcut icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+        <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.png' %}">
+
         <script>document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';</script>
     </head>
 


### PR DESCRIPTION
Related ticket(s):
(https://national-archives.atlassian.net/browse/UN-466)

## About these changes

Added correct font to the 404, 500, and 503 error pages.
Also added page icons

## How to check these changes

Go to localhost:8000/404, localhost:8000/500, localhost:8000/503 and see that font is different to the one currently shown on develop/beta.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly myself before handing over to reviewer.
- [x] Included the ticket number in the PR title to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer

Once PR is merged, check and arrange to deploy on platform-sh.
