### PR TITLE
CHORE: Fix Reference to `PageRevision` in data migration

### DIFF
--- a/etna/insights/migrations/0036_migrate_insights_body_content_to_content_sections.py
+++ b/etna/insights/migrations/0036_migrate_insights_body_content_to_content_sections.py
@@ -6,7 +6,7 @@ from django.db import migrations
 
 def migrate_forwards(apps, schema_editor):
     InsightsPage = apps.get_model("insights", "InsightsPage")
-    PageRevision = apps.get_model("wagtailcore", "PageRevision")
+    Revision = apps.get_model("wagtailcore", "Revision")
     for page in InsightsPage.objects.only("id", "title", "body").iterator():
         new_content = []
         current_section_heading = None
@@ -103,7 +103,7 @@ def migrate_forwards(apps, schema_editor):
 
         # Update the page's latest revision, so that changes 'stick' in the editor
         latest_revision = (
-            PageRevision.objects.filter(page_id=page.id).order_by("-created_at").first()
+            Revision.objects.filter(page_id=page.id).order_by("-created_at").first()
         )
         if latest_revision:
             revision_content = json.loads(latest_revision.content_json)

--- a/etna/insights/migrations/0036_migrate_insights_body_content_to_content_sections.py
+++ b/etna/insights/migrations/0036_migrate_insights_body_content_to_content_sections.py
@@ -114,6 +114,7 @@ def migrate_forwards(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ("wagtailcore", "0077_alter_revision_user"),
         ("insights", "0035_add_content_section_blocks_to_insights_body"),
     ]
 


### PR DESCRIPTION
We've noticed on other PRs that tests can fail due to app migrations running in an unpredictable order.

Previously, the data migration in the `insights` app would always run BEFORE the migration to rename the `PageRevision` model in wagtail - So, it was fine to carry on using that model name. However, when migration changes cause Django to run the wagtail migration BEFORE reaching ours, the model name is no longer valid, and we see the errors in CI again.

Because Django migrations do not have a way to specify "Run this migration BEFORE these other ones", but do have a way to specify "Run this migration AFTER these other ones", the safer/more consistant fix is to make sure our data migration runs AFTER the rename ones, and use the updates `Revision` model name so that the error goes away.

