### PR TITLE
DF-513:Make record attributes consistent with API response

### DIFF
--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -1,6 +1,6 @@
 # format <record_field_name> : <human readable label name>
 FIELD_LABELS = {
-    "title": "Title",
+    "summary_title": "Summary title",
     "reference_number": "Reference",
     "legal_status": "Legal status",
     "created_by": "Creator",

--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -6,7 +6,7 @@ FIELD_LABELS = {
     "created_by": "Creator",
     "description": "Description",
     "date_created": "Date",
-    "closure_status": "Closure status",
+    "access_condition": "Access conditions",
     "held_by": "Held by",
     "parent": "This record is in",
     "hierarchy": "Where am I in the catalogue?",

--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -5,7 +5,7 @@ FIELD_LABELS = {
     "legal_status": "Legal status",
     "created_by": "Creator",
     "description": "Description",
-    "origination_date": "Date",
+    "date_created": "Date",
     "closure_status": "Closure status",
     "held_by": "Held by",
     "parent": "This record is in",

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -41,7 +41,7 @@ class Record(DataLayerMixin, APIModel):
         return cls(response)
 
     def __str__(self):
-        return f"{self.title} ({self.iaid})"
+        return f"{self.summary_title} ({self.iaid})"
 
     def get(self, key: str, default: Optional[Any] = NOT_PROVIDED):
         """
@@ -163,7 +163,7 @@ class Record(DataLayerMixin, APIModel):
             return True
 
     @cached_property
-    def title(self) -> str:
+    def summary_title(self) -> str:
         try:
             return self.highlights["@template.details.summaryTitle"]
         except KeyError:
@@ -393,15 +393,15 @@ class Record(DataLayerMixin, APIModel):
             if (
                 ancestor.level_code == 3
                 and ancestor.has_reference_number()
-                and ancestor.title
+                and ancestor.summary_title
             ):
-                return f"{ancestor.reference_number} - {ancestor.title}"
+                return f"{ancestor.reference_number} - {ancestor.summary_title}"
         return ""
 
     @property
     def custom_dimension_14(self) -> str:
-        if self.has_reference_number() and self.title:
-            return f"{self.reference_number} - {self.title}"
+        if self.has_reference_number() and self.summary_title:
+            return f"{self.reference_number} - {self.summary_title}"
         return ""
 
     def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -259,13 +259,13 @@ class Record(DataLayerMixin, APIModel):
         return self.get("level.code", None)
 
     @cached_property
-    def availability_delivery_condition(self) -> str:
+    def delivery_option(self) -> str:
         return self.template.get("deliveryOption", "")
 
     @property
     def availability_condition_category(self) -> str:
         return settings.AVAILABILITY_CONDITION_CATEGORIES.get(
-            self.availability_delivery_condition, ""
+            self.delivery_option, ""
         )
 
     @cached_property
@@ -423,7 +423,7 @@ class Record(DataLayerMixin, APIModel):
             customDimension14=self.custom_dimension_14,
             customDimension15=self.catalogue_source,
             customDimension16=self.availability_condition_category,
-            customDimension17=self.availability_delivery_condition,
+            customDimension17=self.delivery_option,
         )
         return data
 

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -264,9 +264,7 @@ class Record(DataLayerMixin, APIModel):
 
     @property
     def availability_condition_category(self) -> str:
-        return settings.AVAILABILITY_CONDITION_CATEGORIES.get(
-            self.delivery_option, ""
-        )
+        return settings.AVAILABILITY_CONDITION_CATEGORIES.get(self.delivery_option, "")
 
     @cached_property
     def repo_summary_title(self) -> str:

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -182,7 +182,7 @@ class Record(DataLayerMixin, APIModel):
         return False
 
     @cached_property
-    def closure_status(self) -> str:
+    def access_condition(self) -> str:
         try:
             return self.template["accessCondition"]
         except KeyError:

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -247,7 +247,7 @@ class Record(DataLayerMixin, APIModel):
         return self.template.get("heldBy", "")
 
     @cached_property
-    def origination_date(self) -> str:
+    def date_created(self) -> str:
         return self.template.get("dateCreated", "")
 
     @cached_property

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -65,9 +65,9 @@ class RecordModelTests(SimpleTestCase):
         with self.assertRaises(ValueError):
             self.record.iaid
 
-    def test_title(self):
+    def test_summary_title(self):
         self.assertEqual(
-            self.record.title,
+            self.record.summary_title,
             "Law Officers' Department: Registered Files",
         )
 
@@ -118,7 +118,7 @@ class RecordModelTests(SimpleTestCase):
     def test_parent(self):
         r = self.record.parent
         self.assertEqual(
-            (r.iaid, r.reference_number, r.title),
+            (r.iaid, r.reference_number, r.summary_title),
             (
                 "C199",
                 "LO",
@@ -129,7 +129,7 @@ class RecordModelTests(SimpleTestCase):
     def test_hierarchy(self):
         self.assertEqual(
             [
-                (r.level_code, r.reference_number, r.title)
+                (r.level_code, r.reference_number, r.summary_title)
                 for r in self.record.hierarchy
             ],
             [
@@ -231,21 +231,21 @@ class RecordModelTests(SimpleTestCase):
     def test_next_record(self):
         r = self.record.next_record
         self.assertEqual(
-            (r.iaid, r.reference_number, r.title),
+            (r.iaid, r.reference_number, r.summary_title),
             ("C10298", "LO 1", "Law Officers' Department: Law Officers' Opinions"),
         )
 
     def test_previous_record(self):
         r = self.record.previous_record
         self.assertEqual(
-            (r.iaid, r.reference_number, r.title),
+            (r.iaid, r.reference_number, r.summary_title),
             ("C10296", "LO 3", "Law Officers' Department: Patents for Inventions"),
         )
 
     @unittest.skip("Data not supported for the json record")
     def test_related_records(self):
         self.assertEqual(
-            [(r.iaid, r.title) for r in self.record.related_records],
+            [(r.iaid, r.summary_title) for r in self.record.related_records],
             [
                 (
                     "C8981250",
@@ -258,7 +258,7 @@ class RecordModelTests(SimpleTestCase):
     @unittest.skip("Data not supported for the json record")
     def test_related_articles(self):
         self.assertEqual(
-            [(r.title, r.url) for r in self.record.related_articles],
+            [(r.summary_title, r.url) for r in self.record.related_articles],
             [
                 (
                     "Irish maps c.1558-c.1610",
@@ -391,7 +391,7 @@ class UnexpectedParsingIssueTest(TestCase):
         # reference_nubmers were skipped but now we're linking to the details
         # page using the iaid, these records should be present
         self.assertEqual(
-            [(r.iaid, r.title) for r in record.related_records],
+            [(r.iaid, r.summary_title) for r in record.related_records],
             [
                 ("C568", "Records of the Office of First Fruits and Tenths"),
             ],

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -166,9 +166,7 @@ class RecordModelTests(SimpleTestCase):
 
     @unittest.skip("Data not supported for the json record")
     def test_delivery_option(self):
-        self.assertEqual(
-            self.record.delivery_option, "DigitizedDiscovery"
-        )
+        self.assertEqual(self.record.delivery_option, "DigitizedDiscovery")
 
     @unittest.skip("Data not supported for the json record")
     def test_availability_delivery_surrogates(self):

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -165,9 +165,9 @@ class RecordModelTests(SimpleTestCase):
         self.assertEqual(self.record.is_digitised, False)
 
     @unittest.skip("Data not supported for the json record")
-    def test_availability_delivery_condition(self):
+    def test_delivery_option(self):
         self.assertEqual(
-            self.record.availability_delivery_condition, "DigitizedDiscovery"
+            self.record.delivery_option, "DigitizedDiscovery"
         )
 
     @unittest.skip("Data not supported for the json record")

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -106,8 +106,8 @@ class RecordModelTests(SimpleTestCase):
             ),
         )
 
-    def test_origination_date(self):
-        self.assertEqual(self.record.origination_date, "1885-1979")
+    def test_date_created(self):
+        self.assertEqual(self.record.date_created, "1885-1979")
 
     def test_legal_status(self):
         self.assertEqual(self.record.legal_status, "Public Record(s)")
@@ -353,7 +353,7 @@ class UnexpectedParsingIssueTest(TestCase):
 
         record = Record.api.fetch(iaid="C123456")
 
-        self.assertEqual(record.origination_date, "")
+        self.assertEqual(record.date_created, "")
 
     @responses.activate
     def test_related_record_with_no_identifier(self):

--- a/templates/articles/blocks/featured_record.html
+++ b/templates/articles/blocks/featured_record.html
@@ -16,8 +16,8 @@
 
             <h4 class="featured-record__standfirst">{{ value.title }}</h4>
 
-            {% if value.record.title %}
-                <p class="featured-record__title"><span class="sr-only">{{ 'title'|as_label }}:</span> {{ value.record.title }}</p>
+            {% if value.record.summary_title %}
+                <p class="featured-record__title"><span class="sr-only">{{ 'summary_title'|as_label }}:</span> {{ value.record.summary_title }}</p>
             {% endif %}
 
             <div class="featured-record__metadata">
@@ -31,7 +31,7 @@
                 {% endif %}
             </div>
 
-            <a class="tna-button--dark" href="{% record_url value.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Button" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>View <span class="sr-only">{{ value.record.title }}</span> in the catalogue{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
+            <a class="tna-button--dark" href="{% record_url value.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Button" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>View <span class="sr-only">{{ value.record.summary_title }}</span> in the catalogue{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
         </div>
     </div>
 </div>

--- a/templates/articles/blocks/featured_record.html
+++ b/templates/articles/blocks/featured_record.html
@@ -24,9 +24,9 @@
                 {% if value.record.reference_number %}
                     <p class="featured-record__reference">{{ 'reference_number'|as_label }}: {{ value.record.reference_number }}</p>
                 {% endif %}
-                {% if value.record.origination_date %}
+                {% if value.record.date_created %}
                     <p class="featured-record__date">
-                    {{ 'origination_date'|as_label }}: {{ value.record.origination_date }}
+                    {{ 'date_created'|as_label }}: {{ value.record.date_created }}
                     </p>
                 {% endif %}
             </div>

--- a/templates/articles/blocks/featured_records.html
+++ b/templates/articles/blocks/featured_records.html
@@ -19,7 +19,7 @@
                                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
                             </a>
                         </dt>
-                        <dd class="featured-records__list-item-description">{{ item.record.title|striptags }}</dd>
+                        <dd class="featured-records__list-item-description">{{ item.record.summary_title|striptags }}</dd>
                     </div>
                 {% endfor %}
             </dl>

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -8,14 +8,14 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|safe record.title|striptags %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary-no-image" data-card-title="{% firstof description_override|safe record.summary_title|striptags %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
                     {{ record.reference_number }} -
                 </span>
                 {% endif %}
-                {% firstof description_override|safe record.title|striptags %}
+                {% firstof description_override|safe record.summary_title|striptags %}
                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %}<span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>

--- a/templates/includes/card-group-record-summary.html
+++ b/templates/includes/card-group-record-summary.html
@@ -3,14 +3,14 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">
-        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{% firstof description_override|safe record.title|striptags %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
+        <a href="{% record_url record is_editorial=True %}" class="card-group-record-summary__link" data-card-type="card-group-record-summary" data-card-title="{% firstof description_override|safe record.summary_title|striptags %}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
             <p class="card-group-record-summary__heading">
                 {% if record.reference_number %}
                 <span class="sr-only">
                     {{ record.reference_number }} -
                 </span>
                 {% endif %}
-                {% firstof description_override|safe record.title|striptags %}
+                {% firstof description_override|safe record.summary_title|striptags %}
                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
             </p>
         </a>

--- a/templates/includes/records/hierarchy-full-item.html
+++ b/templates/includes/records/hierarchy-full-item.html
@@ -21,6 +21,6 @@
     </div>
     <div class="hierarchy-full-panel__text-container">
         <p class="hierarchy-full-panel__text-level">{% if is_current_item %}You are currently looking at{% else %}Within{% endif %} the {% if hierarchy_level %}{{ hierarchy_level|lower }}{% else %}UNAVAILABLE{% endif %}: <a href="{% record_url item %}">{{item.reference_number}}</a></p>
-        <p class="hierarchy-full-panel__text-title">{{item.title}}</p>
+        <p class="hierarchy-full-panel__text-title">{{item.summary_title}}</p>
     </div>
 </div>

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -105,7 +105,7 @@
                     </div>
                     <div class="hierarchy-full-panel__text-container">
                         <p class="hierarchy-full-panel__text-level">You are currently looking at the department: <a href="{% record_url record %}">{{record.reference_number}}</a></p>
-                        <p class="hierarchy-full-panel__text-title">{{record.title}}</p>
+                        <p class="hierarchy-full-panel__text-title">{{record.summary_title}}</p>
                     </div>
                 </div>
             {%endif%}

--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -9,10 +9,10 @@
                     <td id="analytics-record-reference">{{ page.reference_number }}</td>
                 </tr>
             {% endif %}
-            {% if page.origination_date %}
+            {% if page.date_created %}
                 <tr>
-                    <th scope="row">{{ 'origination_date'|as_label }}</th>
-                    <td>{{ page.origination_date }}</td>
+                    <th scope="row">{{ 'date_created'|as_label }}</th>
+                    <td>{{ page.date_created }}</td>
                 </tr>
             {% endif %}
             {% if page.description %}

--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -52,10 +52,10 @@
                     <td>{{ record.legal_status }}</td>
                 </tr>
             {% endif %}
-            {% if record.closure_status %}
+            {% if record.access_condition %}
                 <tr>
-                    <th scope="row">{{ 'closure_status'|as_label }}</th>
-                    <td>{{ record.closure_status }}</td>
+                    <th scope="row">{{ 'access_condition'|as_label }}</th>
+                    <td>{{ record.access_condition }}</td>
                 </tr>
             {% endif %}
         </tbody>

--- a/templates/includes/records/record-related-records.html
+++ b/templates/includes/records/record-related-records.html
@@ -6,7 +6,7 @@
         {# limit output to three related records #}
         {% for record in record.related_records|slice:":3" %}
             <li>
-                <a href="{% record_url record %}" data-link="{{ record.title }}">{{ record.title }}</a>
+                <a href="{% record_url record %}" data-link="{{ record.summary_title }}">{{ record.summary_title }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/templates/includes/records/record-series-panel.html
+++ b/templates/includes/records/record-series-panel.html
@@ -3,7 +3,7 @@
 
 <div class="series-panel">
     <div class="series-panel__container">
-        <h3 class="series-panel__heading"><span class="series-panel__reference">{{record.hierarchy.1.reference_number}}</span>{{record.hierarchy.1.title}}</h3>
+        <h3 class="series-panel__heading"><span class="series-panel__reference">{{record.hierarchy.1.reference_number}}</span>{{record.hierarchy.1.summary_title}}</h3>
         <p>See the series level description for more information about this record.</p>
         <a class="series-panel__link" href="{% record_url record.hierarchy.1 %}">View series description</a>
     </div>

--- a/templates/includes/records/record-title.html
+++ b/templates/includes/records/record-title.html
@@ -2,7 +2,7 @@
 
 <div class="record-title">
     <p class="record-title__description">You are viewing the catalogue description of the following item:</p>
-    {% if record.title %}
-        <h1 class="record-title__heading">{{ record.title }}</h1>
+    {% if record.summary_title %}
+        <h1 class="record-title__heading">{{ record.summary_title }}</h1>
     {% endif %}
 </div>


### PR DESCRIPTION
Related ticket(s):
https://national-archives.atlassian.net/browse/DF-513

## About these changes

Some record attributes are inconsistent with the API response attribute. This change is to make them consistent and apply them to the templates. 
**Making them consistent enables easier debug and maintenance.**

- created_date
- access_condition
- summary_title
- delivery_option

## How to check these changes

As mentioned in the ticket.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## For Reviewer/Developer

- Before merging PR

    `main` branch :

        - check PR merge tile begins with `release/<major.minor.patch>:<default/custom description>`
        - check PR merge tile begins with ticket number Ex `DF-XXX: Ticket name / short description`
        - select `Create a merge commit`

    `develop` branch:

        - check if merges into base branch are `not to be kept On Hold` and then proceed.
        - check PR merge tile begins with ticket number Ex `DF-XXX: Ticket name / short description`
        - select `Squash and merge`

- After merging PR:

  - check and arrange to deploy on platform-sh.
  - update status on JIRA ticket on deployment.
  - update slack on deployment progress of the JIRA ticket once deployed.
