### PR TITLE
UN-496: Record revealed content changes

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -341,7 +341,7 @@ class RecordArticlePage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro
                 strings.extend([item.translation_header, item.translation_text])
         return " ".join(strings)
 
-    @property
+    @cached_property
     def gallery_has_translations_transcriptions(self):
         """
         Returns boolean indicating whether this page has any gallery transcriptions or translations.
@@ -350,6 +350,7 @@ class RecordArticlePage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro
             if item.image.translation or item.image.transcription:
                 return True
         return False
+
 
 class PageGalleryImage(Orderable):
     page = ParentalKey(Page, on_delete=models.CASCADE, related_name="gallery_images")

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -341,6 +341,15 @@ class RecordArticlePage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro
                 strings.extend([item.translation_header, item.translation_text])
         return " ".join(strings)
 
+    @property
+    def gallery_has_translations_transcriptions(self):
+        """
+        Returns boolean indicating whether this page has any gallery transcriptions or translations.
+        """
+        for item in self.gallery_items.all():
+            if item.image.translation or item.image.transcription:
+                return True
+        return False
 
 class PageGalleryImage(Orderable):
     page = ParentalKey(Page, on_delete=models.CASCADE, related_name="gallery_images")

--- a/sass/includes/_card-grid.scss
+++ b/sass/includes/_card-grid.scss
@@ -11,13 +11,8 @@
     }
 
     &__title {
-        font-size: $h3-font-size;
-        font-weight: bold;
+        font-size: $h2-font-size;
+        font-weight: $font-weight-normal;
         padding: 0.5rem 0;
-
-        @media (min-width: map-get($grid-breakpoints, "lg")) {
-            font-size: $h2-font-size;
-        }
     }
-
 }

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -24,6 +24,11 @@
       column-gap: 3rem;
       grid-template-columns: 55% 45%;
     }
+
+    &--full-width {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   &__text {

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -131,20 +131,22 @@
   }
 
   &__image {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-    object-position: center;
+    max-width: 100%;
+    max-height: 100%;
     display: block;
-    max-height: 700px;
 
     &--preview {
       @media screen and (min-width: $screen__sm) {
-        max-width: 80%;
         max-height: 800px;
         margin: 0 auto;
       }
     }
+  }
+  
+  &__figure-image {
+      display: flex;
+      justify-content: center;
+      align-items: center;
   }
 
   &__tablist {

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -142,6 +142,7 @@
 
     &--preview {
       @media screen and (min-width: $screen__sm) {
+        max-width: 80%;
         max-height: 800px;
         margin: 0 auto;
       }

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -42,12 +42,25 @@
   }
 
   &__preview {
-    display: flex;
-    margin-left: auto;
-    margin-right: auto;
     margin-bottom: 4rem;
     display: block;
     position: relative;
+  }
+
+  &__container {
+    display: flex;
+    margin-left: auto;
+    margin-right: auto;
+
+    max-width: 100%;
+    max-height: 100%;
+    display: block;
+
+    @media screen and (min-width: $screen__sm) {
+      max-width: 80%;
+      max-height: 800px;
+      margin: 0 auto;
+    }
   }
 
   &__underline {
@@ -68,9 +81,10 @@
     padding-left: 0.5rem;
     margin-top: 0.5rem;
     font-weight: $font-weight-bold;
+
     p {
-    display: inline;
-    margin: 0;
+      display: inline;
+      margin: 0;
     }
 
     a {
@@ -100,7 +114,7 @@
     left: 50%;
     -webkit-transform: translateX(-50%);
     transform: translateX(-50%);
-    bottom: -5%;
+    bottom: -3%;
     cursor: pointer;
 
     &:hover {
@@ -122,7 +136,7 @@
       background-color: $color__white;
       color: $color__black;
       outline: 0.1875rem solid $color__white;
-      
+
       #{$root}__icon {
         fill: $color__dark;
       }
@@ -139,20 +153,12 @@
     max-width: 100%;
     max-height: 100%;
     display: block;
-
-    &--preview {
-      @media screen and (min-width: $screen__sm) {
-        max-width: 80%;
-        max-height: 800px;
-        margin: 0 auto;
-      }
-    }
   }
-  
+
   &__figure-image {
-      display: flex;
-      justify-content: center;
-      align-items: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   &__tablist {

--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -3,7 +3,7 @@
 {% block content %}
     {% include "includes/record-revealed.html" %}
     {% if page.gallery_items %}
-        {% include "includes/image_gallery.html" with gallery=page.gallery_items %}
+        {% include "includes/image_gallery.html" with gallery=page.gallery_items has_text=page.gallery_has_translations_transcriptions %}
     {% endif %}
     {% if page.record %}
         {% include "includes/record-matters.html" with record=page.record title="Why this record matters" page=page %}

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -7,105 +7,120 @@
                 {% with first_gallery_item=gallery.0 %}
                     {% image first_gallery_item.image fill-1200x700 format-webp as image_webp %}
                     <source srcset="{{ image_webp.url }}"
-                        type="image/webp"
-                        {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
+                            type="image/webp"
+                            {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
                     {% image first_gallery_item.image fill-1200x700 as image_png %}
                     <source srcset="{{ image_png.url }}"
-                        type="image/png"
-                        {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
+                            type="image/png"
+                            {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
                     {% image first_gallery_item.image fill-1200x700 as base_img %}
                     <img width="1200"
-                        height="700"
-                        src="{{ base_img.url }}"
-                        class="transcription__image transcription__image--preview"
-                        {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
+                         height="700"
+                         src="{{ base_img.url }}"
+                         class="transcription__image transcription__image--preview"
+                         {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
                 {% endwith %}
             </picture>
             {% include "static/images/icons/dashed-line.svg" with classes="transcription__underline" %}
             <button id="showButton" class="transcription__open">View images and transcripts</button>
-            </div>
-            <!--start of transcript element-->
-            {% for item in gallery %}
-                <div id="item-{{ forloop.counter }}">
-                    <p class="transcription__image-counter" tabindex="0">Image {{ forloop.counter }} of {{ gallery_length }}</p>
-                    <div class="transcription__content">
-                        <figure aria-labelledby="item-{{ forloop.counter }}-caption">
-                            <picture class="transcription__figure-image">
-                                {% image item.image original format-webp as image_webp %}
-                                <source srcset="{{ image_webp.url }}"
+        </div>
+        <!--start of transcript element-->
+        {% for item in gallery %}
+            <div id="item-{{ forloop.counter }}">
+                <p class="transcription__image-counter" tabindex="0">Image {{ forloop.counter }} of {{ gallery_length }}</p>
+                <div class="transcription__content {% if not item.image.transcription and not item.image.translation %}transcription__content--full-width{% endif %}">
+                    <figure aria-labelledby="item-{{ forloop.counter }}-caption">
+                        <picture class="transcription__figure-image">
+                            {% image item.image original format-webp as image_webp %}
+                            <source srcset="{{ image_webp.url }}"
                                     type="image/webp"
                                     {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>
-                                {% image item.image original format-png as image_png %}
-                                <source srcset="{{ image_png.url }}"
+                            {% image item.image original format-png as image_png %}
+                            <source srcset="{{ image_png.url }}"
                                     type="image/png"
                                     {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>
-                                {% image item.image original as base_img %}
-                                <img 
-                                    src="{{ base_img.url }}"
-                                    class="transcription__image"
-                                    {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>
-                            </picture>
-                            <figcaption class="transcription__caption" id="item-{{ forloop.counter }}-caption">{{ item.caption|richtext }}{% if item.image.record %} Image library ref: <a href="{% record_url item.image.record is_editorial=True %}">{{ item.image.record }}{% endif %}</a></figcaption>
-                        </figure>
-
-                        {# non-JS version #}
-                        <div class="transcription__text">
+                            {% image item.image original as base_img %}
+                            <img src="{{ base_img.url }}"
+                                 class="transcription__image"
+                                 {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>
+                        </picture>
+                        <figcaption class="transcription__caption"
+                                    id="item-{{ forloop.counter }}-caption">
+                            {{ item.caption|richtext }}
+                            {% if item.image.record %}
+                                Image library ref: <a href="{% record_url item.image.record is_editorial=True %}">{{ item.image.record }}
+                            {% endif %}
+                        </a>
+                    </figcaption>
+                </figure>
+                {# non-JS version #}
+                {% if item.image.transcription or item.image.translation %}
+                    <div class="transcription__text">
+                        {% if item.image.transcription %}
                             <h2>{{ item.image.transcription_heading }}</h2>
                             <p>{{ item.image.transcription|richtext }}</p>
-                            {% if item.image.translation %}
-                                <h2>{{ item.image.translation_heading }}</h2>
-                                <p>{{ item.image.translation|richtext }}</p>
-                            {% endif %}
-                        </div>
-                        {# JS version #}
-                        <div>
-                            <div role="tablist"
-                                aria-labelledby="tablist-1-{{ forloop.counter }}"
-                                class="transcription__tablist hidden">
+                        {% endif %}
+                        {% if item.image.translation %}
+                            <h2>{{ item.image.translation_heading }}</h2>
+                            <p>{{ item.image.translation|richtext }}</p>
+                        {% endif %}
+                    </div>
+                {% endif %}
+                {# JS version #}
+                {% if item.image.transcription or item.image.translation %}
+                    <div>
+                        <div role="tablist"
+                             aria-labelledby="tablist-1-{{ forloop.counter }}"
+                             class="transcription__tablist hidden">
+                            {% if item.image.transcription %}
                                 <button id="tab-1-{{ forloop.counter }}"
-                                    class="transcription__tab"
-                                    type="button"
-                                    role="tab"
-                                    aria-selected="true"
-                                    aria-controls="tabpanel-1-{{ forloop.counter }}">
+                                        class="transcription__tab"
+                                        type="button"
+                                        role="tab"
+                                        aria-selected="true"
+                                        aria-controls="tabpanel-1-{{ forloop.counter }}">
                                     <span>{{ item.image.transcription_heading }}</span>
                                 </button>
-                                {% if item.image.translation %}
-                                    <button id="tab-2-{{ forloop.counter }}"
+                            {% endif %}
+                            {% if item.image.translation %}
+                                <button id="tab-2-{{ forloop.counter }}"
                                         class="transcription__tab"
                                         type="button"
                                         role="tab"
                                         aria-selected="false"
                                         aria-controls="tabpanel-2-{{ forloop.counter }}"
                                         tabindex="-1">
-                                        <span>{{ item.image.translation_heading }}</span>
-                                    </button>
-                                {% endif %}
-                            </div>
-                            <div id="tabpanel-1-{{ forloop.counter }}"
-                                role="tabpanel"
-                                tabindex="0"
-                                aria-labelledby="tab-1-{{ forloop.counter }}"
-                                class="transcription__tabpanel hidden">
-                                <p>{{ item.image.transcription|richtext }}</p>
-                            </div>
-                            {% if item.image.translation %}
-                                <div id="tabpanel-2-{{ forloop.counter }}"
-                                    role="tabpanel"
-                                    tabindex="0"
-                                    aria-labelledby="tab-2-{{ forloop.counter }}"
-                                    class="transcription__tabpanel hidden">
-                                    <p>{{ item.image.translation|richtext }}</p>
-                                </div>
+                                    <span>{{ item.image.translation_heading }}</span>
+                                </button>
                             {% endif %}
                         </div>
+                        {% if item.image.transcription %}
+                            <div id="tabpanel-1-{{ forloop.counter }}"
+                                 role="tabpanel"
+                                 tabindex="0"
+                                 aria-labelledby="tab-1-{{ forloop.counter }}"
+                                 class="transcription__tabpanel hidden">
+                                <p>{{ item.image.transcription|richtext }}</p>
+                            </div>
+                        {% endif %}
+                        {% if item.image.translation %}
+                            <div id="tabpanel-2-{{ forloop.counter }}"
+                                 role="tabpanel"
+                                 tabindex="0"
+                                 aria-labelledby="tab-2-{{ forloop.counter }}"
+                                 class="transcription__tabpanel hidden">
+                                <p>{{ item.image.translation|richtext }}</p>
+                            </div>
+                        {% endif %}
                     </div>
-                </div>
-            {% endfor %}
-        {% endwith %}
-        <button class="transcription__close hidden" id="closeButton" type="button">
-            Close
-            {% include "static/images/fontawesome-svgs/x-mark.svg" with classes="transcription__icon" %}
-        </button>
-    </div>
-    <!--end of transcript element-->
+                {% endif %}
+            </div>
+        </div>
+    {% endfor %}
+{% endwith %}
+<button class="transcription__close hidden" id="closeButton" type="button">
+    Close
+    {% include "static/images/fontawesome-svgs/x-mark.svg" with classes="transcription__icon" %}
+</button>
+</div>
+<!--end of transcript element-->

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -22,7 +22,7 @@
                 {% endwith %}
             </picture>
             {% include "static/images/icons/dashed-line.svg" with classes="transcription__underline" %}
-            <button id="showButton" class="transcription__open">View images and transcripts</button>
+            <button id="showButton" class="transcription__open">View images{% if has_text %} and transcripts{% endif %}</button>
         </div>
         <!--start of transcript element-->
         {% for item in gallery %}

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -1,28 +1,33 @@
 {% load static wagtailimages_tags wagtailcore_tags records_tags %}
 <div class="transcription">
     <div class="transcription__preview hidden">
-        {% with gallery_length=gallery|length %}
-            <p class="transcription__image-counter">Image 1 of {{ gallery_length }}</p>
-            <picture>
-                {% with first_gallery_item=gallery.0 %}
-                    {% image first_gallery_item.image fill-1200x700 format-webp as image_webp %}
-                    <source srcset="{{ image_webp.url }}"
-                            type="image/webp"
-                            {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
-                    {% image first_gallery_item.image fill-1200x700 as image_png %}
-                    <source srcset="{{ image_png.url }}"
-                            type="image/png"
-                            {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
-                    {% image first_gallery_item.image fill-1200x700 as base_img %}
-                    <img width="1200"
-                         height="700"
-                         src="{{ base_img.url }}"
-                         class="transcription__image transcription__image--preview"
-                         {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
-                {% endwith %}
-            </picture>
-            {% include "static/images/icons/dashed-line.svg" with classes="transcription__underline" %}
-            <button id="showButton" class="transcription__open">View images{% if has_text %} and transcripts{% endif %}</button>
+        <div class="transcription__container">
+            {% with gallery_length=gallery|length %}
+                <p class="transcription__image-counter">Image 1 of {{ gallery_length }}</p>
+                <picture>
+                    {% with first_gallery_item=gallery.0 %}
+                        {% image first_gallery_item.image fill-1200x700 format-webp as image_webp %}
+                        <source srcset="{{ image_webp.url }}"
+                                type="image/webp"
+                                {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
+                        {% image first_gallery_item.image fill-1200x700 as image_png %}
+                        <source srcset="{{ image_png.url }}"
+                                type="image/png"
+                                {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
+                        {% image first_gallery_item.image fill-1200x700 as base_img %}
+                        <img width="1200"
+                             height="700"
+                             src="{{ base_img.url }}"
+                             class="transcription__image transcription__image--preview"
+                             {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
+                    {% endwith %}
+                </picture>
+                {% include "static/images/icons/dashed-line.svg" with classes="transcription__underline" %}
+                <button id="showButton" class="transcription__open">
+                    View images
+                    {% if has_text %}and transcripts{% endif %}
+                </button>
+            </div>
         </div>
         <!--start of transcript element-->
         {% for item in gallery %}

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -30,18 +30,17 @@
                     <p class="transcription__image-counter" tabindex="0">Image {{ forloop.counter }} of {{ gallery_length }}</p>
                     <div class="transcription__content">
                         <figure aria-labelledby="item-{{ forloop.counter }}-caption">
-                            <picture>
-                                {% image item.image fill-480x600 format-webp as image_webp %}
+                            <picture class="transcription__figure-image">
+                                {% image item.image original format-webp as image_webp %}
                                 <source srcset="{{ image_webp.url }}"
                                     type="image/webp"
                                     {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>
-                                {% image item.image fill-480x600 format-png as image_png %}
+                                {% image item.image original format-png as image_png %}
                                 <source srcset="{{ image_png.url }}"
                                     type="image/png"
                                     {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>
-                                {% image item.image fill-480x600 as base_img %}
-                                <img width="480"
-                                    height="600"
+                                {% image item.image original as base_img %}
+                                <img 
                                     src="{{ base_img.url }}"
                                     class="transcription__image"
                                     {% if item.alt_text %}alt="{{ item.alt_text }}"{% endif %}/>

--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -22,20 +22,22 @@
                 {% if page.about %}
                     <div id="readLessContent" class="hidden">
                         {% with about=page.about|richtext|truncatechars_html:300 %}
-                        {{ about }}
-                        <button id="readMoreButton" class="record-matters__plain-button {% if about|length <= 300 %}hidden{% endif %}" href="" aria-label="Expand to read more about this record">
-                            Read more
-                            {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}
-                        </button>
-                    {% endwith %}
+                            {{ about }}
+                            <button id="readMoreButton"
+                                    class="record-matters__plain-button {% if about|length <= 300 %}hidden{% endif %}"
+                                    href=""
+                                    aria-label="Expand to read more about this record">
+                                Read more
+                                {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}
+                            </button>
+                        {% endwith %}
                     </div>
                     <div id="readMoreContent">
                         {{ page.about|richtext }}
                         <button id="readLessButton"
                                 class="record-matters__plain-button hidden"
                                 type="button"
-                                aria-label="Close to read less about this record"
-                                >
+                                aria-label="Close to read less about this record">
                             Read less
                             {% include "static/images/fontawesome-svgs/circle-x-mark.svg" with classes="record-matters__svg" %}
                         </button>
@@ -57,8 +59,8 @@
                     <a class="tna-button--yellow tna-button--full-width"
                        href="{{ page.print_on_demand_link }}"
                        rel="noopener noreferrer">Buy an art print</a>
-                </div>
-            {% endif %}
+                {% endif %}
+            </div>
         </div>
     </div>
 </div>

--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -21,11 +21,13 @@
                 {% endif %}
                 {% if page.about %}
                     <div id="readLessContent" class="hidden">
-                        {{ page.about|richtext|truncatechars_html:300 }}
-                        <button id="readMoreButton" class="record-matters__plain-button {% if page.about|length <= 50 %}hidden{% endif %}" href="" aria-label="Expand to read more about this record">
+                        {% with about=page.about|richtext|truncatechars_html:300 %}
+                        {{ about }}
+                        <button id="readMoreButton" class="record-matters__plain-button {% if about|length <= 300 %}hidden{% endif %}" href="" aria-label="Expand to read more about this record">
                             Read more
                             {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}
                         </button>
+                    {% endwith %}
                     </div>
                     <div id="readMoreContent">
                         {{ page.about|richtext }}

--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -44,23 +44,25 @@
                     </div>
                 {% endif %}
             </div>
-            <div class="col-md-10 col-sm-12 record-matters__buttons">
-                {% if record %}
-                    <a class="tna-button--yellow tna-button--full-width"
-                       href="{% record_url record is_editorial=True %}"
-                       rel="noopener noreferrer">View record details</a>
-                {% endif %}
-                {% if page.image_library_link %}
-                    <a class="tna-button--yellow tna-button--full-width"
-                       href="{{ page.image_library_link }}"
-                       rel="noopener noreferrer">Use this image</a>
-                {% endif %}
-                {% if page.print_on_demand_link %}
-                    <a class="tna-button--yellow tna-button--full-width"
-                       href="{{ page.print_on_demand_link }}"
-                       rel="noopener noreferrer">Buy an art print</a>
-                {% endif %}
-            </div>
+            {% if record or page.image_library_link or page.print_on_demand_link %}
+                <div class="col-md-10 col-sm-12 record-matters__buttons">
+                    {% if record %}
+                        <a class="tna-button--yellow tna-button--full-width"
+                           href="{% record_url record is_editorial=True %}"
+                           rel="noopener noreferrer">View record details</a>
+                    {% endif %}
+                    {% if page.image_library_link %}
+                        <a class="tna-button--yellow tna-button--full-width"
+                           href="{{ page.image_library_link }}"
+                           rel="noopener noreferrer">Use this image</a>
+                    {% endif %}
+                    {% if page.print_on_demand_link %}
+                        <a class="tna-button--yellow tna-button--full-width"
+                           href="{{ page.print_on_demand_link }}"
+                           rel="noopener noreferrer">Buy an art print</a>
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -21,7 +21,7 @@
                 {% endif %}
                 {% if page.about %}
                     <div id="readLessContent" class="hidden">
-                        {{ page.about|richtext|truncatechars_html:50 }}
+                        {{ page.about|richtext|truncatechars_html:300 }}
                         <button id="readMoreButton" class="record-matters__plain-button {% if page.about|length <= 50 %}hidden{% endif %}" href="" aria-label="Expand to read more about this record">
                             Read more
                             {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}

--- a/templates/includes/record-revealed.html
+++ b/templates/includes/record-revealed.html
@@ -1,16 +1,16 @@
-{% load static wagtailimages_tags %}
+{% load static wagtailimages_tags wagtailcore_tags %}
 <div class="explore-intro">
     <div class="container">
         <div class="row">
             <div class="col-md-8 col-sm-12">
                 <p class="explore-intro__title explore-intro__title--meta">Record revealed</p>
                 <h1 class="explore-intro__title">{{ page.title }}</h1>
-                <p class="explore-intro__paragraph">{{ page.standfirst }}</p>
+                <p class="explore-intro__paragraph">{{ page.intro|richtext }}</p>
             </div>
             <div class="col-4 explore-intro__image">
                 {% if page.teaser_image %}
-                    {% image page.teaser_image fill-390x300 as teaser_image %}
-                    <img height=390 width=300 src="{{ teaser_image.url }}" alt="" />
+                    {% image page.teaser_image fill-390x390 as teaser_image %}
+                    <img height=390 width=390 src="{{ teaser_image.url }}" alt="" />
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-496

## About these changes

- Teaser images are now square instead of rectangular.
- non-preview images are now original size, although if displayed with text they're restricted to the max-width of the div to create as consistent sizing of content as possible.
- Logic added to allow for images to be added without transcriptions / translations. This displays the images as full-width / height (as much as possible).
- view images and transcirptions text now shows as "views images" if no transcriptions and translations are added.
- "Read more" in the record revealed only shows if is over 300 characters. Likewise truncation happens at this point.
- Fix the layout of the featured article button so it uses the correct colour scheme.
- "You maybe interested" and "why this record matters" headers are now the same font weight and size.

## How to check these changes
- Populate a RecordArticlePage model and inspect the changes, compare against the related designs in the ticket, although please note somem of these changes are not in the designs so please nitpick if you think the direction I've taken for any of them could be better.


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.
