### PR TITLE
[DF-556] Filter number indicator does not appear until after opening the filter dropdown

### DIFF
--- a/scripts/src/modules/search/mobile-filter-expander-enhanced.js
+++ b/scripts/src/modules/search/mobile-filter-expander-enhanced.js
@@ -17,13 +17,12 @@ export default function() {
         $showHideButton.innerHTML=$buttonHtml;
 
     } else {
-        // no filters selected
-        $showHideButton.innerHTML = 'Filters';
+        // no filters selected (always display number of active filters)
+        $showHideButton.innerHTML = 'Show filters<span class="filter-indicator">'+ $noOfFilters +'<span class="sr-only"> active</span></span>';
     }
     $showHideButton.classList.add('search-results__filter-button');
     $showHideButton.setAttribute('aria-expanded', false);
     $showHideButton.setAttribute('aria-controls', 'searchFilterContainer');
-    $showHideButton.setAttribute('aria-label', 'Show or hide filters');
     $showHideButton.setAttribute('data-link-type', 'Mobile Button');
     $showHideButton.setAttribute('data-link', 'Show search filters');
     $showHideButton.hidden = true;
@@ -42,8 +41,7 @@ export default function() {
             $showHideButton.innerHTML = 'Hide filters';
         }
         else {
-            $showHideButton.innerHTML = 'Filters<span class="filter-indicator">'+ $noOfFilters +'</span>';
-
+            $showHideButton.innerHTML = 'Show filters<span class="filter-indicator">'+ $noOfFilters +'<span class="sr-only"> active</span></span>';
         }
     });
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/projects/DF/boards/76?selectedIssue=DF-556

## About these changes

- Removes aria-label so SR users hear the button content (including number of active filters)
- Always show number of active filters (even if its 0) for users benefit

## How to check these changes

- Perform search on mobile view
- See that the filters button text is updated to 'Show filters' and now always shows number of active filters
- Inspect filters button to confirm the aria-label has been removed
- Test with Voiceover (or another SR) to check the button content & number of active filters are read aloud. Make sure the current state of the button is still announced correctly.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [  ] Added/updated tests and documentation where relevant. - N/A

## Merging a feature or bug fix?

1. Use the `Squash and merge` option to keep the target branch's commit history nice and clean.
2. Where relevant, include the ticket number in commit title, e.g. `DF-XXX: Ticket name / short description`.

## Merging a release branch?

1. Use the `Create a merge commit` option to preserve the original commit IDs.
2. Use the message format `release/<major.minor.patch>` when merging.

## Deployment guidance

1. Post to the appropriate Slack channel to check that it is okay to continue.
2. To start a deployment, push the relevant branch to the `platform` remote.
3. Update the appropriate Slack channel when the deployment is complete.
4. Update the status on the corresponding Jira ticket (where relevant).
