### PR TITLE
[DF-563] Bug fix: Select box width

### DIFF
--- a/sass/includes/search/_search-sort-view.scss
+++ b/sass/includes/search/_search-sort-view.scss
@@ -19,6 +19,7 @@
 
     &__form {
         margin-left: auto;
+        width: 100%;
 
         @media only screen and (max-width: $screen__md) {
             margin-left: 0;
@@ -137,6 +138,7 @@
         padding-right: 1rem;
         border-radius: 5px;
         background: #eeedf3;
+        min-height: 44px;
         width: 100%;
         margin-bottom:1rem;
     }

--- a/sass/includes/search/_search-sort-view.scss
+++ b/sass/includes/search/_search-sort-view.scss
@@ -19,10 +19,10 @@
 
     &__form {
         margin-left: auto;
-        width: 100%;
 
         @media only screen and (max-width: $screen__md) {
             margin-left: 0;
+            width: 100%;
         }
 
         &-select {

--- a/templates/search/blocks/catalogue_search_buckets.html
+++ b/templates/search/blocks/catalogue_search_buckets.html
@@ -8,7 +8,7 @@
         <h2 class="search-sort-view__heading">
             <label for="id-for-this-dropdown">Show results from:</label>
         </h2>
-        <select name="group" id="id-for-this-dropdown">
+        <select name="group" id="id-for-this-dropdown" class="search-sort-view__form-select">
             {% for bucket in buckets %}
                 {% if bucket.result_count != None %}
                     <option value="{{ bucket.key }}" {% if bucket.is_current %}selected{% endif %} >{{ bucket.label_with_count }}</option>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-563

## About these changes

Small bug fix to move the select box width change to the smaller breakpoint - currently it is applied at desktop and causing mis-alignment of the select box.

## How to check these changes

- Open catalogue search results page
- Check desktop and see the sort by filters are aligned correctly on the right-hand side
- Check mobile / tablet and see the sort by filters re-aligned correctly to full-width

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging a feature or bug fix?

1. Use the `Squash and merge` option to keep the target branch's commit history nice and clean.
2. Where relevant, include the ticket number in commit title, e.g. `DF-XXX: Ticket name / short description`.

## Merging a release branch?

1. Use the `Create a merge commit` option to preserve the original commit IDs.
2. Use the message format `release/<major.minor.patch>` when merging.

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
