### PR TITLE
UN-501: Remove "collapsed" by default ContentWarningMixin

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -120,7 +120,7 @@ class ArticlePage(
                     FieldPanel("custom_warning_text"),
                 ],
                 heading="Content Warning Options",
-                classname="collapsible collapsed",
+                classname="collapsible",
             ),
             FieldPanel("body"),
         ]
@@ -271,7 +271,7 @@ class RecordArticlePage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro
     content_panels = BasePageWithIntro.content_panels + [
         MultiFieldPanel(
             heading="Content Warning Options",
-            classname="collapsible collapsed",
+            classname="collapsible",
             children=[
                 FieldPanel("display_content_warning"),
                 FieldPanel("custom_warning_text"),


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-501

## About these changes

Removed `collapsed` class on the MultiFieldPanel on required articles pages.

## How to check these changes

Enter admin panel, edit an articles page - see if the Content Warning options section is un-collapsed/opened by default.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging a feature or bug fix?

1. Use the `Squash and merge` option to keep the target branch's commit history nice and clean.
2. Where relevant, include the ticket number in commit title, e.g. `DF-XXX: Ticket name / short description`.