### PR TITLE
[DF-583] Element 'input' not allowed as child of element 'ul'

### DIFF
--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -46,10 +46,10 @@
                 </a>
             {% endif %}
         </li>
-
-        {{ form.display.errors }}
-        {{ form.display.as_hidden }}
     </ul>
+
+    {{ form.display.errors }}
+    {{ form.display.as_hidden }}
 </div>
 
 <script>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/projects/DF/boards/76?selectedIssue=DF-583

## About these changes

Moves hidden form input fields (and error fields) outside of the `<ul>` element to avoid validation issues. 

## How to check these changes

- Visit search results page
- View page source
- Copy page code into w3 validator (https://validator.w3.org/)
- Run validator check
- See that the `Element 'input' not allowed as child of element 'ul'` validation issue is no longer present

**IMPORTANT:** I'm not 100% sure of the best way to test the way the errors display for the 'sort by' fields, so I'd appreciate if this could be tested by someone who knows this better than I do! Thank you! 

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant. n/a

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
