### PR TITLE
[584] Duplicate ID catalogue-sort-form

### DIFF
--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -1,7 +1,7 @@
 {% load search_tags %}
 
 <div class="search-sort-view">
-    <form method="GET" class="search-sort-view__form search-sort-view__mobile" data-id="sort-form" id="catalogue-sort-form">
+    <form method="GET" class="search-sort-view__form search-sort-view__mobile" data-id="sort-form" id="catalogue-sort-form-mobile">
         <h2 class="search-sort-view__heading">
             <label for="{{form.sort_by.id_for_label}}">Sort by</label>
         </h2>

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -2,7 +2,7 @@
 
 
 <div class="search-sort-view">
-    <form method="GET" class="search-sort-view__form search-sort-view__desktop" data-id="sort-form" id="catalogue-sort-form" search-type="{% with request.resolver_match.url_name as url_name  %} {% if url_name == 'search-featured' %} {{searchtabs.ALL.value}} {% elif url_name == 'search-catalogue' %}{{searchtabs.CATALOGUE.value}}{% elif url_name == 'search-website' %}
+    <form method="GET" class="search-sort-view__form search-sort-view__desktop" data-id="sort-form" id="catalogue-sort-form-desktop" search-type="{% with request.resolver_match.url_name as url_name  %} {% if url_name == 'search-featured' %} {{searchtabs.ALL.value}} {% elif url_name == 'search-catalogue' %}{{searchtabs.CATALOGUE.value}}{% elif url_name == 'search-website' %}
 {{searchtabs.WEBSITE.value}} {% endif %} {%endwith%}"  search-bucket="{{buckets.current.label}}" search-filter-name="Sort results" search-filter-value="">
 
         <h2 class="search-sort-view__heading">
@@ -60,8 +60,7 @@
         selectElement = document.querySelector('#id_sort_by');
         output = selectElement.value;
         //alert(output);
-        document.getElementById("catalogue-sort-form").setAttribute("search-filter-value",output);
-        
+        document.getElementById("catalogue-sort-form-desktop").setAttribute("search-filter-value",output);
     }
 
     getOption();


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/projects/DF/boards/76?selectedIssue=DF-584

## About these changes

- Adds unique ID for 'sort by' forms to differentiate mobile & desktop forms
- This also updates the ID for the search results sort by GTM tracking so this will also need double checking to make sure it's still pulling through the correct values

## How to check these changes

- Navigate to search results
- On desktop, inspect 'sort by' form and see that the ID has been updated to identify desktop form `id="catalogue-sort-form-desktop"`
- On mobile, inspect 'sort by' form and see that the ID has been updated to identify mobile form `id="catalogue-sort-form-mobile"`
- Test GTM tracking to make sure this is still pulling through as expected (one for Beth/Helen)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant. n/a

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
