### PR TITLE
UN-481:Fix-commented tna-toolkit.0.0.1.css to allow upgrade to Django4.1.X;Kong open beta API does not support media.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -45,7 +45,8 @@ hooks:
     export NVM_DIR="$HOME/.nvm"
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
-    wget https://raw.githubusercontent.com/nationalarchives/tna-frontend-design-toolkit/main/dist/css/tna-toolkit.0.0.1.css --directory-prefix templates/static/css/libraries/
+    # TODO commented to allow upgrade to Django 4.1.X;Kong open beta API does not support media. Re-enable/update once media is available.
+    # wget https://raw.githubusercontent.com/nationalarchives/tna-frontend-design-toolkit/main/dist/css/tna-toolkit.0.0.1.css --directory-prefix templates/static/css/libraries/
 
     nvm install v14.19.1
     nvm use v14.19.1

--- a/templates/base-images.html
+++ b/templates/base-images.html
@@ -21,7 +21,10 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
         {# Global stylesheets #}
+        {% comment %}     
+        # TODO commented to allow upgrade to Django 4.1.X;Kong open beta API does not support media. Re-enable/update once media is available.
         <link rel="stylesheet" type="text/css" href="{% static 'css/libraries/tna-toolkit.0.0.1.css' %}">
+        {% endcomment %}
         <link rel="stylesheet" type="text/css" href="{% static 'css/dist/etna.css' %}">
 
         {% block extra_css %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-481

## About these changes

Fixes `css/libraries/tna-toolkit.0.0.1.css.map' could not be found with <django.contrib.staticfiles.storage.ManifestStaticFilesStorage` on Django Upgrade; but also commented as Kong open beta API does not support media currently.

## How to check these changes

At the time of deployment to server.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
