### PR TITLE
[DF-586] Remove SR-only text

### DIFF
--- a/templates/search/blocks/search_pagination.html
+++ b/templates/search/blocks/search_pagination.html
@@ -7,8 +7,7 @@
     <ul class="pagination__list">
         {% if page.has_previous %}
         <li class="pagination__list-item">
-          <a class="pagination__page-chevron-previous" href="?{% query_string_include 'page' page.previous_page_number %}" data-link-type="Pagination" aria-label="Go to Previous Page" data-link="Previous page"><span
-                    class="sr-only">< Previous</span>&lt; Previous</a>
+          <a class="pagination__page-chevron-previous" href="?{% query_string_include 'page' page.previous_page_number %}" data-link-type="Pagination" aria-label="Go to Previous Page" data-link="Previous page">&lt; Previous</a>
         </li>
         {% else %}
         <li class="pagination__list-item">
@@ -21,14 +20,14 @@
                 <li class="pagination__list-item">
                     {% if page.number == i %}
                     <a class="pagination__page-link-current" href="?{% query_string_include 'page' i %}" aria-label="Current page, Page {{ i }}" aria-current="true" data-link-type="Pagination" data-link="{{ i }}">
-                        <span class="sr-only">Current page </span>{{ i }}
+                        {{ i }}
                     </a>
                     {% else %}
                     {% if i == page.paginator.ELLIPSIS %}
                     {{ i }}
                     {% else %}
                     <a class="pagination__page-link" href="?{% query_string_include 'page' i %}" data-link-type="Pagination" aria-label="Go to page {{ i }}" data-link="{{ i }}">
-                        <span class="sr-only">Page </span>{{ i }}
+                        {{ i }}
                     </a>
                     {% endif %}
                     {% endif %}
@@ -39,7 +38,7 @@
         {% if page.has_next %}
         <li class="pagination__list-item">
             <a class="pagination__page-chevron-next" href="?{% query_string_include 'page' page.next_page_number %}"
-               data-link="Next page" data-link-type="Pagination" aria-label="Go to Next Page">Next &gt;<span class="sr-only">Next page</span></a>
+               data-link="Next page" data-link-type="Pagination" aria-label="Go to Next Page">Next &gt;</a>
         </li>
         {% else %}
         <li class="pagination__list-item">

--- a/templates/search/blocks/search_pagination.html
+++ b/templates/search/blocks/search_pagination.html
@@ -8,11 +8,11 @@
         {% if page.has_previous %}
         <li class="pagination__list-item">
           <a class="pagination__page-chevron-previous" href="?{% query_string_include 'page' page.previous_page_number %}" data-link-type="Pagination" aria-label="Go to Previous Page" data-link="Previous page"><span
-                    class="sr-only">< Previous</span>< Previous</a>
+                    class="sr-only">< Previous</span>&lt; Previous</a>
         </li>
         {% else %}
         <li class="pagination__list-item">
-            <span class="pagination__page-chevron-previous--disabled">< Previous</span>
+            <span class="pagination__page-chevron-previous--disabled">&lt; Previous</span>
         </li>
         {% endif %}
         <li class="pagination__list-pages" aria-label="Page numbers">
@@ -39,11 +39,11 @@
         {% if page.has_next %}
         <li class="pagination__list-item">
             <a class="pagination__page-chevron-next" href="?{% query_string_include 'page' page.next_page_number %}"
-               data-link="Next page" data-link-type="Pagination" aria-label="Go to Next Page">Next ><span class="sr-only">Next page</span></a>
+               data-link="Next page" data-link-type="Pagination" aria-label="Go to Next Page">Next &gt;<span class="sr-only">Next page</span></a>
         </li>
         {% else %}
         <li class="pagination__list-item">
-            <span class="pagination__page-chevron-next--disabled">Next ></span>
+            <span class="pagination__page-chevron-next--disabled">Next &gt;</span>
         </li>
         {% endif %}
     </ul>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-586

## About these changes

An additional update to remove SR-only text on pagination labels. Each label already has an aria-label which takes precedence, so the SR-only text was redundant.

## How to check these changes

- Check the template and see the SR-only text has been removed
- Test search result pagination with screenreader to confirm that aria-label is read aloud and label text is ignored

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
