### PR TITLE
DF-596: Prevent stripping of HTML from record descriptions in detail view

### DIFF
--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -227,7 +227,7 @@ class Record(DataLayerMixin, APIModel):
         """
         Returns the records full description value with all HTML left intact.
         """
-        return mark_safe(self._get_raw_description(use_highlights=False))
+        return mark_safe(self._get_raw_description())
 
     @cached_property
     def listing_description(self) -> str:
@@ -236,7 +236,7 @@ class Record(DataLayerMixin, APIModel):
         anywhere. When highlight data is provided by the API, <mark> tags
         will be left in-tact, but and other HTML is stripped.
         """
-        if raw := self._get_raw_description(use_highlights=False):
+        if raw := self._get_raw_description(use_highlights=True):
             return mark_safe(strip_html(raw, preserve_marks=True))
         return ""
 

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -224,15 +224,28 @@ class Record(DataLayerMixin, APIModel):
 
     @cached_property
     def description(self) -> str:
-        if raw := self._get_raw_description():
+        """
+        Returns the records full description value with all HTML left intact.
+        """
+        return mark_safe(self._get_raw_description(use_highlights=False))
+
+    @cached_property
+    def listing_description(self) -> str:
+        """
+        Returns a version of the record's description that is safe to use
+        anywhere. When highlight data is provided by the API, <mark> tags
+        will be left in-tact, but and other HTML is stripped.
+        """
+        if raw := self._get_raw_description(use_highlights=False):
             return mark_safe(strip_html(raw, preserve_marks=True))
         return ""
 
-    def _get_raw_description(self) -> str:
-        try:
-            return "... ".join(self.highlights["@template.details.description"])
-        except KeyError:
-            pass
+    def _get_raw_description(self, use_highlights: bool = True) -> str:
+        if use_highlights:
+            try:
+                return "... ".join(self.highlights["@template.details.description"])
+            except KeyError:
+                pass
         try:
             return self.template["description"]
         except KeyError:
@@ -300,7 +313,6 @@ class Record(DataLayerMixin, APIModel):
 
     @cached_property
     def hierarchy(self) -> Tuple["Record"]:
-
         # TODO Leaving this here for potential later use for testing the data for the front-end aspects.
         # This is to create spoof data for the missing API data from K-int. Can be removed from code when
 

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -240,7 +240,7 @@ class Record(DataLayerMixin, APIModel):
             return mark_safe(strip_html(raw, preserve_marks=True))
         return ""
 
-    def _get_raw_description(self, use_highlights: bool = True) -> str:
+    def _get_raw_description(self, use_highlights: bool = False) -> str:
         if use_highlights:
             try:
                 return "... ".join(self.highlights["@template.details.description"])

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -154,6 +154,18 @@ class RecordModelTests(SimpleTestCase):
         self.assertEqual(
             self.record.description,
             (
+                '<span class="scopecontent"><p>This series contains papers concering a wide variety of legal matters referred '
+                "to the Law Officers for their advice or approval and includes applications for the "
+                "Attorney General's General Fiat for leave to appeal to the House of Lords in criminal "
+                "cases.</p><p>Also included are a number of opinions, more of which can be found in "
+                '<a class="extref" href="C10298">LO 3</a></p></span>'
+            ),
+        )
+
+    def test_listing_description(self):
+        self.assertEqual(
+            self.record.listing_description,
+            (
                 "\nThis series contains papers concering a wide variety of legal matters referred "
                 "to the Law Officers for their advice or approval and includes applications for the "
                 "Attorney General's General Fiat for leave to appeal to the House of Lords in criminal "

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -39,7 +39,7 @@
             </a>
         </h4>
         <p class="search-results__list-card-description">
-            {{ record.description }}
+            {{ record.listing_description }}
         </p>
         <ul class="search-results__list-card-metadata">
             {% if record.held_by %}

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -39,7 +39,7 @@
                 </h3>
 
                 <p class="search-results__list-card-description">
-                    {{ record.description }}
+                    {{ record.listing_description }}
                 </p>
 
                 <ul class="search-results__list-card-metadata">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-596

## About these changes

We rightly strip HTML from record descriptions in listings, where links and other HTML entities cause unnecessary complication for users. However, in certain circumstances, we want to display the full value as retrieved from the API, with any links etc left in-tact.

This PR changes the `description` property available for records, so that it no longer strips HTML. A new `listing_description` property is added to make the value available with the same treatment.

## How to check these changes

As per the example in the ticket, head to http://0.0.0.0:8000/catalogue/id/C18099/ locally and look out for the 'Description' value there. It should now include the link from the original value.

However, when you see the description in search results, it'll still be the safe/text-only version:
http://0.0.0.0:8000/search/catalogue/?q=www.firekills.gov.uk&group=tna

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
