### PR TITLE
Fix: RecordChoiceField.validate() and LazyRecord.__init__() still using old 'Manager' to access api

### DIFF
--- a/etna/records/fields.py
+++ b/etna/records/fields.py
@@ -7,6 +7,7 @@ from django.utils.functional import SimpleLazyObject
 
 from requests import HTTPError
 
+from .api import records_client
 from .models import Record
 from .widgets import RecordChooser
 
@@ -23,7 +24,7 @@ class LazyRecord(SimpleLazyObject):
         self.__dict__["iaid"] = iaid
 
         def _fetch_record():
-            return Record.api.fetch(iaid=iaid)
+            return records_client.fetch(iaid=iaid)
 
         super().__init__(_fetch_record)
 
@@ -53,7 +54,7 @@ class RecordChoiceField(CharField):
         if value in self.empty_values:
             return None
         try:
-            Record.api.fetch(iaid=value)
+            records_client.fetch(iaid=value)
         except HTTPError:
             raise ValidationError(
                 f"Record data could not be retrieved using iaid '{value}'.",


### PR DESCRIPTION
## About these changes

This issue was picked up in another piece of work: https://github.com/nationalarchives/ds-wagtail/pull/731/files/5a8225228352f4314cc6b0ffa4943661c12fe815#diff-30c282345332260c1c59165b3100c5301fb4efe3e7902eaecff52036a2289d19

## How to check these changes

You should be able to successfully choose a record for an image in Wagtail, save the image, then successfully edit the image again.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
