### PR TITLE
UN-494: Show character count for `teaser_text`

### DIFF
--- a/etna/core/static/admin/js/inputLengthIndicators.js
+++ b/etna/core/static/admin/js/inputLengthIndicators.js
@@ -40,7 +40,8 @@ const initializeLengthIndicator = function (input) {
     // Add hidden HTML element to display the count
     const lengthIndicator = document.createElement("div");
     lengthIndicator.className = lengthIndicatorClassname;
-    lengthIndicator.style.display = "none";
+    lengthIndicator.classList.add("w-help-text");
+    lengthIndicator.style.visibility = "hidden";
     input.after(lengthIndicator);
 
     // Add initial value to indicator
@@ -48,11 +49,11 @@ const initializeLengthIndicator = function (input) {
     updateLengthIndicator(lengthIndicator, charCount, maxChars);
 
     input.onfocus = function () {
-        lengthIndicator.style.display = "block";
+        lengthIndicator.style.visibility = "visible";
     };
 
     input.onblur = function () {
-        lengthIndicator.style.display = "none";
+        lengthIndicator.style.visibility = "hidden";
     };
 
     input.oninput = function () {

--- a/etna/core/static/admin/js/inputLengthIndicators.js
+++ b/etna/core/static/admin/js/inputLengthIndicators.js
@@ -22,16 +22,11 @@ const countChars = function (text) {
 const updateLengthIndicator = function (
     lengthIndicator,
     length,
-    maxChars = null,
+    maxChars,
 ) {
-    if (maxChars === null) {
-        lengthIndicator.innerHTML = countHTMLBase + `${length}`;
-    }
-    else {
-        lengthIndicator.innerHTML = countHTMLBase + `${length}/${maxChars}`;
-    }
+    lengthIndicator.innerHTML = countHTMLBase + `${length}/${maxChars}`;
 
-    if (maxChars !== null && length > maxChars) {
+    if (length > maxChars) {
         lengthIndicator.classList.add(lengthIndicatorExceededClassname);
     } else {
         lengthIndicator.classList.remove(lengthIndicatorExceededClassname);
@@ -68,7 +63,7 @@ const initializeLengthIndicator = function (input) {
 };
 
 document.addEventListener("DOMContentLoaded", function () {
-    for (input of document.querySelectorAll(".w-field__input input[maxlength], .w-field__input textarea")) {
+    for (input of document.querySelectorAll(".w-field__input input[maxlength], .w-field__input textarea[maxlength]")) {
         initializeLengthIndicator(input);
     }
 });

--- a/etna/core/static/admin/js/inputLengthIndicators.js
+++ b/etna/core/static/admin/js/inputLengthIndicators.js
@@ -38,8 +38,7 @@ const initializeLengthIndicator = function (input) {
 
     // Add hidden HTML element to display the count
     const lengthIndicator = document.createElement("div");
-    lengthIndicator.className = lengthIndicatorClassname;
-    lengthIndicator.classList.add("w-help-text");
+    lengthIndicator.classList.add(lengthIndicatorClassname, "w-help-text");
     lengthIndicator.style.visibility = "hidden";
     input.after(lengthIndicator);
 

--- a/etna/core/static/admin/js/inputLengthIndicators.js
+++ b/etna/core/static/admin/js/inputLengthIndicators.js
@@ -4,7 +4,7 @@ const truthyValues = ["True", "true", "yes", "y", "1"];
 const countHTMLBase = '<span class="w-sr-only">Character count:</span> ';
 
 const countChars = function (text) {
-    /*
+  /*
   Count characters in a string, with special processing to account for astral symbols in UCS-2. See:
   - https://github.com/RadLikeWhoa/Countable/blob/master/Countable.js#L29
   - https://mathiasbynens.be/notes/javascript-unicode

--- a/etna/core/static/admin/js/inputLengthIndicators.js
+++ b/etna/core/static/admin/js/inputLengthIndicators.js
@@ -68,7 +68,7 @@ const initializeLengthIndicator = function (input) {
 };
 
 document.addEventListener("DOMContentLoaded", function () {
-    for (input of document.querySelectorAll(".w-field__input input[type='text'], .w-field__input textarea")) {
+    for (input of document.querySelectorAll(".w-field__input input[maxlength], .w-field__input textarea")) {
         initializeLengthIndicator(input);
     }
 });

--- a/etna/core/static/admin/js/inputLengthIndicators.js
+++ b/etna/core/static/admin/js/inputLengthIndicators.js
@@ -1,6 +1,5 @@
 const lengthIndicatorClassname = "inputlengthindicator";
 const lengthIndicatorExceededClassname = "inputlengthindicator--exceeded";
-const truthyValues = ["True", "true", "yes", "y", "1"];
 const countHTMLBase = '<span class="w-sr-only">Character count:</span> ';
 
 const countChars = function (text) {

--- a/etna/core/static/css/wagtail-overrides.css
+++ b/etna/core/static/css/wagtail-overrides.css
@@ -2,9 +2,26 @@
   font-size: 11px;
 }
 
+.inputlengthindicator {
+  display: block;
+  background-color: #fff;
+  position: absolute;
+  bottom: -1.6rem;
+  right: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  pointer-events: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.inputlengthindicator--exceeded {
+  color: #cd4444;
+}
+
+
 /* CSS to be applied to record chooser widget, due to
 Wagtail 4.1 upgrade changes breaking the CSS to display on hover */
-@media (hover: hover) { 
+@media (hover: hover) {
   .chooser__actions {
     opacity: 0;
   }

--- a/etna/core/static/css/wagtail-overrides.css
+++ b/etna/core/static/css/wagtail-overrides.css
@@ -2,14 +2,17 @@
   font-size: 11px;
 }
 
+/* Add padding and background colour to Draftail character counts to
+aid legibility when appearing over help text */
+
 .inputlengthindicator {
   display: block;
   background-color: #fff;
   position: absolute;
   bottom: -1.6rem;
   right: 0;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
   pointer-events: none;
   font-variant-numeric: tabular-nums;
 }
@@ -18,6 +21,18 @@
   color: #cd4444;
 }
 
+/* Add padding and background colour to Draftail character counts to
+aid legibility when appearing over help text */
+
+.Draftail-MetaToolbar {
+  padding-right: 0 !important;
+}
+
+.Draftail-MetaToolbar .w-help-text {
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+  background-color: #ffffff;
+}
 
 /* CSS to be applied to record chooser widget, due to
 Wagtail 4.1 upgrade changes breaking the CSS to display on hover */

--- a/etna/core/wagtail_hooks.py
+++ b/etna/core/wagtail_hooks.py
@@ -12,6 +12,13 @@ def editor_css():
     )
 
 
+@hooks.register("insert_editor_js")
+def editor_js():
+    return format_html(
+        '<script src="{}"></script>', static("admin/js/inputLengthIndicators.js")
+    )
+
+
 @hooks.register("insert_global_admin_css")
 def global_admin_css():
     if settings.FEATURE_PLATFORM_ENVIRONMENT_TYPE != "production":


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-494

## About these changes

Adds a Draftail-like character count to any plain text input with a `maxlength` attribute (as long as it's present when the form is initially rendered).

This means that behaviour will be a little inconsistent between inputs present in newly added blocks VS blocks that were present on load... But, I can't find a nice way to cater for those. Let's just see how we get on with this lightweight version and we can complicate things further later if necessary?

I have also snuck some style overrides to help the legibility of Draftail character counts when help text is long enough to clash.

## How to check these changes

Edit any page in the Wagtail admin and open the **Promote** tab. You should see a character count when editing the following fields:
- Slug
- Title tag
- Teaser text

NOTE: The position is a little different when compared with the Draftail version - but, I couldn't find a graceful way to solve that.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
