### PR TITLE
Un 514 short description

### DIFF
--- a/sass/includes/_explore-intro.scss
+++ b/sass/includes/_explore-intro.scss
@@ -34,6 +34,7 @@
   
     &__paragraph {
       margin-bottom: 1rem;
+      font-size: 1.313rem; 
 
       @media (max-width: $screen__md) {
         padding-bottom: 1.5em;

--- a/sass/includes/_generic-intro.scss
+++ b/sass/includes/_generic-intro.scss
@@ -31,6 +31,7 @@
 
   &__paragraph {
     margin-bottom: 0.5rem;
+    font-size: 1.313rem; 
 
     p {
       margin-bottom: 0.5rem;

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -9,7 +9,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
     <div class="container">
         <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -9,7 +9,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     <div class="container">
         <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -8,7 +8,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     {% include 'includes/hero-img.html' %}
 
     <div class="article-container">

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -8,7 +8,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
     {% include 'includes/hero-img.html' %}
 
     <div class="article-container">

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -7,7 +7,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
 
     <div class="container mt-4" id="analytics-explorer-index" data-container-name="explorer-index">
        <div class="row">

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -7,7 +7,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
     <div class="container mt-4" id="analytics-explorer-index" data-container-name="explorer-index">
        <div class="row">

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -6,7 +6,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
     {% if page.highlights %}
         {% include 'includes/highlights-gallery.html' with highlights=page.highlights %}

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -6,7 +6,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
 
     {% if page.highlights %}
         {% include 'includes/highlights-gallery.html' with highlights=page.highlights %}

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -7,7 +7,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
 
     <div class="container mt-4">
         <div class="row">

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -7,7 +7,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
     <div class="container mt-4">
         <div class="row">

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -6,7 +6,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
     {% if page.featured_article %}
         <div class="container">
             <div class="featured-article">

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -6,7 +6,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     {% if page.featured_article %}
         <div class="container">
             <div class="featured-article">

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -7,7 +7,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
 
     <div class="container mt-4">
         <div class="row">

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -7,7 +7,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
     <div class="container mt-4">
         <div class="row">

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -6,7 +6,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     {% if page.featured_article %}
             <div class="container">
                 <div class="featured-article">

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -6,7 +6,7 @@
   {% meta_tags %}
 {% endblock %}
 {% block content %}
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
     {% if page.featured_article %}
             <div class="container">
                 <div class="featured-article">

--- a/templates/generic_pages/general_page.html
+++ b/templates/generic_pages/general_page.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
 
     <div class="container pt-4">
         {% for block in page.body %}

--- a/templates/generic_pages/general_page.html
+++ b/templates/generic_pages/general_page.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
     <div class="container pt-4">
         {% for block in page.body %}

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -14,7 +14,7 @@
 {% endblock %}
 {% block content %}
 
-    {% include 'includes/generic-intro.html' %}
+    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
     <div class="container pt-2">
         <div class="row">
             {% for item in page.body %}

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -14,7 +14,7 @@
 {% endblock %}
 {% block content %}
 
-    {% include 'includes/generic-intro.html' with title=page.title intro=page.intro %}
+    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     <div class="container pt-2">
         <div class="row">
             {% for item in page.body %}

--- a/templates/includes/generic-intro.html
+++ b/templates/includes/generic-intro.html
@@ -4,11 +4,11 @@
         <div class="row">
             <div class="col-12">
                 <h1 class="generic-intro__title">
-                    {{ self.title }}
+                    {{ title }}
                 </h1>
-                {% if page.intro %}
+                {% if intro %}
                     <div class="generic-intro__paragraph">
-                        {{ page.intro|richtext }}
+                        {{ intro|richtext }}
                     </div>
                 {% endif %}
             </div>

--- a/templates/includes/record-revealed.html
+++ b/templates/includes/record-revealed.html
@@ -5,7 +5,7 @@
             <div class="col-md-8 col-sm-12">
                 <p class="explore-intro__title explore-intro__title--meta">Record revealed</p>
                 <h1 class="explore-intro__title">{{ page.title }}</h1>
-                <p class="explore-intro__paragraph">{{ page.intro|richtext }}</p>
+                <div class="explore-intro__paragraph">{{ page.intro|richtext }}</div>
             </div>
             <div class="col-4 explore-intro__image-container">
                 {% if page.teaser_image %}

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -4,7 +4,7 @@
 {% load datalayer_tags %}
 
 {% block content %}
-    {% include 'includes/generic-intro.html'  with self="Several records share this reference" only %}
+    {% include 'includes/generic-intro.html'  with title="Several records share this reference" only %}
 
     <div class="disambiguation-explanation">
         <div class="container">

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -4,7 +4,7 @@
 {% load datalayer_tags %}
 
 {% block content %}
-    {% include 'includes/generic-intro.html'  with title="Several records share this reference" only %}
+    {% include "includes/generic-intro.html" with title="Several records share this reference" only %}
 
     <div class="disambiguation-explanation">
         <div class="container">


### PR DESCRIPTION
Ticket URL: [here](https://national-archives.atlassian.net/browse/UN-514)

## About these changes

This change increases the intro-text of all page types to be `1.3125em` which is approx 21px as requested in the ticket. 

affected templates; 
```
./templates/articles/article_page.html
./templates/articles/article_index_page.html
./templates/collections/time_period_explorer_index_page.html
./templates/collections/topic_explorer_index_page.html
./templates/collections/explorer_index_page.html
./templates/collections/topic_explorer_page.html
./templates/collections/time_period_explorer_page.html
./templates/collections/highlight_gallery_page.html
./templates/generic_pages/general_page.html
./templates/home/home_page.html
./templates/records/record_disambiguation_page.html
./templates/includes/record-revealed.html
```
--


## How to check these changes

To verify this change you only need to open two templates, as record-revealed AKA `RecordArticlePage` is one of the few templates with a custom intro, the other being any opther page template listed above, like a `HighlightGalleryPage` which inherits the "generic-intro".

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
