### PR TITLE
Hide teaser image at tablet viewport

### DIFF
--- a/sass/includes/_explore-intro.scss
+++ b/sass/includes/_explore-intro.scss
@@ -12,7 +12,7 @@
       max-width: 100%;
       height: auto;
       
-      @media (max-width: $screen__md) {
+      @media (max-width: $screen__lg) {
         display:none ;
       }
     }

--- a/templates/includes/record-revealed.html
+++ b/templates/includes/record-revealed.html
@@ -2,7 +2,7 @@
 <div class="explore-intro">
     <div class="container">
         <div class="row">
-            <div class="col-md-8 col-sm-12">
+            <div class="col-lg-8 col-sm-12">
                 <p class="explore-intro__title explore-intro__title--meta">Record revealed</p>
                 <h1 class="explore-intro__title">{{ page.title }}</h1>
                 <div class="explore-intro__paragraph">{{ page.intro|richtext }}</div>


### PR DESCRIPTION
Ticket URL: [here](https://national-archives.atlassian.net/browse/UN-496?focusedCommentId=44225)

## About these changes

Increases the breakpoint of hiding the `teaser_image` from mobile -> tablet to reduce aliasing seen by users
## How to check these changes

This can be seen at any RecordArticlePage, such as [this](http://0.0.0.0:8000/explore-the-collection/a-letter-by-the-women-workers-at-fords-of-dagenham/)

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
