### PR TITLE
UN-391: [BE] Topic/Time Period page updates (follow-up)

### DIFF
--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -181,8 +181,18 @@ class TopicExplorerPage(AlertMixin, BasePageWithIntro):
         )
 
     @cached_property
-    def related_page_pks(self):
-        return tuple(self.topic_pages.values_list("page__pk", flat=True))
+    def related_page_pks(self) -> Tuple[int]:
+        """
+        Returns a list of ids of pages that have used the `PageTopic` inline
+        to indicate a relationship with this topic. The values are ordered by:
+        - The order in which this topic was specified (more important topics are specified first)
+        - When the page was first published ('more recently added' pages take presendence)
+        """
+        return tuple(
+            self.topic_pages.values_list("page_id", flat=True).order_by(
+                "sort_order", "-page__first_published_at"
+            )
+        )
 
 
 class TimePeriodExplorerIndexPage(BasePageWithIntro):
@@ -318,8 +328,18 @@ class TimePeriodExplorerPage(AlertMixin, BasePageWithIntro):
         )
 
     @cached_property
-    def related_page_pks(self):
-        return tuple(self.time_period_pages.values_list("page__pk", flat=True))
+    def related_page_pks(self) -> Tuple[int]:
+        """
+        Returns a list of ids of pages that have used the `PageTimePeriod` inline
+        to indicate a relationship with this time period. The values are ordered by:
+        - The order in which this time period was specified (more important time periods are specified first)
+        - When the page was first published ('more recently added' pages take presendence)
+        """
+        return tuple(
+            self.time_period_pages.values_list("page_id", flat=True).order_by(
+                "sort_order", "-page__first_published_at"
+            )
+        )
 
 
 class PageTopic(Orderable):


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-391

## About these changes

Updates the `related_page_pks` cached properties as follows:
- Add docstrings and type hints
- Use 'page_id' instead of 'page__pk' (using the values already in the join table instead of table-hopping)
- Apply some sensible/predictable ordering to the return value, which can hopefully be utilised in future

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
