### PR TITLE
un-511 hero and gallery cards

### DIFF
--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -189,8 +189,6 @@ class TopicExplorerPage(AlertMixin, BasePageWithIntro):
     def related_highlight_gallery_pages(self):
         return (
             HighlightGalleryPage.objects.live()
-            .public()
-            .filter(pk__in=self.related_page_pks)
             .order_by("title")
             .select_related("teaser_image")
         )
@@ -351,8 +349,6 @@ class TimePeriodExplorerPage(AlertMixin, BasePageWithIntro):
     def related_highlight_gallery_pages(self):
         return (
             HighlightGalleryPage.objects.live()
-            .public()
-            .filter(pk__in=self.related_page_pks)
             .order_by("title")
             .select_related("teaser_image")
         )
@@ -577,6 +573,10 @@ class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIn
             .select_related("image")
             .prefetch_related("image__renditions")
         )
+
+    @cached_property
+    def highlight_image_count(self):
+        return self.highlights.count()
 
     @property
     def highlights_text(self) -> str:

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -512,6 +512,7 @@ class TopicalPageMixin:
     def highlight_image_count(self):
         return self.highlights.count()
 
+
 class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro):
     parent_page_types = [TimePeriodExplorerPage, TopicExplorerPage]
     subpage_types = []

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -189,6 +189,7 @@ class TopicExplorerPage(AlertMixin, BasePageWithIntro):
     def related_highlight_gallery_pages(self):
         return (
             HighlightGalleryPage.objects.live()
+            .live()
             .public()
             .filter(pk__in=self.related_page_pks)
             .order_by("title")

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -189,6 +189,8 @@ class TopicExplorerPage(AlertMixin, BasePageWithIntro):
     def related_highlight_gallery_pages(self):
         return (
             HighlightGalleryPage.objects.live()
+            .public()
+            .filter(pk__in=self.related_page_pks)
             .order_by("title")
             .select_related("teaser_image")
         )
@@ -349,6 +351,8 @@ class TimePeriodExplorerPage(AlertMixin, BasePageWithIntro):
     def related_highlight_gallery_pages(self):
         return (
             HighlightGalleryPage.objects.live()
+            .public()
+            .filter(pk__in=self.related_page_pks)
             .order_by("title")
             .select_related("teaser_image")
         )
@@ -504,6 +508,9 @@ class TopicalPageMixin:
         """
         return ", ".join(item.title for item in self.time_periods)
 
+    @cached_property
+    def highlight_image_count(self):
+        return self.highlights.count()
 
 class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro):
     parent_page_types = [TimePeriodExplorerPage, TopicExplorerPage]
@@ -573,10 +580,6 @@ class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIn
             .select_related("image")
             .prefetch_related("image__renditions")
         )
-
-    @cached_property
-    def highlight_image_count(self):
-        return self.highlights.count()
 
     @property
     def highlights_text(self) -> str:

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -110,3 +110,4 @@ These are Etna specific components, created using BEM and following our guidelin
 @import "includes/archive-description";
 @import "includes/archive-collections";
 @import "includes/archive-additional-resources";
+@import 'includes/related-highlight-cards';

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -105,6 +105,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/new_cards';
 @import 'includes/highlight-gallery';
 @import 'includes/highlight-cards';
+@import "includes/highlight-intro";
 @import 'includes/utilities';
 @import "includes/archive-description";
 @import "includes/archive-collections";

--- a/sass/includes/_card-grid.scss
+++ b/sass/includes/_card-grid.scss
@@ -11,6 +11,22 @@
         }
     }
 
+    &--trio {
+
+        grid-gap: 1.5rem;
+        row-gap: 1.8rem;
+        padding: 0 1rem 1rem 1rem;
+
+        @media (min-width: map-get($grid-breakpoints, "sm")) {
+            grid-template-columns: repeat(2, 1fr);        row-gap: 3rem;
+            row-gap: 3rem;
+        }
+
+        @media (min-width: map-get($grid-breakpoints, "md")) {
+            grid-template-columns: repeat(3, 1fr);
+        }
+    }
+
     &--quad {
         grid-gap: 40px;
         margin: 20px 0;

--- a/sass/includes/_card-grid.scss
+++ b/sass/includes/_card-grid.scss
@@ -12,13 +12,12 @@
     }
 
     &--trio {
-
         grid-gap: 1.5rem;
         row-gap: 1.8rem;
         padding: 0 1rem 1rem 1rem;
 
         @media (min-width: map-get($grid-breakpoints, "sm")) {
-            grid-template-columns: repeat(2, 1fr);        row-gap: 3rem;
+            grid-template-columns: repeat(2, 1fr);
             row-gap: 3rem;
         }
 

--- a/sass/includes/_highlight-intro.scss
+++ b/sass/includes/_highlight-intro.scss
@@ -14,20 +14,8 @@
         color: $color__white;
         padding: 28px 24px 36px 24px;
         
-        // normalise font-size and spacing
-        p {
-            line-height: 1.5;
-            margin: 0;
-        }
-        
-        
-        h1 {
-            font-size: $h1-font-size;
-            margin: 0;
-        }
-        
         // tablet and up
-        @media screen and (min-width: map-get($grid-breakpoints, "md")) {
+        @media screen and (min-width: map-get($grid-breakpoints, "lg")) {
             width: 736px;
             position: absolute;
             left: 0;
@@ -36,7 +24,7 @@
             
         }
         // desktop and up
-        @media screen and (min-width: map-get($grid-breakpoints, "lg")) {
+        @media screen and (min-width: map-get($grid-breakpoints, "xl")) {
             background: $color__white;
             color: $color__black;
             left: 132px;
@@ -47,20 +35,19 @@
     }
 
     &__title {
+        font-family: $font__supria-sans;
         @include font-size("xxxl");
         font-weight: $font-weight-bold;
         line-height: 78px;
         padding-bottom: 0.75rem;
-        font-family: $font__supria-sans;
-
+        margin: 0;
     }
 
     &__intro {
-        font-size: $h3-font-size;
         @include font-size("xl");
-        line-height: 36px;
-        font-weight: $font-weight-normal;
-        padding: 0;
         font-family: $font__open-sans;
+        line-height: 36px;
+        padding: 0;
+        margin: 0;
     }
 }

--- a/sass/includes/_highlight-intro.scss
+++ b/sass/includes/_highlight-intro.scss
@@ -1,0 +1,66 @@
+.highlight-intro {
+    position: relative;
+
+    &__image {
+        width: 100%;
+        height: auto;
+    }    
+
+    &__standout {
+        position: relative;
+        height: auto;
+        background: $color__grey-6;
+        left: 0;
+        color: $color__white;
+        padding: 28px 24px 36px 24px;
+        
+        // normalise font-size and spacing
+        p {
+            line-height: 1.5;
+            margin: 0;
+        }
+        
+        
+        h1 {
+            font-size: $h1-font-size;
+            margin: 0;
+        }
+        
+        // tablet and up
+        @media screen and (min-width: map-get($grid-breakpoints, "md")) {
+            width: 736px;
+            color: $color__black;
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            margin: auto;
+          
+            background: $color__white;
+        }
+        // desktop and up
+        @media screen and (min-width: map-get($grid-breakpoints, "lg")) {
+            left: 132px;
+            bottom: 52px;
+            margin: auto;
+        }
+
+    }
+
+    &__title {
+        @include font-size("xxxl");
+        font-weight: $font-weight-bold;
+        line-height: 78px;
+        padding-bottom: 0.75rem;
+        font-family: $font__supria-sans;
+
+    }
+
+    &__intro {
+        font-size: $h3-font-size;
+        @include font-size("xl");
+        line-height: 36px;
+        font-weight: $font-weight-normal;
+        padding: 0;
+        font-family: $font__open-sans;
+    }
+}

--- a/sass/includes/_highlight-intro.scss
+++ b/sass/includes/_highlight-intro.scss
@@ -29,16 +29,16 @@
         // tablet and up
         @media screen and (min-width: map-get($grid-breakpoints, "md")) {
             width: 736px;
-            color: $color__black;
             position: absolute;
             left: 0;
             bottom: 0;
             margin: auto;
-          
-            background: $color__white;
+            
         }
         // desktop and up
         @media screen and (min-width: map-get($grid-breakpoints, "lg")) {
+            background: $color__white;
+            color: $color__black;
             left: 132px;
             bottom: 52px;
             margin: auto;

--- a/sass/includes/_related-highlight-cards.scss
+++ b/sass/includes/_related-highlight-cards.scss
@@ -6,8 +6,6 @@
         margin-bottom: 96px;
     }
 
-
-
     &__title {
         @include font-size("xxl");
         margin: 0;
@@ -26,7 +24,6 @@
 
     &__card {
         background-color: $color__grey-6;
-
         text-decoration: none !important;
     }
 

--- a/sass/includes/_related-highlight-cards.scss
+++ b/sass/includes/_related-highlight-cards.scss
@@ -1,0 +1,49 @@
+.related-highlight-cards {
+    $root: &;
+    margin-bottom: 72px;
+
+    @media screen and (min-width: map-get($grid-breakpoints, "md")) {
+        margin-bottom: 96px;
+    }
+
+
+
+    &__title {
+        @include font-size("xxl");
+        margin: 0;
+        padding: 3rem 0 1.5rem 0;
+
+        @media (min-width: map-get($grid-breakpoints, "md")) {
+            padding: 4.5rem 0 3rem 0;
+        }
+
+        &--small {
+            @include font-size("xl");
+            font-weight: $font-weight-bold;
+            padding: 0.5rem 0;
+        }
+    }
+
+    &__card {
+        background-color: $color__grey-6;
+
+        text-decoration: none !important;
+    }
+
+    &__content {
+        margin: 1.75rem;
+        color: $color__white;
+    }
+
+    &__text {
+        @include font-size("s");
+        color: $color__grey-7;
+        margin: 0;
+    }
+
+    &__image {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+    }
+}

--- a/sass/includes/_variables.scss
+++ b/sass/includes/_variables.scss
@@ -35,7 +35,7 @@ $color__red: #a72916;
 
 $color__grey-8: #4e5a5a;
 $color__grey-7: #cccccc;
-$color__grey-6: #333333;
+$color__grey-6: #343338;
 $color__grey-5: #efefef;
 $color__grey-4: #dddddd;
 $color__grey-3: #6f777b;

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -5,8 +5,16 @@
 {% endblock meta_tag %}
 {% block content %}
     {% include "includes/highlight-intro.html" with background_image=page.teaser_image title=page.title intro=page.intro %}
+    {% if page.related_highlight_gallery_pages %}
+        {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
+    {% endif %}
     {% if page.featured_article %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
+    {% endif %}
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
+        {% if page.related_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% endif %}
     {% endif %}
     <div class="container"
          data-container-name="time-period-explorer"
@@ -19,22 +27,6 @@
             </div>
         </div>
     </div>
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
-        {% endif %}
-    {% endif %}
-    {%comment%}
-                <div class="row">
-                    <div class="col-md-12">
-                        {% for article_page in page.related_article %}
-                            <li>
-                            <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
-                        </li>
-                    {% endfor %}
-                </div>
-            </div>
-{% endcomment %}
 {% endblock content %}
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -4,27 +4,13 @@
     {% meta_tags %}
 {% endblock meta_tag %}
 {% block content %}
-    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
-    {% comment %}
-    <div class="row">
-        <div class="col-md-12">
-            {% for highlight_gallery in page.related_highlight_gallery_pages %}
-                <li>
-                    <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
-                </li>
-            {% endfor %}
-        </div>
-    </div>
-    {% endcomment %}
-    {% if page.related_record_articles %}
-        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-    {% endif %}
+    {% include "includes/highlight-intro.html" with background_image=page.teaser_image title=page.title intro=page.intro %}
     {% if page.featured_article %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     <div class="container"
-        data-container-name="time-period-explorer"
-        id="analytics-time-period-explorer">
+         data-container-name="time-period-explorer"
+         id="analytics-time-period-explorer">
         <div class="row">
             <div class="col-md-12">
                 {% for block in page.body %}
@@ -33,17 +19,22 @@
             </div>
         </div>
     </div>
-    {% if page.related_articles %}
-        <div class="row">
-            <div class="col-md-12">
-                {% for article_page in page.related_articles %}
-                    <li>
-                        <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
-                    </li>
-                {% endfor %}
-            </div>
-        </div>
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
+        {% if page.related_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% endif %}
     {% endif %}
+    {%comment%}
+                <div class="row">
+                    <div class="col-md-12">
+                        {% for article_page in page.related_article %}
+                            <li>
+                            <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+{% endcomment %}
 {% endblock content %}
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -8,9 +8,6 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article %}
-    {% endif %}
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
         {% if page.related_articles %}
             {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
@@ -27,6 +24,9 @@
             </div>
         </div>
     </div>
+    {% if page.featured_article %}
+        {% include "includes/article-spotlight.html" with page=page.featured_article %}
+    {% endif %}
 {% endblock content %}
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -9,23 +9,36 @@
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% if page.related_record_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
         {% endif %}
-    {% endif %}
-    <div class="container"
-         data-container-name="time-period-explorer"
-         id="analytics-time-period-explorer">
-        <div class="row">
-            <div class="col-md-12">
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
+        {% if page.body %}
+            <div class="container"
+                 data-container-name="time-period-explorer"
+                 id="analytics-time-period-explorer">
+                <div class="row">
+                    <div class="col-md-12">
+                        {% for block in page.body %}
+                            {% include_block block %}
+                        {% endfor %}
+                    </div>
+                </div>
             </div>
-        </div>
-    </div>
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article %}
+        {% endif %}
+        {% if page.featured_article %}
+            {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
+        {% endif %}
+        {% if page.related_articles %}
+            <div class="row">
+                <div class="col-md-12">
+                    {% for article_page in page.related_articles %}
+                        <li>
+                            <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block extra_js %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -27,17 +27,6 @@
     {% if page.featured_article %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
-    {%comment%}
-            <div class="row">
-                <div class="col-md-12">
-                    {% for highlight_gallery in page.related_highlight_gallery_pages %}
-                        <li>
-                        <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
-                    </li>
-                {% endfor %}
-            </div>
-        </div>
-{% endcomment %}
 {% endblock content %}
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -5,8 +5,13 @@
 {% endblock meta_tag %}
 {% block content %}
     {% include "includes/highlight-intro.html" with background_image=page.teaser_image title=page.title intro=page.intro %}
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article %}
+    {% if page.related_highlight_gallery_pages %}
+        {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
+    {% endif %}
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
+        {% if page.related_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% endif %}
     {% endif %}
     <div class="container"
          data-container-name="topic-explorer"
@@ -19,18 +24,8 @@
             </div>
         </div>
     </div>
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_articles %}
-            <div class="row">
-                <div class="col-md-12">
-                    {% for article_page in page.related_articles %}
-                        <li>
-                            <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
-                        </li>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
+    {% if page.featured_article %}
+        {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     {%comment%}
             <div class="row">

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -1,30 +1,16 @@
 {% extends "base_page.html" %}
-{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
+{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags wagtailmetadata_tags %}
 {% block meta_tag %}
     {% meta_tags %}
 {% endblock meta_tag %}
 {% block content %}
-    {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
-    {% comment %}
-    <div class="row">
-        <div class="col-md-12">
-            {% for highlight_gallery in page.related_highlight_gallery_pages %}
-                <li>
-                    <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
-                </li>
-            {% endfor %}
-        </div>
-    </div>
-    {% endcomment %}
-    {% if page.related_record_articles %}
-        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-    {% endif %}
+    {% include "includes/highlight-intro.html" with background_image=page.teaser_image title=page.title intro=page.intro %}
     {% if page.featured_article %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     <div class="container"
-        data-container-name="topic-explorer"
-        id="analytics-topic-explorer">
+         data-container-name="topic-explorer"
+         id="analytics-topic-explorer">
         <div class="row">
             <div class="col-md-12">
                 {% for block in page.body %}
@@ -33,17 +19,30 @@
             </div>
         </div>
     </div>
-    {% if page.related_articles %}
-        <div class="row">
-            <div class="col-md-12">
-                {% for article_page in page.related_articles %}
-                    <li>
-                        <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
+        {% if page.related_articles %}
+            <div class="row">
+                <div class="col-md-12">
+                    {% for article_page in page.related_articles %}
+                        <li>
+                            <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    {%comment%}
+            <div class="row">
+                <div class="col-md-12">
+                    {% for highlight_gallery in page.related_highlight_gallery_pages %}
+                        <li>
+                        <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
                     </li>
                 {% endfor %}
             </div>
         </div>
-    {% endif %}
+{% endcomment %}
 {% endblock content %}
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -1,5 +1,5 @@
 {% extends "base_page.html" %}
-{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags wagtailmetadata_tags %}
+{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
 {% block meta_tag %}
     {% meta_tags %}
 {% endblock meta_tag %}
@@ -9,23 +9,36 @@
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% if page.related_record_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
         {% endif %}
-    {% endif %}
-    <div class="container"
-         data-container-name="topic-explorer"
-         id="analytics-topic-explorer">
-        <div class="row">
-            <div class="col-md-12">
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
+        {% if page.body %}
+            <div class="container"
+                 data-container-name="topic-explorer"
+                 id="analytics-topic-explorer">
+                <div class="row">
+                    <div class="col-md-12">
+                        {% for block in page.body %}
+                            {% include_block block %}
+                        {% endfor %}
+                    </div>
+                </div>
             </div>
-        </div>
-    </div>
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article %}
+        {% endif %}
+        {% if page.featured_article %}
+            {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
+        {% endif %}
+        {% if page.related_articles %}
+            <div class="row">
+                <div class="col-md-12">
+                    {% for article_page in page.related_articles %}
+                        <li>
+                            <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block extra_js %}

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -1,7 +1,9 @@
 {% load wagtailimages_tags wagtailcore_tags i18n %}
 
 <div class="container">
-    <h2 class="extra-padding">{% translate title %}</h2>
+    {% if title %}
+        <h2 class="extra-padding">{% translate title %}</h2>
+    {% endif %}
     <div class="featured-article">
         {% if page.hero_image %}
             <a href="{% pageurl page %}" class="featured-article__image-link" tabindex="-1" aria-hidden="true" data-component-name="Featured Story: {{ page.title }}" data-link-type="Image" {% if page.is_newly_published %}data-label="New"{% endif %}>

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -2,20 +2,32 @@
 <div class="highlight-intro">
     <picture>
         {% image background_image fill-1440x500 format-webp as webp_img %}
-        <source srcset="{{ webp_img.url }}" media="(min-width: 577px)"width="390" height="320" type="image/webp" />
+        <source srcset="{{ webp_img.url }}"
+                media="(min-width: 577px)"
+                width="390"
+                height="320"
+                type="image/webp"/>
         {% image background_image fill-390x320 format-webp as mobile_webp_img %}
-        <source srcset="{{ mobile_webp_img.url }}" media="(max-width: 576px)" width="390" height="320" type="image/webp" />
+        <source srcset="{{ mobile_webp_img.url }}"
+                media="(max-width: 576px)"
+                width="390"
+                height="320"
+                type="image/webp"/>
         {% image background_image fill-390x320 as mobile_jpeg_img %}
-        <source srcset="{{ mobile_jpeg_img.url }}" media="(max-width: 576px)" width="390" height="320" type="image/jpeg" />
+        <source srcset="{{ mobile_jpeg_img.url }}"
+                media="(max-width: 576px)"
+                width="390"
+                height="320"
+                type="image/jpeg"/>
         {% image background_image fill-1440x500 as base_img %}
         <img src="{{ base_img.url }}"
              height="500"
              width="1440"
              class="highlight-intro__image"
              {% if background_image.alt_text %}alt="{{ background_image.alt_text }}"{% endif %}/>
-             <div class="highlight-intro__standout">
-                 <h1 class="highlight-intro__title">{{ title }}</h1>
-                 <div class="highlight-intro__intro">{{ intro|richtext }}</div>
-             </div>
     </picture>
+    <div class="highlight-intro__standout">
+        <h1 class="highlight-intro__title">{{ title }}</h1>
+        <div class="highlight-intro__intro">{{ intro|richtext }}</div>
+    </div>
 </div>

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -1,0 +1,21 @@
+{% load wagtailimages_tags wagtailcore_tags %}
+<div class="highlight-intro">
+    <picture>
+        {% image background_image fill-1440x500 format-webp as webp_img %}
+        <source srcset="{{ webp_img.url }}" media="(min-width: 577px)"width="390" height="320" type="image/webp" />
+        {% image background_image fill-390x320 format-webp as mobile_webp_img %}
+        <source srcset="{{ mobile_webp_img.url }}" media="(max-width: 576px)" width="390" height="320" type="image/webp" />
+        {% image background_image fill-390x320 as mobile_jpeg_img %}
+        <source srcset="{{ mobile_jpeg_img.url }}" media="(max-width: 576px)" width="390" height="320" type="image/jpeg" />
+        {% image background_image fill-1440x500 as base_img %}
+        <img src="{{ base_img.url }}"
+             height="500"
+             width="1440"
+             class="highlight-intro__image"
+             {% if background_image.alt_text %}alt="{{ background_image.alt_text }}"{% endif %}/>
+             <div class="highlight-intro__standout">
+                 <h1 class="highlight-intro__title">{{ title }}</h1>
+                 <div class="highlight-intro__intro">{{ intro|richtext }}</div>
+             </div>
+    </picture>
+</div>

--- a/templates/includes/related-highlight-cards.html
+++ b/templates/includes/related-highlight-cards.html
@@ -1,0 +1,33 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+<section class="related-highlight-cards">
+    <div class="container">
+        <h2 class="related-highlight-cards__title">{{ title }} highlights in pictures</h2>
+        <div class="card-grid card-grid--trio">
+            {% for card in cards %}
+                <a href="{{ card.url }}" class="related-highlight-cards__card">
+                    <picture>
+                    {% image card.teaser_image fill-350x229-c100 format-webp as mobile_webp_image %}
+                    <source media="(max-width: 390px)"
+                            srcset="{{ mobile_webp_image.url }}"
+                            type="image/webp"/>
+                    {% image card.teaser_image fill-375x229-c100 format-webp as desktop_webp_image %}
+                    <source srcset="{{ desktop_webp_image.url }}"
+                            type="image/webp"/>
+                    {% image card.teaser_image fill-350x229-c100 as mobile_img %}
+                    <source srcset="{{ mobile_img.url }}" media="(max-width: 390px)"/>
+                    {% image card.teaser_image fill-375x229-c100 as base_img %}
+                    <img src="{{ base_img.url }}"
+                         height="{{ base_img.height }}"
+                         width="{{ base_img.width }}"
+                         class="related-highlight-cards__image"
+                         {% if card.teaser_image.alt_text %} alt="{{ card.teaser_image.alt_text }}"{% endif %}/>
+                    </picture>
+                    <div class="related-highlight-cards__content">
+                        <h3 class="related-highlight-cards__title related-highlight-cards__title--small">{{ card.title }}</h3>
+                        <p class="related-highlight-cards__text">{{ card.highlight_image_count }} images</p>
+                    </div>
+                </a>
+            {% endfor %}
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Ticket URL: [here](https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-511)

## About these changes

These changes add a hero, and the cards seen bellow. 

Please note that I've taken a fair amount of liberty with the layout / colours for the hero, as were positioning the text offset centre I've tried to preserve this as much as possible instead of just using the mobile view basically for anything lower than 1440px width. I also found that without the hero intro colour being darker than the page it wasn't particularly clear what was happening for tablet+ sized screen widths. Please do let me know if you think this could be done better.

Also note, the lettering of the titles for the hero and cards is wrong, we do not have `Supra Sans` available in the code base and it appears we load these from third-parties, so will need to change this. 

Example: 
![0 0 0 0_8000_explore-the-collection_explore-by-topic_agriculture-and-environment_ (2)](https://user-images.githubusercontent.com/22497837/229533307-b5698a1a-e5cd-4756-a7a7-9b0e1f97dcd6.png)

Desktop:
![0 0 0 0_8000_explore-the-collection_explore-by-topic_agriculture-and-environment_ (1)](https://user-images.githubusercontent.com/22497837/229534099-f64c66ac-6a20-49b2-be6d-2d75c402557e.png)

Tablet large:
![0 0 0 0_8000_explore-the-collection_explore-by-topic_agriculture-and-environment_ (2)](https://user-images.githubusercontent.com/22497837/229534303-a2d94cd0-2f10-4cc0-8590-fbc42901140c.png)

Tablet small:
![0 0 0 0_8000_explore-the-collection_explore-by-topic_agriculture-and-environment_ (3)](https://user-images.githubusercontent.com/22497837/229534366-f2a18e27-7037-4887-ba58-5c8095bd6544.png)

Mobile:
![0 0 0 0_8000_explore-the-collection_explore-by-topic_agriculture-and-environment_ (4)](https://user-images.githubusercontent.com/22497837/229534622-0f11b73b-2427-4deb-9e6a-d9b47635a842.png)


## How to check these changes

To test this, you'll need to check both the TopicExplorerPage/ TimePeriodExplorerPage (adding at least 4 highlight gallery page children and then in the promote tab and assigning them to this TopicExplorerPage/ TimePeriodExplorerPage to show them. 

Some things to note:
It's not clear where the hero image is coming from for the hero, I've used the teaser_image, although as this is not required, it can be left blank. The designs don't accomodate this.

The 

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
