### PR TITLE
fix; use related_record_articles instead of related_articles

### DIFF
--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -158,7 +158,7 @@ class TopicExplorerPage(AlertMixin, BasePageWithIntro):
         )
 
     @cached_property
-    def related_record_article(self):
+    def related_record_articles(self):
         from etna.articles.models import RecordArticlePage
 
         return (
@@ -167,7 +167,7 @@ class TopicExplorerPage(AlertMixin, BasePageWithIntro):
             .public()
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
-            .select_related("teaser_image")
+            .select_related("teaser_image")[:4]
         )
 
     @cached_property
@@ -314,7 +314,7 @@ class TimePeriodExplorerPage(AlertMixin, BasePageWithIntro):
             .public()
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
-            .select_related("teaser_image")
+            .select_related("teaser_image")[:4]
         )
 
     @cached_property

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -54,8 +54,8 @@
         </div>
     </div>
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% if page.related_record_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
         {% endif %}
     {% endif %}
         {%comment%}

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -17,7 +17,7 @@
     </div>
     {% endcomment %}
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% page.related_record_articles %}
+        {% if page.related_record_articles %}
             {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
         {% endif %}
         {% if page.featured_article %}

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -1,46 +1,26 @@
-{% extends 'base_page.html' %}
-{% load i18n static wagtailcore_tags wagtailimages_tags %}
-{% load wagtailmetadata_tags %}
+{% extends "base_page.html" %}
+{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
 {% block meta_tag %}
     {% meta_tags %}
-{% endblock %}
+{% endblock meta_tag %}
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
-    {% if page.featured_article %}
-        <div class="container">
-            <div class="featured-article">
-                {% if page.featured_article.teaser_image %}
-                    <div class="featured-article__image">
-                        <picture>
-                            {% image page.featured_article.teaser_image fill-412x361 as hero %}
-                            <source media="(max-width: 480px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-510x351 as hero %}
-                            <source media="(max-width: 640px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-510x304 as hero %}
-                            <source media="(max-width: 768px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-345x495 as hero %}
-                            <source media="(max-width: 991px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-555x367 as hero %}
-                            <source media="(max-width: 1200px)" srcset="{{ hero.url }}"/>
-                            {% if page.featured_article.hero_image_decorative %}
-                                <img src="{{ hero.url }}" alt="" />
-                            {% else %}
-                                <img src="{{ hero.url }}"
-                                     alt="{{ page.featured_article.hero_image_alt_text }}"/>
-                            {% endif %}
-                        </picture>
-                    </div>
-                {% endif %}
-                <div class="featured-article__description">
-                    <h2 class="featured-article__heading">
-                        <small>{% trans "Spotlight on" %}</small>
-                        {{ page.featured_article.title }}
-                    </h2>
-                    <p>{{ page.featured_article.teaser_text }}</p>
-                    <a class="tna-button--dark" href="{% pageurl page.featured_article %}">Read</a>
-                </div>
-            </div>
+    {% comment %}
+    <div class="row">
+        <div class="col-md-12">
+            {% for highlight_gallery in page.related_highlight_gallery_pages %}
+                <li>
+                    <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
+                </li>
+            {% endfor %}
         </div>
+    </div>
+    {% endcomment %}
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES and page.related_record_articles %}
+        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
+    {% endif %}
+    {% if page.featured_article %}
+        {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     <div class="container"
          data-container-name="time-period-explorer"
@@ -53,23 +33,17 @@
             </div>
         </div>
     </div>
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_record_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-        {% endif %}
-    {% endif %}
-        {%comment%}
-            <div class="row">
-                <div class="col-md-12">
-                    {% for highlight_gallery in page.related_highlight_gallery_pages %}
-                        <li>
-                            <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
-                        </li>
-                    {% endfor %}
-                </div>
+    {% if page.related_articles %}
+        <div class="row">
+            <div class="col-md-12">
+                {% for article_page in page.related_articles %}
+                    <li>
+                        <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+                    </li>
+                {% endfor %}
             </div>
-        {% endcomment %}
-</div>
+        </div>
+    {% endif %}
 {% endblock content %}
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -16,33 +16,35 @@
         </div>
     </div>
     {% endcomment %}
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES and page.related_record_articles %}
-        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-    {% endif %}
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article %}
-    {% endif %}
-    <div class="container"
-         data-container-name="time-period-explorer"
-         id="analytics-time-period-explorer">
-        <div class="row">
-            <div class="col-md-12">
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
+        {% page.related_record_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
+        {% endif %}
+        {% if page.featured_article %}
+            {% include "includes/article-spotlight.html" with page=page.featured_article %}
+        {% endif %}
+        <div class="container"
+            data-container-name="time-period-explorer"
+            id="analytics-time-period-explorer">
+            <div class="row">
+                <div class="col-md-12">
+                    {% for block in page.body %}
+                        {% include_block block %}
+                    {% endfor %}
+                </div>
             </div>
         </div>
-    </div>
-    {% if page.related_articles %}
-        <div class="row">
-            <div class="col-md-12">
-                {% for article_page in page.related_articles %}
-                    <li>
-                        <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
-                    </li>
-                {% endfor %}
+        {% if page.related_articles %}
+            <div class="row">
+                <div class="col-md-12">
+                    {% for article_page in page.related_articles %}
+                        <li>
+                            <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block extra_js %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -17,7 +17,7 @@
     </div>
     {% endcomment %}
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% page.related_record_articles %}
+        {% if page.related_record_articles %}
             {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
         {% endif %}
         {% if page.featured_article %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -1,47 +1,26 @@
 {% extends "base_page.html" %}
-{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags wagtailmetadata_tags %}
-
+{% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
 {% block meta_tag %}
     {% meta_tags %}
 {% endblock meta_tag %}
-
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
-    {% if page.featured_article %}
-        <div class="container">
-            <div class="featured-article">
-                {% if page.featured_article.teaser_image %}
-                    <div class="featured-article__image">
-                        <picture>
-                            {% image page.featured_article.teaser_image fill-412x361 as hero %}
-                            <source media="(max-width: 480px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-510x351 as hero %}
-                            <source media="(max-width: 640px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-510x304 as hero %}
-                            <source media="(max-width: 768px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-345x495 as hero %}
-                            <source media="(max-width: 991px)" srcset="{{ hero.url }}"/>
-                            {% image page.featured_article.teaser_image fill-555x367 as hero %}
-                            <source media="(max-width: 1200px)" srcset="{{ hero.url }}"/>
-                            {% if page.featured_article.hero_image_decorative %}
-                                <img src="{{ hero.url }}" alt="" />
-                            {% else %}
-                                <img src="{{ hero.url }}"
-                                     alt="{{ page.featured_article.hero_image_alt_text }}"/>
-                            {% endif %}
-                        </picture>
-                    </div>
-                {% endif %}
-                <div class="featured-article__description">
-                    <h2 class="featured-article__heading">
-                        <small>{% trans "Spotlight on" %}</small>
-                        {{ page.featured_article.title }}
-                    </h2>
-                    <p>{{ page.featured_article.teaser_text }}</p>
-                    <a class="tna-button--dark" href="{% pageurl page.featured_article %}">Read</a>
-                </div>
-            </div>
+    {% comment %}
+    <div class="row">
+        <div class="col-md-12">
+            {% for highlight_gallery in page.related_highlight_gallery_pages %}
+                <li>
+                    <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
+                </li>
+            {% endfor %}
         </div>
+    </div>
+    {% endcomment %}
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES and page.related_record_articles %}
+        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
+    {% endif %}
+    {% if page.featured_article %}
+        {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     <div class="container"
          data-container-name="topic-explorer"
@@ -54,24 +33,18 @@
             </div>
         </div>
     </div>
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_record_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-        {% endif %}
-    {% endif %}
-    {%comment%}
+    {% if page.related_articles %}
         <div class="row">
             <div class="col-md-12">
-                {% for highlight_gallery in page.related_highlight_gallery_pages %}
+                {% for article_page in page.related_articles %}
                     <li>
-                        <a href="{% pageurl highlight_gallery %}">{{ highlight_gallery.title }}</a>
+                        <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
                     </li>
                 {% endfor %}
             </div>
         </div>
-    {% endcomment %}
+    {% endif %}
 {% endblock content %}
-
 {% block extra_js %}
     <script src="{% static 'scripts/explorer.js' %}"></script>
 {% endblock extra_js %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -16,33 +16,35 @@
         </div>
     </div>
     {% endcomment %}
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES and page.related_record_articles %}
-        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-    {% endif %}
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article %}
-    {% endif %}
-    <div class="container"
-         data-container-name="topic-explorer"
-         id="analytics-topic-explorer">
-        <div class="row">
-            <div class="col-md-12">
-                {% for block in page.body %}
-                    {% include_block block %}
-                {% endfor %}
+    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
+        {% page.related_record_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
+        {% endif %}
+        {% if page.featured_article %}
+            {% include "includes/article-spotlight.html" with page=page.featured_article %}
+        {% endif %}
+        <div class="container"
+            data-container-name="topic-explorer"
+            id="analytics-topic-explorer">
+            <div class="row">
+                <div class="col-md-12">
+                    {% for block in page.body %}
+                        {% include_block block %}
+                    {% endfor %}
+                </div>
             </div>
         </div>
-    </div>
-    {% if page.related_articles %}
-        <div class="row">
-            <div class="col-md-12">
-                {% for article_page in page.related_articles %}
-                    <li>
-                        <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
-                    </li>
-                {% endfor %}
+        {% if page.related_articles %}
+            <div class="row">
+                <div class="col-md-12">
+                    {% for article_page in page.related_articles %}
+                        <li>
+                            <a href="{% pageurl article_page %}">{{ article_page.title }}</a>
+                        </li>
+                    {% endfor %}
+                </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block extra_js %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -55,8 +55,8 @@
         </div>
     </div>
     {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_articles title="Records revealed" %}
+        {% if page.related_record_articles %}
+            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
         {% endif %}
     {% endif %}
     {%comment%}

--- a/templates/includes/related-articles-highlight-cards.html
+++ b/templates/includes/related-articles-highlight-cards.html
@@ -5,7 +5,7 @@
         <div class="card-grid card-grid--quad">
             {% for article in articles %}
                 {% if forloop.first %}
-                    <a href="{{ article.url }}"
+                    <a href="{% pageurl article %}"
                        class="highlight-cards__card--highlight highlight-cards__link">
                         {# Desktop/ tablet image #}
                         {% image article.teaser_image fill-534x413-c100 format-webp as image_webp %}
@@ -26,24 +26,25 @@
                             <p class="highlight-cards__description">{{ article.teaser_text }}</p>
                         </div>
                     </a>
+                {% else %}
+                    <a href="{% pageurl article %}"
+                       class="highlight-cards__card highlight-cards__link">
+                        {% image article.teaser_image fill-268x171-c100 format-webp as image_webp %}
+                        <source srcset="{{ image_webp.url }}"
+                                type="image/webp"
+                                {% if article.teaser_image.alt_text %}alt="{{ article.teaser_image.alt_text }}"{% endif %}/>
+                        {% image article.teaser_image fill-268x171-c100 as base_img %}
+                        <img src="{{ base_img.url }}"
+                             height="{{ base_img.height }}"
+                             width="{{ base_img.width }}"
+                             class="highlight-cards__image"
+                             {% if article.teaser_image.alt_text %}alt="{{ article.image.alt_text }}"{% endif %}/>
+                        <div class="highlight-cards__card__content">
+                            <h3 class="highlight-cards__card_title">{{ article.title }}</h3>
+                            <p class="highlight-cards__description">{{ article.teaser_text }}</p>
+                        </div>
+                    </a>
                 {% endif %}
-                <a href="{{ article.url }}"
-                   class="highlight-cards__card highlight-cards__link">
-                    {% image article.teaser_image fill-268x171-c100 format-webp as image_webp %}
-                    <source srcset="{{ image_webp.url }}"
-                            type="image/webp"
-                            {% if article.teaser_image.alt_text %}alt="{{ article.teaser_image.alt_text }}"{% endif %}/>
-                    {% image article.teaser_image fill-268x171-c100 as base_img %}
-                    <img src="{{ base_img.url }}"
-                         height="{{ base_img.height }}"
-                         width="{{ base_img.width }}"
-                         class="highlight-cards__image"
-                         {% if article.teaser_image.alt_text %}alt="{{ article.image.alt_text }}"{% endif %}/>
-                    <div class="highlight-cards__card__content">
-                        <h3 class="highlight-cards__card_title">{{ article.title }}</h3>
-                        <p class="highlight-cards__description">{{ article.teaser_text }}</p>
-                    </div>
-                </a>
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
Ticket URL: [here](https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-512)

## About these changes

A quick change to use related_record_articles instead of related_articles for TimePeriod and Topic ExplorerPages.

From review, this MR's purpose has extended slightly to cover some formatting issues, which uncovered some issues from rebasing develop.

## How to check these changes

Check both of those page types, see that the section titled "records revealed" is populated by RecordArticlePages.

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
