### PR TITLE
DF-617: Remove 'Highlights' from WEBSITE_BUCKETS

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -102,7 +102,6 @@ WEBSITE_BUCKETS = BucketList(
         Bucket(key="blog", label="Blog posts"),
         Bucket(key="researchGuide", label="Research Guides"),
         Bucket(key=BucketKeys.INSIGHT.value, label="Insights"),
-        Bucket(key=BucketKeys.HIGHLIGHT.value, label="Highlights"),
         Bucket(key="audio", label="Audio"),
         Bucket(key="video", label="Video"),
     ]

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -102,6 +102,8 @@ WEBSITE_BUCKETS = BucketList(
         Bucket(key="blog", label="Blog posts"),
         Bucket(key="researchGuide", label="Research Guides"),
         Bucket(key=BucketKeys.INSIGHT.value, label="Insights"),
+        # TODO: Restore when we are succesfully indexing new highlight pages
+        # Bucket(key=BucketKeys.HIGHLIGHT.value, label="Highlights"),
         Bucket(key="audio", label="Audio"),
         Bucket(key="video", label="Video"),
     ]

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -773,6 +773,14 @@ class WebsiteSearchArticleTest(WagtailTestUtils, TestCase):
                     is_current=True,
                     results=None,
                 ),
+                # TODO: Restore when we are succesfully indexing new highlight pages
+                # Bucket(
+                #   key="highlight",
+                #   label="Highlights",
+                #   result_count=1,
+                #   is_current=True,
+                #   results=None,
+                # ),
                 Bucket(
                     key="audio",
                     label="Audio",
@@ -926,6 +934,14 @@ class WebsiteSearchHighlightTest(WagtailTestUtils, TestCase):
                     is_current=False,
                     results=None,
                 ),
+                # TODO: Restore when we are succesfully indexing new highlight pages
+                # Bucket(
+                #   key="highlight",
+                #   label="Highlights",
+                #   result_count=2,
+                #   is_current=True,
+                #   results=None,
+                # ),
                 Bucket(
                     key="audio",
                     label="Audio",

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -1,4 +1,5 @@
 import json as json_module
+import unittest
 
 from typing import Any, Dict
 
@@ -773,13 +774,6 @@ class WebsiteSearchArticleTest(WagtailTestUtils, TestCase):
                     results=None,
                 ),
                 Bucket(
-                    key="highlight",
-                    label="Highlights",
-                    result_count=1,
-                    is_current=False,
-                    results=None,
-                ),
-                Bucket(
                     key="audio",
                     label="Audio",
                     result_count=0,
@@ -805,6 +799,7 @@ class WebsiteSearchArticleTest(WagtailTestUtils, TestCase):
         )
 
 
+@unittest.skip("Highlights bucket to be re-instated at a later date")
 @override_settings(
     KONG_CLIENT_BASE_URL="https://kong.test",
 )
@@ -929,13 +924,6 @@ class WebsiteSearchHighlightTest(WagtailTestUtils, TestCase):
                     label="Insights",
                     result_count=1,
                     is_current=False,
-                    results=None,
-                ),
-                Bucket(
-                    key="highlight",
-                    label="Highlights",
-                    result_count=2,
-                    is_current=True,
                     results=None,
                 ),
                 Bucket(
@@ -1452,6 +1440,7 @@ class TestDataLayerSearchViews(WagtailTestUtils, TestCase):
             },
         )
 
+    @unittest.skip("Highlights bucket to be re-instated at a later date")
     @responses.activate
     def test_datalayer_website_search_highlight(self):
         self.assertDataLayerEquals(


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-617

## About these changes

As the way the Highlights are created the current implementation in the Website results tab is broken i.e. the links go to 404 pages and thumbnail images no longer exist. 

The task is to remove (or hide) the Highlights bucket until we can properly include the descriptions and images from the Highlights.

## How to check these changes

Head to this URL locally: https://localhost:8000/search/website/?q=test

The 'Highlights' bucket should no longer be visible.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
