### PR TITLE
DF-618:Fix missing search counts

### DIFF
--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -15,7 +15,7 @@
             <p id="search-results-title" class="search-results__metadata-count">
                 Showing
                 {{page.start_index}}-{{page.end_index}}
-                (of {{ count|intcomma }}) result{{ count|pluralize}}
+                (of {{ paginator.count|intcomma }}) result{{ paginator.count|pluralize}}
                 for "{{ form.q.value|default:'*' }}"
                 in "<span id="analytics-current-bucket" data-current-bucket="{{ buckets.current.label }}">{{ buckets.current.label }}</span>"
             </p>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-618

## About these changes

Fix paginator count to show in search results.

## How to check these changes

- Navigate to search bucket - Ex Catalogue results -> Records at National Archives
- View Showing 1-20 (of `missing count should show here`) result for "*" in "Records at The National Archives"


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
