### PR TITLE
Visit the record -> View in the catalogue

### DIFF
--- a/sass/includes/_featured-record.scss
+++ b/sass/includes/_featured-record.scss
@@ -59,7 +59,7 @@
 
     @media only screen and (min-width: $screen__lg) {
       display: block;
-      padding: 2rem 0;
+      padding: 2rem 1rem 2rem 0;
     }
   }
 

--- a/templates/articles/blocks/featured_record.html
+++ b/templates/articles/blocks/featured_record.html
@@ -27,7 +27,7 @@
         </div>
 
         <div class="featured-record__action">
-            <a class="featured-record__button tna-button--yellow" href="{% record_url value.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Button" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>Visit <span class="sr-only">{{ value.record.summary_title }}</span> the record{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
+            <a class="featured-record__button tna-button--yellow" href="{% record_url value.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Button" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>View <span class="sr-only">{{ value.record.summary_title }}</span> in the catalogue{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Ticket URL: [paste URL here](https://national-archives.atlassian.net/browse/UN-509)

## About these changes

Changes the label "Visit the record" -> "View in the catalogue" and adds some additional right padding at large breakpoint to account for the longer button

<img width="1688" alt="Screenshot 2023-04-05 at 12 59 46" src="https://user-images.githubusercontent.com/298766/230075044-e1cdbe24-1ce3-42af-91a5-f78ada7b0e8b.png">
<img width="896" alt="Screenshot 2023-04-05 at 12 59 53" src="https://user-images.githubusercontent.com/298766/230075060-a3a05cac-4bdb-4cb6-a79c-77ea1b53ac83.png">


## How to check these changes

Add a featured record to the story template, and check that the button text shows "View in the catalogue"

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
