### PR TITLE
UN-378: Spacing between Featured Records and Image components

### DIFF
--- a/sass/includes/_featured-records.scss
+++ b/sass/includes/_featured-records.scss
@@ -1,4 +1,6 @@
 .featured-records {
+  margin-bottom: 4rem;
+
   &__heading {
     color: $color__dark;
     background-color: $color__yellow_2;

--- a/sass/includes/_featured-records.scss
+++ b/sass/includes/_featured-records.scss
@@ -1,5 +1,5 @@
 .featured-records {
-  margin-bottom: 4rem;
+  margin-bottom: 2rem;
 
   &__heading {
     color: $color__dark;


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-378

## About these changes

Added `margin-bottom` to the `featured-records` element in the SASS.

## How to check these changes

Go on a Stories/Article page, add a featured records block to the page.

I would suggest William Cuffey, an example here:
![image](https://user-images.githubusercontent.com/62654785/230436311-92c94d3f-bfeb-4f2d-a8b3-59a5e569c191.png)

Then view the page and ensure there is a gap between the featured-records component, and the content below it


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
