### PR TITLE
DF-320: Fix FeaturedSearchView when search form is invalid

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Union
 
 from django import forms
-from django.core.validators import MinLengthValidator
 from django.utils.functional import cached_property
 
 from etna.core.fields import END_OF_MONTH, DateInputField
@@ -79,7 +78,6 @@ class FeaturedSearchForm(forms.Form):
         # If no query is provided, pass None to client to fetch all results.
         empty_value=None,
         required=False,
-        validators=[MinLengthValidator(2)],
         widget=forms.TextInput(attrs={"class": "search-results-hero__form-search-box"}),
     )
 

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -758,13 +758,15 @@ class FeaturedSearchView(BaseSearchView):
         but to support template/rendering needs, it returns a `dict` instead of
         a `BucketList`, and instead of receiving additional argument values,
         `result_count` and `results` are set on each bucket using data
-        directly from `self.api_result`.
+        from `self.api_result`.
         """
         buckets = {}
         for i, bucket in enumerate(copy.deepcopy(FEATURED_BUCKETS)):
-            results = self.api_result[i]
-            bucket.result_count = results.total_count
-            bucket.results = results.hits
+            # NOTE: The API might not have been called if the form was invalid
+            if self.api_result:
+                results_for_bucket = self.api_result[i]
+                bucket.result_count = results_for_bucket.total_count
+                bucket.results = results_for_bucket.hits
             buckets[bucket.key] = bucket
         return buckets
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-320

## About these changes

FeaturedSearchView.get_buckets() should only add counts and hits to bucket data if the API has been called - which isn't the case when the form submission is invalid.

We've also changed our minds on applying a minimum length to the query, so this PR has also removed that validation (the first issue was important to resolve though, as the form could always change in future)

Resolves: https://the-national-archives.sentry.io/issues/4079397086

## How to check these changes

Do a search locally for "a" - you should no longer see a Django error page due to the invalid form

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
