### PR TITLE
UN-550: Fix: Poor image search results in Wagtail

### DIFF
--- a/etna/images/models.py
+++ b/etna/images/models.py
@@ -124,7 +124,7 @@ class CustomImage(ClusterableModel, AbstractImage):
         max_length=900,
     )
 
-    search_fields = [
+    search_fields = AbstractImage.search_fields + [
         index.SearchField("transcription", boost=1),
         index.SearchField("translation", boost=1),
         index.SearchField("description"),


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-550

## About these changes

We are not indexing 'title', 'collection' and other default fields when indexing images. Hence why we are seeing such poor results when searching.

## How to check these changes

Run `python manage.py update_index` locally after pulling these changes. You should then see far better search results in Wagtail's search view.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
