### PR TITLE
Fix templates after rebase

### DIFF
--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -8,26 +8,24 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_record_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-        {% endif %}
-        {% if page.body %}
-            <div class="body-container"
-                 data-container-name="time-period-explorer"
-                 id="analytics-time-period-explorer">
-                <div class="row">
-                    <div class="col-md-12">
-                        {% for block in page.body %}
-                            {% include_block block %}
-                        {% endfor %}
-                    </div>
+    {% if page.related_record_articles %}
+        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
+    {% endif %}
+    {% if page.body %}
+        <div class="body-container"
+             data-container-name="time-period-explorer"
+             id="analytics-time-period-explorer">
+            <div class="row">
+                <div class="col-md-12">
+                    {% for block in page.body %}
+                        {% include_block block %}
+                    {% endfor %}
                 </div>
             </div>
-        {% endif %}
-        {% if page.featured_article %}
-            {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
-        {% endif %}
+        </div>
+    {% endif %}
+    {% if page.featured_article %}
+        {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
     {% endif %}
     {% if page.related_articles %}
         {% include "includes/related-article-cards.html" with articles=page.related_articles title="Records revealed" %}


### PR DESCRIPTION
Ticket URL: ticket [here](https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-201)

## About these changes

This change is just removing the feature flag left over from rebasing this one to many times and becoming blind to this. Screenshot of page after removing the flag; 
![0 0 0 0_8000_explore-the-collection_explore-by-time-period_early-modern_ (3)](https://user-images.githubusercontent.com/22497837/231809714-c3ba5fd9-f5e0-4d7e-8072-639286789bf5.png)

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
