### PR TITLE
Fix topic explorer page template

### DIFF
--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -8,26 +8,24 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if FEATURE_RELATED_ARTICLE_ON_EXPLORE_PAGES %}
-        {% if page.related_record_articles %}
-            {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
-        {% endif %}
-        {% if page.body %}
-            <div class="container"
-                 data-container-name="topic-explorer"
-                 id="analytics-topic-explorer">
-                <div class="row">
-                    <div class="col-md-12">
-                        {% for block in page.body %}
-                            {% include_block block %}
-                        {% endfor %}
-                    </div>
+    {% if page.related_record_articles %}
+        {% include "includes/related-articles-highlight-cards.html" with articles=page.related_record_articles title="Records revealed" %}
+    {% endif %}
+    {% if page.body %}
+        <div class="container"
+             data-container-name="topic-explorer"
+             id="analytics-topic-explorer">
+            <div class="row">
+                <div class="col-md-12">
+                    {% for block in page.body %}
+                        {% include_block block %}
+                    {% endfor %}
                 </div>
             </div>
-        {% endif %}
-        {% if page.featured_article %}
-            {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
-        {% endif %}
+        </div>
+    {% endif %}
+    {% if page.featured_article %}
+        {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
     {% endif %}
     {% if page.related_articles %}
         {% include "includes/related-article-cards.html" with articles=page.related_articles %}


### PR DESCRIPTION
Ticket URL: [here](https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-201)

## About these changes

Yet again fixing merge conflicts caused by too many changes over the same templates. 

## How to check these changes

Load a TopicExplorerPage using staging data (local link [here](http://0.0.0.0:8000/explore-the-collection/explore-by-topic/british-state-and-citizens/).

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
