### PR TITLE
DF-396: Fix disappearing selected filters when other applied filters make them redundant

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -52,7 +52,6 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
         self,
         choice_data: List[Dict[str, Union[str, int]]],
         selected_values: Optional[List[Union[str, int]]] = (),
-        order_alphabetically: Optional[bool] = True,
     ):
         """
         Updates this fields `choices` list using aggregation data from the most recent
@@ -86,8 +85,8 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
                 label_base = missing_value
             choices.append((missing_value, f"{label_base} (0)"))
 
-        if order_alphabetically:
-            choices.sort(key=lambda x: x[1])
+        # Order alphabetically
+        choices.sort(key=lambda x: x[1])
 
         # Replace the field's attribute value
         self.choices = choices

--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -19,6 +19,8 @@ from ..ciim.constants import (
 class DynamicMultipleChoiceField(forms.MultipleChoiceField):
     """MultipleChoiceField whose choices can be updated to reflect API response data."""
 
+    widget = forms.widgets.CheckboxSelectMultiple
+
     def __init__(self, *args, **kwargs):
         self.validate_input = bool(kwargs.get("choices")) and kwargs.pop(
             "validate_input", True
@@ -34,6 +36,12 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
         if not self.validate_input:
             return True
         return super().valid_value(value)
+
+    def widget_attrs(self, widget):
+        attrs = super().widget_attrs(widget)
+        if not widget.is_hidden:
+            attrs["class"] = "search-filters__list"
+        return attrs
 
     @cached_property
     def configured_choice_labels(self):
@@ -134,16 +142,10 @@ class BaseCollectionSearchForm(forms.Form):
     level = DynamicMultipleChoiceField(
         label="Level",
         choices=LEVEL_CHOICES,
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"},
-        ),
         required=False,
     )
     topic = DynamicMultipleChoiceField(
         label="Topics",
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"}
-        ),
         required=False,
     )
     # Choices are supplied to this field to influence labels only. The options
@@ -151,31 +153,19 @@ class BaseCollectionSearchForm(forms.Form):
     collection = DynamicMultipleChoiceField(
         label="Collections",
         choices=COLLECTION_CHOICES,
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"}
-        ),
         required=False,
         validate_input=False,
     )
     closure = DynamicMultipleChoiceField(
         label="Closure Status",
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"}
-        ),
         required=False,
     )
     catalogue_source = DynamicMultipleChoiceField(
         label="Catalogue Sources",
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"}
-        ),
         required=False,
     )
     held_by = DynamicMultipleChoiceField(
         label="Held By",
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"}
-        ),
         required=False,
     )
     # Choices are supplied to this field to influence labels only. The options
@@ -183,9 +173,6 @@ class BaseCollectionSearchForm(forms.Form):
     type = DynamicMultipleChoiceField(
         label="Creator type",
         choices=TYPE_CHOICES,
-        widget=forms.widgets.CheckboxSelectMultiple(
-            attrs={"class": "search-filters__list"}
-        ),
         required=False,
         validate_input=False,
     )

--- a/etna/search/tests/fixtures/catalogue_search_with_multiple_filters.json
+++ b/etna/search/tests/fixtures/catalogue_search_with_multiple_filters.json
@@ -1,0 +1,1108 @@
+{
+    "took":88,
+    "responses":[
+        {
+            "took":2,
+            "timed_out":false,
+            "_shards":{
+                "total":3,
+                "successful":3,
+                "skipped":0,
+                "failed":0
+            },
+            "hits":{
+                "total":{
+                    "value":11,
+                    "relation":"eq"
+                },
+                "max_score":null,
+                "hits":[
+
+                ]
+            },
+            "aggregations":{
+                "heldBy":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"The National Archives, Kew",
+                            "doc_count":7
+                        },
+                        {
+                            "key":"Oxford University: Bodleian Library, Special Collections",
+                            "doc_count":2
+                        },
+                        {
+                            "key":"Walsall Local History Centre",
+                            "doc_count":1
+                        },
+                        {
+                            "key":"Wellcome Library",
+                            "doc_count":1
+                        }
+                    ]
+                },
+                "level":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"Piece",
+                            "doc_count":5
+                        },
+                        {
+                            "key":"Lettercode",
+                            "doc_count":3
+                        },
+                        {
+                            "key":"Division",
+                            "doc_count":1
+                        },
+                        {
+                            "key":"Item",
+                            "doc_count":1
+                        },
+                        {
+                            "key":"Series",
+                            "doc_count":1
+                        }
+                    ]
+                },
+                "catalogueSource":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"CAT",
+                            "doc_count":7
+                        },
+                        {
+                            "key":"MYC",
+                            "doc_count":4
+                        }
+                    ]
+                },
+                "topic":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+
+                    ]
+                },
+                "collection":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"HW",
+                            "doc_count":5
+                        },
+                        {
+                            "key":"DEFE",
+                            "doc_count":1
+                        },
+                        {
+                            "key":"RGO",
+                            "doc_count":1
+                        }
+                    ]
+                },
+                "type":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+
+                    ]
+                },
+                "closure":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"Open Document, Open Description",
+                            "doc_count":6
+                        }
+                    ]
+                },
+                "group":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"tna",
+                            "doc_count":7
+                        },
+                        {
+                            "key":"record",
+                            "doc_count":6
+                        },
+                        {
+                            "key":"aggregation",
+                            "doc_count":5
+                        },
+                        {
+                            "key":"nonTna",
+                            "doc_count":4
+                        },
+                        {
+                            "key":"evidential",
+                            "doc_count":3
+                        },
+                        {
+                            "key":"digitised",
+                            "doc_count":1
+                        }
+                    ]
+                }
+            },
+            "status":200
+        },
+        {
+            "took":88,
+            "timed_out":false,
+            "_shards":{
+                "total":3,
+                "successful":3,
+                "skipped":0,
+                "failed":0
+            },
+            "hits":{
+                "total":{
+                    "value":5,
+                    "relation":"eq"
+                },
+                "max_score":15.379637,
+                "hits":[
+                    {
+                        "_index":"ciim-160322",
+                        "_type":"_doc",
+                        "_id":"mongo-c5317611",
+                        "_score":15.379637,
+                        "_source":{
+                            "parent":[
+                                {
+                                    "summary":{
+                                        "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                    },
+                                    "identifier":[
+                                        {
+                                            "type":"reference number",
+                                            "reference_number":"HW 14",
+                                            "value":"HW 14",
+                                            "primary":true
+                                        }
+                                    ],
+                                    "@link":{
+                                        "role":[
+                                            {
+                                                "value":"parent"
+                                            }
+                                        ],
+                                        "qualifier":"association",
+                                        "relationship":{
+                                            "value":"hierarchical"
+                                        }
+                                    },
+                                    "@admin":{
+                                        "id":"C9293",
+                                        "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                    },
+                                    "level":{
+                                        "code":3
+                                    },
+                                    "source":{
+                                        "value":"CAT"
+                                    },
+                                    "@entity":"reference"
+                                }
+                            ],
+                            "sort":"06 0 494000 0#94000",
+                            "@hierarchy":[
+                                [
+                                    {
+                                        "summary":{
+                                            "title":"Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW",
+                                                "value":"HW",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C156",
+                                            "uuid":"478ea85d-91d2-3af4-bb0a-3ab86af087d1"
+                                        },
+                                        "level":{
+                                            "code":1
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"General records of the Government Code and Cypher School"
+                                        },
+                                        "@admin":{
+                                            "id":"C1209",
+                                            "uuid":"8068ff70-70ee-357c-8131-3a2400153c48"
+                                        },
+                                        "level":{
+                                            "code":2
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14",
+                                                "value":"HW 14",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C9293",
+                                            "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                        },
+                                        "level":{
+                                            "code":3
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"EWT to DD (Y) on non-morse equipment for Kedleston Hall Dec 16, Kenworthy at Knockholt..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14/94",
+                                                "value":"HW 14/94",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C5317611",
+                                            "uuid":"7627ea39-330a-3023-8f60-161d712880f6"
+                                        },
+                                        "level":{
+                                            "code":6
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    }
+                                ]
+                            ],
+                            "@template":{
+                                "details":{
+                                    "iaid":"C5317611",
+                                    "catalogueContext":[
+                                        "<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World...",
+                                        "General records of the Government Code and Cypher School",
+                                        "Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                    ],
+                                    "level":"Piece",
+                                    "legalStatus":"Public Record(s)",
+                                    "description":"<span class=\"wrapper\"><span class=\"scopecontent\"><p>EWT to DD (Y) on non-morse equipment for Kedleston Hall Dec 16, Kenworthy at Knockholt to EWT on non-morse equipment for Kedleston Dec 20, 8 new sets in operation at Knockholt from 20th, target figure for Kedleston 16 sets, program to start early 1944; WTC to GPO on extension and improvement of Sandridge aerial system Dec 19, AD (S) to DD (Y) with details of release of 4 GP sets at Sandridge to other countries\\' cover Dec 26, details of Spanish, Bulgarian, Romanian, Croat and Turkish military and police cover; John de Grey of WTC to Lt Col Ellingworth OC Beaumanor and to Capt Donnan at Harrogate with Chicksands\\' document on Sigint search Dec 17; WTC to MI-8 Dec 23 on meeting at WO Dec 16 on Sigint cover for W Europe operations, suggests increased cover Bishops Waltham and reactivation of Fort Bridgewoods Chatham; paper by JS Colman on recording test at Beaumanor, Nov 22, recordings unreliable, DD (Y) considers this test unsatisfactory, wishes to have similar test on GP at Kedleston Hall Dec 29; BP NCO to be posted to Beaumanor as RFP expert Dec 26; AD (S) to C on Spanish Military Attach\\xc3\\xa9 decrypts Dec 28; paper from AD (S) to Section Heads on Interception, TA and Cryptography as Parts of Sigint, term W/T I to be replaced by TA Dec 30; C asks BP to look for Sigint on Soviet activities in Poland for FO Dec 29, list of FO questions to be answered, questions designed to reveal state of Soviet plans for possible future Communist regime in Poland after Soviet occupation, BP unable to supply answers; organisation of AS W/T I Sub-Section Dec 17, Wing Cdr Garrett to DDI 4 on changes in AS since DDI 4 visit of Dec 14, AW Bonsall to HAS Dec 21 on small cypher and Orchestral W/T I, AD (S) to C Dec 21 accompanying AS paper on undesirability of shooting down GAF Zenit aircraft, implications for breaking Shark U-boat keys, reporting instructions for AS reports Dec 22, Wing Cdr Oeser of Hut 3 to Lt Col Crankshaw of WTC on BP\\'s failure to obtain continuity on GAF bomber unit from Nov 1, reply from Crankshaw Dec 23, letter of thanks to HAS from Dr RV Jones in AM Dec 31; liaison with AM, WO and RSS Barnet; liaison with ETOUSA Dec 16-18, ETOUSA wishes to start GP processing but looked upon unfavourably by AD (S) and AD (O), further request from ETOUSA Dec 31; EWT with O\\'Connor in Washington, Hinsley of BP NS arrives Washington Dec 22; minutes of WO meeting to discuss DF and Sigint cover before and during W Europe operations Dec 16; AS to AD (S) Dec 25 with suggested Ultra Charter for CSIO (Air); Chicksands weekly cover returns for w.e. Dec 18 and 25; telephone extensions at 21 AG, CSO locations and telephone numbers in Ebury House, Victoria St, London Dec 31; PG Lucas of SALU to HAS on suspected forced landing of GAF aircraft in Eire Dec 13 and possible return of crew by other GAF aircraft nights of Dec 15/16 and 16/17, report sent on to C Dec 21, AD (S) to C Dec 25 with log of GAF aircraft which made emergency landing in Eire Dec 13, sent by German Legation Dublin to Berlin Dec 24; BP decrypts of Rumanian Police messages July-Nov, samples to SIS for deciding distribution Dec 30; AD (S) to AS with distribution for Spanish Military Attach\\xc3\\xa9 decrypts Dec 30</p></span></span>",
+                                    "primaryIdentifier":"C5317611",
+                                    "type":"record",
+                                    "summaryTitle":"EWT to DD (Y) on non-morse equipment for Kedleston Hall Dec 16, Kenworthy at Knockholt...",
+                                    "dateCreated":"1943 Dec 16-31",
+                                    "closureStatus":"Open Document, Open Description",
+                                    "heldBy":"The National Archives, Kew",
+                                    "referenceNumber":"HW 14/94",
+                                    "heldById":"A13530124",
+                                    "deliveryOption":"No availability condition provisioned for this record"
+                                }
+                            }
+                        },
+                        "highlight":{
+                            "@template.details.closureStatus":[
+                                "<mark>Open</mark> <mark>Document</mark>, <mark>Open</mark> <mark>Description</mark>"
+                            ],
+                            "@template.details.description":[
+                                "OC Beaumanor and to Capt Donnan at Harrogate with Chicksands\\' document on Sigint <mark>search</mark>",
+                                "Waltham and reactivation of Fort Bridgewoods Chatham; paper by JS Colman on recording <mark>test</mark>",
+                                "at Beaumanor, Nov 22, recordings unreliable, DD (Y) considers this <mark>test</mark> unsatisfactory",
+                                ", wishes to have similar <mark>test</mark> on GP at Kedleston Hall Dec 29; BP NCO to be posted",
+                                "AD (S) to Section Heads on Interception, TA and Cryptography as Parts of Sigint, <mark>term</mark>"
+                            ]
+                        }
+                    },
+                    {
+                        "_index":"ciim-160322",
+                        "_type":"_doc",
+                        "_id":"mongo-c5317628",
+                        "_score":9.53506,
+                        "_source":{
+                            "parent":[
+                                {
+                                    "summary":{
+                                        "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                    },
+                                    "identifier":[
+                                        {
+                                            "type":"reference number",
+                                            "reference_number":"HW 14",
+                                            "value":"HW 14",
+                                            "primary":true
+                                        }
+                                    ],
+                                    "@link":{
+                                        "role":[
+                                            {
+                                                "value":"parent"
+                                            }
+                                        ],
+                                        "qualifier":"association",
+                                        "relationship":{
+                                            "value":"hierarchical"
+                                        }
+                                    },
+                                    "@admin":{
+                                        "id":"C9293",
+                                        "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                    },
+                                    "level":{
+                                        "code":3
+                                    },
+                                    "source":{
+                                        "value":"CAT"
+                                    },
+                                    "@entity":"reference"
+                                }
+                            ],
+                            "sort":"06 0 5111000 0#111000",
+                            "@hierarchy":[
+                                [
+                                    {
+                                        "summary":{
+                                            "title":"Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW",
+                                                "value":"HW",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C156",
+                                            "uuid":"478ea85d-91d2-3af4-bb0a-3ab86af087d1"
+                                        },
+                                        "level":{
+                                            "code":1
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"General records of the Government Code and Cypher School"
+                                        },
+                                        "@admin":{
+                                            "id":"C1209",
+                                            "uuid":"8068ff70-70ee-357c-8131-3a2400153c48"
+                                        },
+                                        "level":{
+                                            "code":2
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14",
+                                                "value":"HW 14",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C9293",
+                                            "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                        },
+                                        "level":{
+                                            "code":3
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"EWT to C Sept 1 reporting cypher change by GP from double Playfair to Raster stencil..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14/111",
+                                                "value":"HW 14/111",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C5317628",
+                                            "uuid":"0436fcfc-2250-38c1-9b52-5e34e92ea9eb"
+                                        },
+                                        "level":{
+                                            "code":6
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    }
+                                ]
+                            ],
+                            "@template":{
+                                "details":{
+                                    "iaid":"C5317628",
+                                    "catalogueContext":[
+                                        "<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World...",
+                                        "General records of the Government Code and Cypher School",
+                                        "Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                    ],
+                                    "level":"Piece",
+                                    "legalStatus":"Public Record(s)",
+                                    "description":"<span class=\"scopecontent\"><p>EWT to C Sept 1 reporting cypher change by GP from double Playfair to Raster stencil system; GPO HQ to EWT Sept 2 appreciating release of certain PO operators both now and at end of war; MI-8 to EWT Sept 5 re policy on ATS operators; DD 1 to C Sept 14 reobscene language about Hitler exchanged between German Army in South Ukraine and Berlin Aug 28; Lt Col Gadd of Sixta to AD (WTC) Sept 1 on frequency measurement; DD (CT) paper on post-war strategic Sigint, tasked by SIB meeting of Aug 4 and sent to Sigint Depts of Service Ministries Sept 13; BP notes on task allocation to stations Sept 1, terms of reference for new Task Control Co-ordination Section at BP Sept 4; AD (WTC) to OCs of all Service stations in UK Sept 1, next Station Officers\\' Conference to be at BP Sept 14, postponed Sept 11; AD (WTC) to CSO (SW) Sept 4, GP reception tests at Forest Moor and Shenley Sept 1--16, operators to be drawn from Kedleston Hall; agenda and minutes of 5th Station Commanders\\' meeting at Forest Moor Sept 7, next meeting to be Oct 19 at Shenley or in London, AD (WTC) to CSO (SW) Sept 11 on points arising from meeting at Forest Moor; Sept 9 details of cover of German Army MF frequencies at Bishops Waltham, Broadstairs and Chatham; trawl by AW Bonsall of AS Sept 3 for names of RAF personnel wishing to volunteer for duties involving German language after end of war; AS to AM Sept 5 giving cover situation at Capel; extracts from AS monthly letter to Kendrick in Ottawa on AS developments, Sept 5; Met Section notes for w.e. Sept 9, liaison with Det G of 849 SIS Foggia Sept 5; formation of new Air Intelligence Research Section at AM for post-war situation Sept 9; DDI 4 paper on move of No 365 WU to Continent to intercept and locate German flying bomb associated traffic, Sept 10, unit to operate under control of Cheadle; details of German V2 A4 rocket strikes against SE England Sept 8-12; DD (Y) to EWT Sept 14 re reply to Col Tozer on future cover in ME and/or FE Theatres; GP Capt Jones to C Sept 6 re request for 8 promotions to Major in Hut 3, AM had already approved 5 additional S/L posts; Wing Cdr Oeser of Hut 3 to EWT Sept 14 suggesting he be permitted to go to France to brief T Force officers of 21 and 12 AGs on nature of captured cypher documents required by GCCS; M/S letter from General Search Section at Tean to DD 1 accompanying batch of European development search logs Sept 15; DD 1 order Sept 1 on Stark reporting for SHAEF Advanced HQ; Col Bicher of ETOUSA to EWT Sept 2, to discuss question of combined UK/US crypt processing party with Gen Russbough in France Sept 3, Col Scott at SHAEF to DD (Y) Sept 2 re problems with Bicher; Scott to DD (Y) Sept 3 re expansion of Broadstairs; paper by Scott Sept 9 on obtaining intelligence from captured German Sigint centres; sitreps from 1 SWG to BP Sept 1-5, at Chartres Sept 3, moving to Rheims Sept 5; BP to 1 SIC Normandy Sept 3 with cover details; Gp Capt Winterbotham at HQ to DD 3 Sept 2 with notes of UK/USA meeting of Sept 1 on distribution of BP MSS Sigint to SCI units and American OSS personnel, solution agreed Sept 10, sent to C from Winterbotham, BP to start new ISNAV reporting series; Chicksands\\' cover return for w.e. Sept 9</p></span>",
+                                    "primaryIdentifier":"C5317628",
+                                    "type":"record",
+                                    "summaryTitle":"EWT to C Sept 1 reporting cypher change by GP from double Playfair to Raster stencil...",
+                                    "dateCreated":"1944 Sept 1-15",
+                                    "closureStatus":"Open Document, Open Description",
+                                    "heldBy":"The National Archives, Kew",
+                                    "referenceNumber":"HW 14/111",
+                                    "heldById":"A13530124",
+                                    "deliveryOption":"No availability condition provisioned for this record"
+                                }
+                            }
+                        },
+                        "highlight":{
+                            "@template.details.closureStatus":[
+                                "<mark>Open</mark> <mark>Document</mark>, <mark>Open</mark> <mark>Description</mark>"
+                            ],
+                            "@template.details.description":[
+                                "on nature of captured cypher documents required by GCCS; M/S letter from General <mark>Search</mark>",
+                                "Section at Tean to DD 1 accompanying batch of European development <mark>search</mark> logs Sept"
+                            ]
+                        }
+                    },
+                    {
+                        "_index":"ciim-160322",
+                        "_type":"_doc",
+                        "_id":"mongo-c5317622",
+                        "_score":8.0086975,
+                        "_source":{
+                            "parent":[
+                                {
+                                    "summary":{
+                                        "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                    },
+                                    "identifier":[
+                                        {
+                                            "type":"reference number",
+                                            "reference_number":"HW 14",
+                                            "value":"HW 14",
+                                            "primary":true
+                                        }
+                                    ],
+                                    "@link":{
+                                        "role":[
+                                            {
+                                                "value":"parent"
+                                            }
+                                        ],
+                                        "qualifier":"association",
+                                        "relationship":{
+                                            "value":"hierarchical"
+                                        }
+                                    },
+                                    "@admin":{
+                                        "id":"C9293",
+                                        "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                    },
+                                    "level":{
+                                        "code":3
+                                    },
+                                    "source":{
+                                        "value":"CAT"
+                                    },
+                                    "@entity":"reference"
+                                }
+                            ],
+                            "sort":"06 0 5105000 0#105000",
+                            "@hierarchy":[
+                                [
+                                    {
+                                        "summary":{
+                                            "title":"Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW",
+                                                "value":"HW",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C156",
+                                            "uuid":"478ea85d-91d2-3af4-bb0a-3ab86af087d1"
+                                        },
+                                        "level":{
+                                            "code":1
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"General records of the Government Code and Cypher School"
+                                        },
+                                        "@admin":{
+                                            "id":"C1209",
+                                            "uuid":"8068ff70-70ee-357c-8131-3a2400153c48"
+                                        },
+                                        "level":{
+                                            "code":2
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14",
+                                                "value":"HW 14",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C9293",
+                                            "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                        },
+                                        "level":{
+                                            "code":3
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"June 1 DO Nos 18 and 19, terms of reference for WTC Section and Sixta respectively,..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14/105",
+                                                "value":"HW 14/105",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C5317622",
+                                            "uuid":"09546cca-8ed0-3dad-81af-6b465c203fa0"
+                                        },
+                                        "level":{
+                                            "code":6
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    }
+                                ]
+                            ],
+                            "@template":{
+                                "details":{
+                                    "iaid":"C5317622",
+                                    "catalogueContext":[
+                                        "<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World...",
+                                        "General records of the Government Code and Cypher School",
+                                        "Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                    ],
+                                    "level":"Piece",
+                                    "legalStatus":"Public Record(s)",
+                                    "description":"<span class=\"scopecontent\"><p>June 1 DO Nos 18 and 19, terms of reference for WTC Section and Sixta respectively, DO No 22 of June 8, charter for first GCCS rep to SHAEF, Lt Col Blair-Cunynghame; report by Wing Cdr Garrett, Deputy Head of BP AS, June 1, on his admonishment at AM by Air Cdr Easton and DDI 4 Gp Capt Daubney, accused of allegiance to BP to detriment of AM, resulting in deteriation of liaison between AM and AS, DD (AS) to EWT June 2 following visit to BP by Daubney as follow up to admonishment of Garrett; MI-8 to EWT June 3 with list of potential Allied bombing targets with details of E factories and distribution centres in attempt to hold up introduction of Uncle Dick E modification, list updated June 10; nomenclature for activities relating to study of foreign signals with suggested amendments June 9; minutes of BP meeting June 1 with reps from Huts 3 and 6 on economy of sets for Western cover; BP to MI-8 June 2, all Army CRR staff from Hampstead Special Training Wing to be transferred to BP MW and come under OC Sixta; selected reports and working aids for W Front June 2; WTC on Sutton Valence as contingency station for Capel June 2; results of WTC intercept comparison tests involving Whitchurch June 3; DMS to HBS on expansion of Forest Moor June 3, end of GP cover there June 3, positions to revert to E; WTC\\'s amendments to minutes of 3rd Station Commanders\\' Conference sent to CSO (SW) June 3, reissued by CSO (SW) June 7; J de G\\'s visit reports for Forest Moor (May 19/20 and 27/28), Scarborough (May 21), Hawklaw (May 22-26) and Cheadle, Tean and Marston (May 29/30); J de G to OC Kedleston Hall June 9, unable to attend party there June 10 but will visit following week to deliver lecture to operators, J de G to OC RN Sigint Station Scarborough June 10 inviting him to next inter-Service Station Commanders\\' meeting; summary of cover and DF in the West June 4 by Lt Col Blair-Cunynghame, includes 1 SWG and 1 SIC at Rustington, 7 SWS at Bishops Waltham, 10 SW at Broadstairs and 116 SWG at Saxmunden, DF networks centred on Bishops Waltham and Harpendon, B-Cunnynghame to Col Scott at SHAEF June 4 on use of SCU channel for passing Allied combat intentions to BP; EWT to C June 6 re Comsec monitoring of Allied comms for SHAEF; HBS to BEW and WEC re Whitchurch and Forest Moor June 6, WTC to Hut 6 June 13 on transfer of E cover from Whitchurch to Forest Moor; HQ AEAF Sigint Weekly Notes No 14 May 31-June 6 including D-Day; Sixta reports on German W/T reactions to Allied invasion as at midday June 7 and June 13; Sayer to DDI 4 June 8 re printers at Chicksands, reply June 13, WTC to HCS Maine at HQ June 9 re request for more printer links between Chicksands and BP, reply June 12, Sayer to AD (CI) and reply, Colman of Hut 6 to Sayer June 14 on shortage of printer links to Chicksands, reply June 15; WTC notes on meeting with Gp Capt Daubney June 7; WTC to MI-8 on Beaumanor CRR staff problems June 8; WTC to OC Cheadle giving instructions to Tean search June 8; Sayer asks OC Beaumanor to come to BP to discuss W Front matters June 13, cancelled, Sayer and DD (Y) to Beaumanor June 13, Sayer to DD (Y) June 14 summarising meeting; minutes of WTC weekly meeting No 6 of June 12; DMS to BEW June 13 on increase of E positions since Feb; WTC tasking for Harpendon June 13; minutes of meeting at WO June 14 to discuss SHAEF document of June 12 on collection of MF E, training of new operators for Broadstairs to start at Harpendon, 116 SW to move from Saxmundham to Rustington; Hut 6 Research report June 15 on success against German Western Army keys since D-Day; AS instruction for handling Elgar traffic June 1; list of all AS reporting series with separate distribution list June 1; AS to SHAEF June 2 on dissemination of Sigint by Operational Watch during Overlord; DD (AS) to OC Cheadle June 2 on reporting of GAF activity; Supplement No 2 to W Front Summary No 38, Sixta report on GAF W/T exercises, June 2; HQ AEAF to DD (AS) June 3 listing officers of AEAF, 2nd TAF and IXth AF entitled to see Hutment and Tentage Sigint reports, AS starts Hutment and Tentage Sigint service to AEAF and TAF June 3; AS rules for passing Hutment and Tentage to West Kingsdown June 7; AW Bonsall to DD (AS) June 4 giving update on GAF codes prior to Overlord; Handel Edwards of AS to Sayer of WTC on F cover at Capel and Lydford June 4, F sets at Capel to be re-allocated to E w.e.f. June 16/17; terms of reference for AS June 6; instructions for AS Operational Watch reporting of Fliegerkorps IX and X bombing intentions June 8, Gp Capt Jones to Hut 3 key staff on liaison with AS Operational Watch June 12; HQ AEAF to OC Cheadle re W/T links between 365 WU 3rd Mobile Radio Sqn Detachment A and Cheadle June 9, W/T links for AEAF 365 WU with Detachment A of SIS IX AF June 11; report by Air Sigs Section to DD (AS) June 12 on visit to 365 WU with senior officers of HQ AEAF; DD (AS) to Gp Capt Scott-Farnie at HQ AEAF re Sigint support to Commands June 13; DD (AS) to EWT June 13 re visit to AS by Capt Bergman of ETOUSA, Col Bicher pushing for more US integrees at BP, DD (AS) vetoes Bicher\\'s proposed transfer of US personnel from Cheadle to BP; Met Section notes for w.e. June 10; USSTAF to BP June 13 requesting more Sigint from Russia, France, Italy and Balkans; BP liaison with 4 FU Malta on Playfair traffic June 1; Chicksands\\' cover returns for w.e. May 27 and June 10, Chicksands\\' traffic totals for 24 hours June 6/7 with division of messages sent to BP by printer and DR; Col Scott at SHAEF to DD (Y) June 9 highly critical of Sigint security instruction from MI-8; Hut 3 directive on Cobra-series reporting on tactical air intelligence in West June 1; report for w.e. June 2 and 9 on Foynes Radio, Eire</p></span>",
+                                    "primaryIdentifier":"C5317622",
+                                    "type":"record",
+                                    "summaryTitle":"June 1 DO Nos 18 and 19, terms of reference for WTC Section and Sixta respectively,...",
+                                    "dateCreated":"1944 June 1-15",
+                                    "closureStatus":"Open Document, Open Description",
+                                    "heldBy":"The National Archives, Kew",
+                                    "referenceNumber":"HW 14/105",
+                                    "heldById":"A13530124",
+                                    "deliveryOption":"No availability condition provisioned for this record"
+                                }
+                            }
+                        },
+                        "highlight":{
+                            "@template.details.closureStatus":[
+                                "<mark>Open</mark> <mark>Document</mark>, <mark>Open</mark> <mark>Description</mark>"
+                            ],
+                            "@template.details.description":[
+                                "Beaumanor CRR staff problems June 8; WTC to OC Cheadle giving instructions to Tean <mark>search</mark>"
+                            ]
+                        }
+                    },
+                    {
+                        "_index":"ciim-160322",
+                        "_type":"_doc",
+                        "_id":"mongo-c5317614",
+                        "_score":5.1649218,
+                        "_source":{
+                            "parent":[
+                                {
+                                    "summary":{
+                                        "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                    },
+                                    "identifier":[
+                                        {
+                                            "type":"reference number",
+                                            "reference_number":"HW 14",
+                                            "value":"HW 14",
+                                            "primary":true
+                                        }
+                                    ],
+                                    "@link":{
+                                        "role":[
+                                            {
+                                                "value":"parent"
+                                            }
+                                        ],
+                                        "qualifier":"association",
+                                        "relationship":{
+                                            "value":"hierarchical"
+                                        }
+                                    },
+                                    "@admin":{
+                                        "id":"C9293",
+                                        "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                    },
+                                    "level":{
+                                        "code":3
+                                    },
+                                    "source":{
+                                        "value":"CAT"
+                                    },
+                                    "@entity":"reference"
+                                }
+                            ],
+                            "sort":"06 0 497000 0#97000",
+                            "@hierarchy":[
+                                [
+                                    {
+                                        "summary":{
+                                            "title":"Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW",
+                                                "value":"HW",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C156",
+                                            "uuid":"478ea85d-91d2-3af4-bb0a-3ab86af087d1"
+                                        },
+                                        "level":{
+                                            "code":1
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"General records of the Government Code and Cypher School"
+                                        },
+                                        "@admin":{
+                                            "id":"C1209",
+                                            "uuid":"8068ff70-70ee-357c-8131-3a2400153c48"
+                                        },
+                                        "level":{
+                                            "code":2
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14",
+                                                "value":"HW 14",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C9293",
+                                            "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                        },
+                                        "level":{
+                                            "code":3
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"MI-8 to Col Tiltman at BP Feb 2 with draft of Allied signals requirements from Germans..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14/97",
+                                                "value":"HW 14/97",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C5317614",
+                                            "uuid":"3acea365-f315-3fd4-9809-2b29e9882c8b"
+                                        },
+                                        "level":{
+                                            "code":6
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    }
+                                ]
+                            ],
+                            "@template":{
+                                "details":{
+                                    "iaid":"C5317614",
+                                    "catalogueContext":[
+                                        "<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World...",
+                                        "General records of the Government Code and Cypher School",
+                                        "Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                    ],
+                                    "level":"Piece",
+                                    "legalStatus":"Public Record(s)",
+                                    "description":"<span class=\"wrapper\"><span class=\"scopecontent\"><p>MI-8 to Col Tiltman at BP Feb 2 with draft of Allied signals requirements from Germans under Armistice terms, asking for Tiltman\\'s comments, reply Feb 8; AD (S)\\'s comments on para dealing with German cyphers and Sigint of FO draft on German Armistice Feb3, more correspondence Feb 13; DD (S) Serial Order No 145 on Sixta Section Feb 5; AD (S) exclusive to C quoting message from Spanish AA in Rome Feb 8; DMI to C Feb 7 on compromise of Sigint Ultra by officer in WO; program for visit of DMI to BP on Feb 9, confirmed Feb 7; DDMI (I) Brig JM Kirkman to EWT Feb 12, to visit BP late Feb, praise for BP\\'s Sigint reports; WTC to DD (Y) WO Feb 1 on meeting to be held at BP on role of Kedleston in printer cover and interaction with Knockholt, meeting on Feb 8, Lt Col Sayer\\'s summary; Sayer to DD (Y) Feb 3 requesting that GCCS be consulted by OCs Army Sigint stations when given orders by senior military authorities such as CSO SW or DD (Y), agreed Feb 12; Sayer to CSO SW Col Balmain Feb 7 on proposed visit to BP, Sayer obstructive; Sayer to AD (S) Feb 9 summarising meeting at BP Feb 8 on printer cover at Kedleston Hall; John de Grey\\'s trip report on visit to Chicksands Feb 12, new CO and Sigint expansion program there; Feb 12 results of sound recording test on GP tasks at Kedleston Hall Jan 7-14; suggested times for DR runs between BP, Beaumanor and Forest Moor Feb 12; comparison by Forest Moor CRR of Forest Moor intercept with that of Chicksands Feb 4; JS Colman to Sayer Feb 5 on requirement for more search positions at Beaumanor at expense of GP positions; comparison of GP intercept quality at Beaumanor and Kedleston Hall Feb 10, inconclusive; AS orders for reporting 3-figure codes Feb 1; suggested Ultra Charter for CSIO (Air) sent to AD (S) with copy of Tentage regulations Feb 1; AS to DDI 4 Feb 1 requesting extra sets at Capel for F Lily cover, DDI 4 to AS Feb 1 on frequency measuring equipment for Kingsdown, Sigint channels from BP via Bentley Priory to Sigint air customers in UK Feb 2; AS bid for more sets at Capel Feb 5, DDI 4 unsympathetic, Feb 6 Handel Edwards to HAS supporting case for increase at Capel, Gp Capt Jones to HAS on Hut 3\\'s acceptance of tying up E with F Cockroach, AS to provide F working aids to Hut 3 Feb 6; liaison to be arranged by AM between COPC and AS, study of BMP reports Feb 9; evaluation by HAS Feb 13 of practice reports from AEAF WAtch at Kingsdown; UK sets on GAF low grade cover as at Feb 14, Handel Edwards to HAS Feb 13 on additional sets required for F traffic, AS list of German Western Front groups using F as at Feb 10; AS liaison with BC Feb 15; list of 42 members of AS with knowledge of Russian, Balkan or Turkish languages Feb 10; paper by Dr GC McVittie of Met Section on weather forecasting for air operations over enemy territories with particular emphasis on Japanese Theatre Feb 6; progress report Feb 10 for Jan 1944 sent to BP Met Section from Detachment G of US 849th SIS with cumulative production chart; Col Scott of SHAEF to Sayer on Sigint cover for Western Front Feb 2, reply from AD (S) Feb 9 re Scott\\'s Draft Directive, Scott to EWT Feb 4 on UK and US tactical E Sigint on Western Front, suggests should be limited to British units, AD (S) thinks not, Sayer asks EWT to confirm, Sayer to Heads of Sections on requirements for Western offensive Feb 7, Section replies Feb 9, JS Colman to Sayer Feb 8 on total of additional sets required for Western offensive plus notes on method of assessing cover situation, WTC summary of extra sets required for W Front Feb 15; GPO letter Feb 4 giving details of new Sigint printer links being established for W Front; Commodore EGN Rushbrooke of NID to C Feb 9 on cover story for Sigint being disseminated for Overlord, suggests normal CX report from a fictitious source, also agreed by DDMI (O) Brigadier Vale, EWT to C Feb 14, C to Rushbrooke Feb 15 agreeing with his suggestions for dissemination to Overlord planners; Draft Directive from Col Scott SHAEF for I (s) G2 Intel Div SHQAEF, this second draft to be discussed at meeting on Feb 21; quarterly report Feb 2 from HC Kenworthy at Knockholt to SIB on printer cover and manning at PO and FO stations, addendum Feb 13; Feb 2/4 Hendon RAF DF station interfers with major GP frequency; exchanges within BP and letter to GPO on subject of military call-up of 24 experienced operators from PO Sigint stations, strong objections from BP Feb 6; GPS to Col Tiltman Feb 6 suggesting planned DOE between BP and Polish Sigint unit at Stanmore, Stanmore should send intercept drop copies to GPS; paper by Lt Col Pritchard Feb 7 on processing of German printer comms, Colossus 2 expected in about 2 months; USA Lt Col Telford Taylor of Hut 3 to Gp Capt Jones Feb 8 on dissemination of BP series diplomatic intelligence to US European and Med Theatre Commands, list of Commands supplied with Ultra from Hut 3, Med and W Front Feb 13; liaison with US, US Sigint site at Bexley Heath to be operational from Mar 1 and direct control line required from Hut 6 to Hall Place Bexley Heath Feb 14, correspondence between Col Bicher of ETOUSA and EWT Feb 2-9, Bicher sends EWT copy of First Anniversary Edition of ETORIG Weekly TA Notes Feb 2, Feb 9 EWT to Bicher on training of US personnel on Bombes at Stanmore, Eastcote and BP; liaison with Director CBME, AS sends regulations for Hutment and Tentage Ultra Sigint, copy also to Winterbotham at HQ, Winterbotham asks HAS if Col Tiltman had put out same regulations to Med and SHAEF Feb 9; D of S WO to SIB listing telephone requirements for WO Field Y stations and DF networks Feb 11; MI-8 report on comms networks in S France Feb 3; minute from Section V at MI-6 to AD (O) on distribution of Abwehr agent reports, C contacted on distribution of BP MEL and ISTUN reports Feb 3; AD (S) to C Feb 11 with suggested distribution for Bulgarian Military Attach\\xc3\\xa9 reports; MI-8 to AD (S) Feb 11 on intelligence content of ZIP/PEARL CROMIL Croat military reports, gives more specific intelligence requirements in attempt to reduce number of reports</p></span></span>",
+                                    "primaryIdentifier":"C5317614",
+                                    "type":"record",
+                                    "summaryTitle":"MI-8 to Col Tiltman at BP Feb 2 with draft of Allied signals requirements from Germans...",
+                                    "dateCreated":"1944 Feb 1-15",
+                                    "closureStatus":"Open Document, Open Description",
+                                    "heldBy":"The National Archives, Kew",
+                                    "referenceNumber":"HW 14/97",
+                                    "heldById":"A13530124",
+                                    "deliveryOption":"No availability condition provisioned for this record"
+                                }
+                            }
+                        },
+                        "highlight":{
+                            "@template.details.closureStatus":[
+                                "<mark>Open</mark> <mark>Document</mark>, <mark>Open</mark> <mark>Description</mark>"
+                            ],
+                            "@template.details.description":[
+                                "12, new CO and Sigint expansion program there; Feb 12 results of sound recording <mark>test</mark>",
+                                "with that of Chicksands Feb 4; JS Colman to Sayer Feb 5 on requirement for more <mark>search</mark>"
+                            ]
+                        }
+                    },
+                    {
+                        "_index":"ciim-160322",
+                        "_type":"_doc",
+                        "_id":"mongo-c5317620",
+                        "_score":4.732587,
+                        "_source":{
+                            "parent":[
+                                {
+                                    "summary":{
+                                        "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                    },
+                                    "identifier":[
+                                        {
+                                            "type":"reference number",
+                                            "reference_number":"HW 14",
+                                            "value":"HW 14",
+                                            "primary":true
+                                        }
+                                    ],
+                                    "@link":{
+                                        "role":[
+                                            {
+                                                "value":"parent"
+                                            }
+                                        ],
+                                        "qualifier":"association",
+                                        "relationship":{
+                                            "value":"hierarchical"
+                                        }
+                                    },
+                                    "@admin":{
+                                        "id":"C9293",
+                                        "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                    },
+                                    "level":{
+                                        "code":3
+                                    },
+                                    "source":{
+                                        "value":"CAT"
+                                    },
+                                    "@entity":"reference"
+                                }
+                            ],
+                            "sort":"06 0 5103000 0#103000",
+                            "@hierarchy":[
+                                [
+                                    {
+                                        "summary":{
+                                            "title":"Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW",
+                                                "value":"HW",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C156",
+                                            "uuid":"478ea85d-91d2-3af4-bb0a-3ab86af087d1"
+                                        },
+                                        "level":{
+                                            "code":1
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"General records of the Government Code and Cypher School"
+                                        },
+                                        "@admin":{
+                                            "id":"C1209",
+                                            "uuid":"8068ff70-70ee-357c-8131-3a2400153c48"
+                                        },
+                                        "level":{
+                                            "code":2
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14",
+                                                "value":"HW 14",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C9293",
+                                            "uuid":"21ba9b44-5dad-331f-ade6-cdab4bac079d"
+                                        },
+                                        "level":{
+                                            "code":3
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    },
+                                    {
+                                        "summary":{
+                                            "title":"EWT to DMI May 2 with notes in preparation for DMI\\'s visit to BP, DMI to C May 8..."
+                                        },
+                                        "identifier":[
+                                            {
+                                                "type":"reference number",
+                                                "reference_number":"HW 14/103",
+                                                "value":"HW 14/103",
+                                                "primary":true
+                                            }
+                                        ],
+                                        "@admin":{
+                                            "id":"C5317620",
+                                            "uuid":"d4c02637-4cf8-3921-8f52-125544b0e8b3"
+                                        },
+                                        "level":{
+                                            "code":6
+                                        },
+                                        "source":{
+                                            "value":"CAT"
+                                        },
+                                        "@entity":"reference"
+                                    }
+                                ]
+                            ],
+                            "@template":{
+                                "details":{
+                                    "iaid":"C5317620",
+                                    "catalogueContext":[
+                                        "<unittitle type=\"Title\">Government Code and Cypher School: Directorate: Second World...",
+                                        "General records of the Government Code and Cypher School",
+                                        "Records created or inherited by Government Communications Headquarters (GCHQ)"
+                                    ],
+                                    "level":"Piece",
+                                    "legalStatus":"Public Record(s)",
+                                    "description":"<span class=\"scopecontent\"><p>EWT to DMI May 2 with notes in preparation for DMI\\'s visit to BP, DMI to C May 8 requesting more Sigint on V1 Crossbow units; DDOD (I) May 9 on impending visit to BP; DD (Y) visits BP May 2 for discussions on Sigs 4 SW/831/1/1 Sigint DF and Sigs 4 SW/22/5/1 employment of ATS; DD (Y) to CSO (SW) May 10, station visits to be reduced in anticipation of D Day, all requests for station visits to go to MI-8 for DD (Y); May 2 Col Scott of SHAEF to SIB, EWT, Col Bicher and named officers at WO, AM and Admiralty, with proposals for introducing a SHAEF Sigint identity card for priority access when engaged on Sigint related duties, idea approved by EWT May 4; MI-8 agrees with DD 1 May 3 that details of GP radio network would not be released to Public Safety sub-section of SHAEF until GP comms closed down under Armistice terms; May 4 minutes of meeting May 3 with Gen Whiteley of SHAEF on DOE between US at Weymouth St and BP on processing of medium grade cyphers and feeding of intelligence to SHAEF and 21 AG; Col Bicher of ETOUSA to EWT May 4 with list of advantages and disadvantages for a combined UK/US medium grade party, amusing counter arguments by DD 1; chart prepared for EWT May 6 illustrating Y units in UK and number of sets targeted against medium grade cyphers, German military units in N France and radius of intercept for each Y station; EWT to Maj Gen Whiteley at SHAEF May 8 following visit of Col Bicher to BP, more discussions on processing of medium grade cyphers, Bicher reluctantly agrees to two separate parties at Weymouth St and BP; Col Scott at SHAEF to Brigadier ET Williams at HQ 21 AG May 8 re Sigint support for Western Front; Sixta to EWT May 7 giving 6 reasons for keeping processing of E and medium grade cyphers at same location, ie BP; minutes of discussions May 11 between Majors Brown of BP and Neff of ETOUSA on continuing problems with processing medium grade (non-indicator) cyphers in preparation for Overlord; meeting to be held May 14 at BP on preparations for Overlord with talks by representatives from all main sections, all key workers to attend; WTC to HCS Maine at HQ May 1 re comms circuits BP - Forest Moor, also to CSO (SW), Forest Moor to man an additional 36 sets during May; minutes of first WTC section weekly meeting of May 1, Wallace and Crankshaw to visit Knockholt early May, minutes of second meeting May 8; WTC to DD 1 May 2 re functions of BP liaison officer with Y stations, (John de Grey), asks for advice on Naval stations; trial of GP cover at Forest Moor May 2; WTC results of reception comparison tests Apr 27-29 between Chicksands and Forest Moor May 5; WTC to EWT May 5 re reception problems with Croat, WTC arranges fortnight\\'s trial at Forest Moor May 5; John de Grey to Sayer May 7 giving details of Chicksands\\' watches; letter of thanks May 8 from OC Beaumanor to WTC for talks by John de Grey to Beaumanor staff May 5/6; 12 printer circuits from Forest Moor to BP May 9, of which 9 for E; WTC to Sixta and Hut 6 asking for comments on performance of US station at Bexley Heath May 9, Major Carr of BP Comcen to WTC May 9 on state of printer circuits to Bexley Heath, evaluation of Bexley Heath May 10 for WTC by JS Colman, Sixta reports May 15 station well below required standard, WTC analysis of traffic taken at US site at Bexley Heath and comparison with intercept at UK stations May 13; notes by John de Grey May 9 following his visit to Whitchurch; WTC to GCWS Knockholt requesting weekly cover return and also details of non-morse cover at Wincombe May 9; WTC to Major Carr May 10 requesting increased landlines for Capel, WTC to John de Grey at Bishops Waltham on F tasking of Capel May 11; WTC reviews deception scheme of DD (AS) to pass disinformation on German comms networks May 11, sent by WTC to DD 1 May 12, rejected by DD 1; Lt Col Wallace of WTC to John de Grey May 12 omitting Knockholt from de Grey\\'s program of visits, EWT rules all matters concerning FORDE or GCWS at Knockholt should in future be dealt with by Wallace personally; BP order on processing Fish from Knockholt signed by EWT May 12; more correspondence May 4 between C and GPO Chief Engineer re BP request for PO monitoring of Berlin - Tokio facsimile service, BP to pursue purchase of intercept equipment in US; May 9 JS Colman at BP to main UK stations giving procedure for reporting local interference on target frequencies, Colman to Sayer May 13 on case for putting more Beaumanor key staff in the know and thus allowing them to visit BP; DD 1 to C May 10 with first deception report for Col Bevan; paper by Lt Col Blair-Cunnynghame May 13 on advantages of having 2 receivers on each intercept position, extended by WTC to O/Cs UK Sigint stations, comments by John de Grey; May 13 Williams\\' evaluation for EWT of Sigint from PO coastal stations; May 14 additional printer circuits being installed between BP and stations for rapid sending of E intercept; Gp Capt Winterbotham at HQ to DD (AS) from C and EWT May 3, Russian met officer going to Iceland to study met conditions for proposed shuttle service Scotland - USSR, BP Met Section rep ordered to go to Dunstable to study met service to Iceland and ensure that the Russian would be unable to determine that UK was breaking German met cyphers; report of May 4 on AS visit to Kingsdown Apr 28 and discussions on Kingsdown Broadcast Carpenter Code, start of Kingsdown Broadcast May 8, AM suggests MAAF Algiers should monitor, useful data for 15th AF, SHAEF order on Kingsdown Sigint Broadcast May 15; Met Section Weekly Summary for May 1-6; May 8 list of 19 AS F tasks not covered in May because of lack of sets, with request for more positions, WTC to MI-8 May 14 on UK shortage of MF positions for W Front; AS takes over Spanish military processing May 9; minutes of meeting of May 12 on tasks of AS Operational Watch; Cheadle Sigint Broaadcast for AEAF May 3, chart showing flow of Sigint for AEF May 4, request from DCIO Sigint AEAF May 12 for one-time pads for 365, 382 and 383 WUs and for 3 Mobile Radio Sqn Detachments A, B and C; contents of Murder Bag for USAF Sigint detachment at Cheadle May 4; Chicksands\\' weekly cover return for w.e. Apr 29 and May 6, upgrading of Chicksands\\' printer links to BP May 13; Tean general search report for Apr dated May 3; details of move of GSI (s) 21 AG from Ilchester Place to Southwick May 14; Foynes Radio Eire report for w.e. May 5 and May 12; Hut 3 to EWT May 5 re naval intelligence from Fish; AM report of May 13 on German met station in E Greenland since Aug 1942, comments from Mc\\'Vittie of Met Section</p></span>",
+                                    "primaryIdentifier":"C5317620",
+                                    "type":"record",
+                                    "summaryTitle":"EWT to DMI May 2 with notes in preparation for DMI\\'s visit to BP, DMI to C May 8...",
+                                    "dateCreated":"1944 May 1-15",
+                                    "closureStatus":"Open Document, Open Description",
+                                    "heldBy":"The National Archives, Kew",
+                                    "referenceNumber":"HW 14/103",
+                                    "heldById":"A13530124",
+                                    "deliveryOption":"No availability condition provisioned for this record"
+                                }
+                            }
+                        },
+                        "highlight":{
+                            "@template.details.closureStatus":[
+                                "<mark>Open</mark> <mark>Document</mark>, <mark>Open</mark> <mark>Description</mark>"
+                            ],
+                            "@template.details.description":[
+                                "29 and May 6, upgrading of Chicksands\\' printer links to BP May 13; Tean general <mark>search</mark>"
+                            ]
+                        }
+                    }
+                ]
+            },
+            "aggregations":{
+                "heldBy":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"The National Archives, Kew",
+                            "doc_count":5
+                        }
+                    ]
+                },
+                "level":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"Piece",
+                            "doc_count":5
+                        }
+                    ]
+                },
+                "catalogueSource":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"CAT",
+                            "doc_count":5
+                        }
+                    ]
+                },
+                "topic":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+
+                    ]
+                },
+                "collection":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"HW",
+                            "doc_count":5
+                        }
+                    ]
+                },
+                "type":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+
+                    ]
+                },
+                "closure":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"Open Document, Open Description",
+                            "doc_count":5
+                        }
+                    ]
+                },
+                "group":{
+                    "doc_count_error_upper_bound":0,
+                    "sum_other_doc_count":0,
+                    "buckets":[
+                        {
+                            "key":"record",
+                            "doc_count":5
+                        },
+                        {
+                            "key":"tna",
+                            "doc_count":5
+                        }
+                    ]
+                }
+            },
+            "status":200
+        }
+    ]
+}

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -396,9 +396,9 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         self.assertSearchWithinOptionRendered(content)
         self.assertSortOrderOptionsRendered(content)
         self.assertNoResultsMessagingRendered(content)
+        self.assertFilterOptionsRendered(content)
 
         # SHOULD NOT see
-        self.assertFilterOptionsRendered(content)
         self.assertResultsNotRendered(content)
 
     @responses.activate
@@ -441,6 +441,32 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         # SHOULD NOT see
         self.assertNoResultsMessagingNotRendered(content)
+
+    @responses.activate
+    def test_selected_filter_options_remain_visible(self):
+        """
+        When a user is viewing search results for a particular bucket,
+        then uses filter options to further refine that search,
+        all selected filters should remain available as filter options,
+        even if they were excluded from the API results 'aggregations'
+        list due to not having any matches.
+        """
+        self.patch_search_endpoint("catalogue_search_with_multiple_filters.json")
+        response = self.client.get(
+            self.test_url,
+            data={
+                "q": "test+search+term",
+                "group": "tna",
+                "collection": ["DEFE", "HW", "RGO"],
+                "level": "Piece",
+                "closure": "Open+Document%2C+Open+Description",
+            },
+        )
+        content = str(response.content)
+
+        self.assertIn('<input type="checkbox" name="collection" value="DEFE"', content)
+        self.assertIn('<input type="checkbox" name="collection" value="HW"', content)
+        self.assertIn('<input type="checkbox" name="collection" value="RGO"', content)
 
 
 class WebsiteSearchEndToEndTest(EndToEndSearchTestCase):

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -460,13 +460,15 @@ class BaseFilteredSearchView(BaseSearchView):
         See also: `get_api_aggregations()`.
         """
         for key, value in api_result.aggregations.items():
-            if buckets := value.get("buckets"):
-                field_name = camelcase_to_underscore(key)
-                if field_name in self.dynamic_choice_fields:
-                    form.fields[field_name].update_choices(buckets)
-                    form[field_name].more_filter_options_available = bool(
-                        value.get("sum_other_doc_count", 0)
-                    )
+            field_name = camelcase_to_underscore(key)
+            if field_name in self.dynamic_choice_fields:
+                choice_data = value.get("buckets", ())
+                form.fields[field_name].update_choices(
+                    choice_data, selected_values=form.cleaned_data.get(field_name, ())
+                )
+                form[field_name].more_filter_options_available = bool(
+                    value.get("sum_other_doc_count", 0)
+                )
 
     def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-396

## How to check these changes

Check out the following URL in develop: https://develop-sr3snxi-rasrzs7pi6sd4.uk-1.platformsh.site/search/catalogue/?collection=DEFE&collection=HW&collection=RGO&level=Piece&closure=Open+Document%2C+Open+Description&q=test+search+term&group=tna

Notice how the **Collections** filter options for 'DEFE' and 'RGO' have disappeared, despite being applied?

Now check out the same URL locally: http://localhost:8000/search/catalogue/?collection=DEFE&collection=HW&collection=RGO&level=Piece&closure=Open+Document%2C+Open+Description&q=test+search+term&group=tna

The missing filter options should now appear with with a '(0)' count in brackets to indicate they have no matches when combined with the other active filters.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
