### PR TITLE
DF-575: Use list markup for search filters

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -16,10 +16,14 @@ from ..ciim.constants import (
 )
 
 
+class SearchFilterCheckboxList(forms.widgets.CheckboxSelectMultiple):
+    template_name = "search/widgets/search-filter-checkbox-list.html"
+
+
 class DynamicMultipleChoiceField(forms.MultipleChoiceField):
     """MultipleChoiceField whose choices can be updated to reflect API response data."""
 
-    widget = forms.widgets.CheckboxSelectMultiple
+    widget = SearchFilterCheckboxList
 
     def __init__(self, *args, **kwargs):
         self.validate_input = bool(kwargs.get("choices")) and kwargs.pop(

--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -41,12 +41,6 @@ class DynamicMultipleChoiceField(forms.MultipleChoiceField):
             return True
         return super().valid_value(value)
 
-    def widget_attrs(self, widget):
-        attrs = super().widget_attrs(widget)
-        if not widget.is_hidden:
-            attrs["class"] = "search-filters__list"
-        return attrs
-
     @cached_property
     def configured_choice_labels(self):
         return {value: label for value, label in self.configured_choices}

--- a/etna/search/templates/search/widgets/search-filter-checkbox-list.html
+++ b/etna/search/templates/search/widgets/search-filter-checkbox-list.html
@@ -1,13 +1,13 @@
 {% with id=widget.attrs.id %}
     <div{% if id %} id="{{ id }}"{% endif %} class="search-filters__widget {{ widget.attrs.class }}">
-        <ol class="search-filters__widget__option-list">
+        <ul class="search-filters__widget-list">
             {% for group, options, index in widget.optgroups %}
                 {% for option in options %}
-                    <li class="search-filter__widget__option-list__item">
+                    <li class="search-filter__widget-list-item">
                         {% include option.template_name with widget=option %}
                     </li>
                 {% endfor %}
             {% endfor %}
-        </ol>
+        </ul>
     </div>
 {% endwith %}

--- a/etna/search/templates/search/widgets/search-filter-checkbox-list.html
+++ b/etna/search/templates/search/widgets/search-filter-checkbox-list.html
@@ -3,7 +3,7 @@
         <ul class="search-filters__widget-list">
             {% for group, options, index in widget.optgroups %}
                 {% for option in options %}
-                    <li class="search-filter__widget-list-item">
+                    <li class="search-filters__widget-list-item">
                         {% include option.template_name with widget=option %}
                     </li>
                 {% endfor %}

--- a/etna/search/templates/search/widgets/search-filter-checkbox-list.html
+++ b/etna/search/templates/search/widgets/search-filter-checkbox-list.html
@@ -1,0 +1,13 @@
+{% with id=widget.attrs.id %}
+    <div{% if id %} id="{{ id }}"{% endif %} class="search-filters__widget {{ widget.attrs.class }}">
+        <ol class="search-filters__widget__option-list">
+            {% for group, options, index in widget.optgroups %}
+                {% for option in options %}
+                    <li class="search-filter__widget__option-list__item">
+                        {% include option.template_name with widget=option %}
+                    </li>
+                {% endfor %}
+            {% endfor %}
+        </ol>
+    </div>
+{% endwith %}

--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -1,100 +1,124 @@
- .search-filters {
-    background-color: $color__grey-5;
-    border: 1px solid $color__grey-3;
-    padding: 1rem;
+.search-filters {
+  background-color: $color__grey-5;
+  border: 1px solid $color__grey-3;
+  padding: 1rem;
 
-    &__heading {
-        font-size: 1.3em;
-    }
+  &__heading {
+    font-size: 1.3em;
+  }
 
-    &__list {
-        list-style: none;
-        padding-left: 0.5rem;
-        
-        &:focus {
+  &__widget {
+    &__option-list {
+      list-style: none;
+      padding-left: 0.5rem;
+
+      &:focus {
+        outline: 5px solid $color__focus-blue-outline-light-bg;
+      }
+
+      &__item {
+        input {
+          margin-bottom: 1rem;
+          margin-right: 0.5rem;
+
+          &:focus {
             outline: 5px solid $color__focus-blue-outline-light-bg;
+          }
         }
+
+        label {
+          cursor: pointer;
+          display: block;
+          max-width: 100%;
+        }
+      }
     }
 
     &__form-block {
-        margin-bottom: 1rem;
+      margin-bottom: 1rem;
     }
 
     &__submit {
-        @extend .search-button;
-        display: block;
-        margin-top: 0.5rem;
+      @extend .search-button;
+      display: block;
+      margin-top: 0.5rem;
     }
 
-    &__label, &__checkbox, &__submit {
-        cursor: pointer;
+    &__label,
+    &__checkbox,
+    &__submit {
+      cursor: pointer;
     }
 
     &__label {
-        max-width: 80%;
-        vertical-align: top;
+      max-width: 80%;
+      vertical-align: top;
 
-        &--block {
-            display: block;
-            max-width: 100%;
-        }
+      &--block {
+        display: block;
+        max-width: 100%;
+      }
     }
 
     &__search {
-        margin-bottom: 0.5rem;
-        border: 1px solid $color__grey-3;
-        border-radius: 0.5rem;
-        width: 100%;
-        height: 3rem;
-        padding: 1rem;
+      margin-bottom: 0.5rem;
+      border: 1px solid $color__grey-3;
+      border-radius: 0.5rem;
+      width: 100%;
+      height: 3rem;
+      padding: 1rem;
     }
 
     &__accordion-section {
-        background-color: $color__grey-1;
-        padding: 0.5rem;
-        margin-bottom: 1rem;
-        border: 1px solid $color__grey-7;
+      background-color: $color__grey-1;
+      padding: 0.5rem;
+      margin-bottom: 1rem;
+      border: 1px solid $color__grey-7;
 
-        &-heading {
-            font-size: 1rem;
-            font-weight: normal;
+      &-heading {
+        font-size: 1rem;
+        font-weight: normal;
+      }
+
+      &-link {
+        color: $color__blue_3;
+
+        &:visited,
+        &:hover {
+          color: $color__blue_3;
         }
-
-        &-link {
-            color: $color__blue_3;
-
-            &:visited, &:hover {
-                color: $color__blue_3;
-            }
-        }
+      }
     }
 
     &__checkbox {
-        margin-bottom: 1rem;
-        margin-right: 0.5rem;
-        &:focus {
-            outline: 5px solid $color__focus-blue-outline-light-bg;
-        }
+      margin-bottom: 1rem;
+      margin-right: 0.5rem;
+
+      &:focus {
+        outline: 5px solid $color__focus-blue-outline-light-bg;
+      }
     }
+
     &__opening-date {
-        width: 5rem;
-        &:focus {
-            outline: 5px solid $color__focus-blue-outline-light-bg;
-        }
-        &-section {
-          margin-bottom: 1rem;
+      width: 5rem;
 
-        }
+      &:focus {
+        outline: 5px solid $color__focus-blue-outline-light-bg;
+      }
+
+      &-section {
+        margin-bottom: 1rem;
+      }
     }
-}
+  }
 
- .errorlist {
-   list-style-type: none;
-   padding-left: 0;
-   font-weight: 700;
-   padding: 1rem 2rem;
-   background-color: #A72916;
-   color: #ffffff;
-   margin-bottom: 2rem;
-   //border:solid 10px ;
- }
+  .errorlist {
+    list-style-type: none;
+    padding-left: 0;
+    font-weight: 700;
+    padding: 1rem 2rem;
+    background-color: #a72916;
+    color: #ffffff;
+    margin-bottom: 2rem;
+  }
+}

--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -7,90 +7,17 @@
     font-size: 1.3em;
   }
 
-  &__widget {
-    &__option-list {
-      list-style: none;
-      padding-left: 0.5rem;
+  &__widget-list {
+    list-style: none;
+    padding-left: 0.5rem;
 
-      &:focus {
-        outline: 5px solid $color__focus-blue-outline-light-bg;
-      }
-
-      &__item {
-        input {
-          margin-bottom: 1rem;
-          margin-right: 0.5rem;
-
-          &:focus {
-            outline: 5px solid $color__focus-blue-outline-light-bg;
-          }
-        }
-
-        label {
-          cursor: pointer;
-          display: block;
-          max-width: 100%;
-        }
-      }
+    &:focus {
+      outline: 5px solid $color__focus-blue-outline-light-bg;
     }
+  }
 
-    &__form-block {
-      margin-bottom: 1rem;
-    }
-
-    &__submit {
-      @extend .search-button;
-      display: block;
-      margin-top: 0.5rem;
-    }
-
-    &__label,
-    &__checkbox,
-    &__submit {
-      cursor: pointer;
-    }
-
-    &__label {
-      max-width: 80%;
-      vertical-align: top;
-
-      &--block {
-        display: block;
-        max-width: 100%;
-      }
-    }
-
-    &__search {
-      margin-bottom: 0.5rem;
-      border: 1px solid $color__grey-3;
-      border-radius: 0.5rem;
-      width: 100%;
-      height: 3rem;
-      padding: 1rem;
-    }
-
-    &__accordion-section {
-      background-color: $color__grey-1;
-      padding: 0.5rem;
-      margin-bottom: 1rem;
-      border: 1px solid $color__grey-7;
-
-      &-heading {
-        font-size: 1rem;
-        font-weight: normal;
-      }
-
-      &-link {
-        color: $color__blue_3;
-
-        &:visited,
-        &:hover {
-          color: $color__blue_3;
-        }
-      }
-    }
-
-    &__checkbox {
+  &__widget-list-item {
+    input {
       margin-bottom: 1rem;
       margin-right: 0.5rem;
 
@@ -99,16 +26,87 @@
       }
     }
 
-    &__opening-date {
-      width: 5rem;
+    label {
+      cursor: pointer;
+      display: block;
+      max-width: 100%;
+    }
+  }
 
-      &:focus {
-        outline: 5px solid $color__focus-blue-outline-light-bg;
-      }
+  &__form-block {
+    margin-bottom: 1rem;
+  }
 
-      &-section {
-        margin-bottom: 1rem;
+  &__submit {
+    @extend .search-button;
+    display: block;
+    margin-top: 0.5rem;
+  }
+
+  &__label,
+  &__checkbox,
+  &__submit {
+    cursor: pointer;
+  }
+
+  &__label {
+    max-width: 80%;
+    vertical-align: top;
+
+    &--block {
+      display: block;
+      max-width: 100%;
+    }
+  }
+
+  &__search {
+    margin-bottom: 0.5rem;
+    border: 1px solid $color__grey-3;
+    border-radius: 0.5rem;
+    width: 100%;
+    height: 3rem;
+    padding: 1rem;
+  }
+
+  &__accordion-section {
+    background-color: $color__grey-1;
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+    border: 1px solid $color__grey-7;
+
+    &-heading {
+      font-size: 1rem;
+      font-weight: normal;
+    }
+
+    &-link {
+      color: $color__blue_3;
+
+      &:visited,
+      &:hover {
+        color: $color__blue_3;
       }
+    }
+  }
+
+  &__checkbox {
+    margin-bottom: 1rem;
+    margin-right: 0.5rem;
+
+    &:focus {
+      outline: 5px solid $color__focus-blue-outline-light-bg;
+    }
+  }
+
+  &__opening-date {
+    width: 5rem;
+
+    &:focus {
+      outline: 5px solid $color__focus-blue-outline-light-bg;
+    }
+
+    &-section {
+      margin-bottom: 1rem;
     }
   }
 

--- a/sass/includes/search/_search-filters.scss
+++ b/sass/includes/search/_search-filters.scss
@@ -18,9 +18,6 @@
 
   &__widget-list-item {
     input {
-      margin-bottom: 1rem;
-      margin-right: 0.5rem;
-
       &:focus {
         outline: 5px solid $color__focus-blue-outline-light-bg;
       }
@@ -28,7 +25,8 @@
 
     label {
       cursor: pointer;
-      display: block;
+      display: inline-block;
+      margin-bottom: 0.5rem;
       max-width: 100%;
     }
   }


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-575

## About these changes

This PR adds a custom widget for use in search filters, allowing us to customise the template, and render an actual `<ol>` element with an `<li>` for each option.

I deliberately haven't gone to pains to ensure labels and checkboxes have custom BEM classes on too, as that feels like complication for complication's sake.

## How to check these changes

Check if the search filters are rendering okay for you here: 
http://localhost:8000/search/catalogue/

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
