### PR TITLE
UN-535: Spotlight article CTA text doesn't provide context

### DIFF
--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -48,7 +48,7 @@
                 <p id ="article-desc" class="aria-desc">This is a link to a new story about {{ page.featured_article.title }}</p>
 
                 <p>{{ page.featured_article.teaser_text }}</p>
-                <a class="tna-button--dark" href="{% pageurl page.featured_article %}" data-component-name="Featured Article: {{ page.featured_article.title }}" data-link-type="Button" data-link="Read" {% if page.featured_article.is_newly_published %}data-label="New"{%endif%}>Read</a>
+                <a class="tna-button--dark" href="{% pageurl page.featured_article %}" data-component-name="Featured Article: {{ page.featured_article.title }}" data-link-type="Button" data-link="Read" {% if page.featured_article.is_newly_published %}data-label="New"{%endif%}>Read <span class="sr-only">about {{ page.featured_article.title }}</span></a>
             </div>
         </div>
     </div>

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -45,7 +45,7 @@
                         {{ page.featured_article.title }}
                     </h2>
                     <p>{{ page.featured_article.teaser_text }}</p>
-                    <a class="tna-button--dark" href="{% pageurl page.featured_article %}">Read</a>
+                    <a class="tna-button--dark" href="{% pageurl page.featured_article %}">Read <span class="sr-only">about {{ page.featured_article.title }}</span></a>
                 </div>
             </div>
         </div>

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -32,7 +32,7 @@
             <p id="article-desc" class="aria-desc">This is a link to a new story about {{ page.title }}</p>
 
             <p>{{ page.teaser_text }}</p>
-            <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Story: {{ page.title }}" data-link-type="Button" {% if page.is_newly_published %}data-label="New"{% endif %}>Read</a>
+            <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Story: {{ page.title }}" data-link-type="Button" {% if page.is_newly_published %}data-label="New"{% endif %}>Read <span class="sr-only">about {{ page.title }}</span></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-535

## About these changes

Added an `sr-only` span to the link, and added the text "about {{ insert_title_variable_here }}" to add context to the links for screen readers.

## How to check these changes

Navigate to a featured article spotlight (e.g. on stories index page) and check that the sr-only span has been added with the correct text.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
