### PR TITLE
UN-542: Stray </a> tag 

### DIFF
--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -56,9 +56,8 @@
                                     id="item-{{ forloop.counter }}-caption">
                             {{ item.caption|richtext }}
                             {% if item.image.record %}
-                                Image library ref: <a href="{% record_url item.image.record is_editorial=True %}">{{ item.image.record }}
+                                Image library ref: <a href="{% record_url item.image.record is_editorial=True %}">{{ item.image.record }}</a>
                             {% endif %}
-                        </a>
                     </figcaption>
                 </figure>
                 {# non-JS version #}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-542

## About these changes

Moved the </a> tag inside the if statement above it. This prevents the </a> from randomly displaying, if the if statement isn't met. It will then display with the <a> which it is supposed to close.

## How to check these changes

Check that the </a> is not being randomly displayed in the HTML.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
