### PR TITLE
UN-543: Remove empty/un-needed <p></p> tags

### DIFF
--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -66,11 +66,11 @@
                     <div class="transcription__text">
                         {% if item.image.transcription %}
                             <h2>{{ item.image.get_transcription_heading_display }}</h2>
-                            <p>{{ item.image.transcription|richtext }}</p>
+                            {{ item.image.transcription|richtext }}
                         {% endif %}
                         {% if item.image.translation %}
                             <h2>{{ item.image.get_translation_heading_display }}</h2>
-                            <p>{{ item.image.translation|richtext }}</p>
+                            {{ item.image.translation|richtext }}
                         {% endif %}
                     </div>
                 {% endif %}
@@ -108,7 +108,7 @@
                                  tabindex="0"
                                  aria-labelledby="tab-1-{{ forloop.counter }}"
                                  class="transcription__tabpanel hidden">
-                                <p>{{ item.image.transcription|richtext }}</p>
+                                {{ item.image.transcription|richtext }}
                             </div>
                         {% endif %}
                         {% if item.image.translation %}
@@ -117,7 +117,7 @@
                                  tabindex="0"
                                  aria-labelledby="tab-2-{{ forloop.counter }}"
                                  class="transcription__tabpanel hidden">
-                                <p>{{ item.image.translation|richtext }}</p>
+                                {{ item.image.translation|richtext }}
                             </div>
                         {% endif %}
                     </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-543

## About these changes

Removed empty `<p></p>` tags.

There will be some empty `<p>`s with ids. This is from the `rich_text` fields, and the editors putting in a blank line. Perhaps some editor guidance on why they shouldn't do this, or is there a way we can ensure there are no blank lines put in?

## How to check these changes

Check on record revealed pages that there are no empty `<p></p>`s.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
