### PR TITLE
UN-544: Remove href attribute on <button> element

### DIFF
--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -25,7 +25,6 @@
                             {{ about }}
                             <button id="readMoreButton"
                                     class="record-matters__plain-button {% if about|length <= 300 %}hidden{% endif %}"
-                                    href=""
                                     aria-label="Expand to read more about this record">
                                 Read more
                                 {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-544

## About these changes

Removed `href` on `<button>` element on record revealed page

## How to check these changes

Ensure that the href has been removed from the button element

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
