### PR TITLE
UN-563: Close button does not provide sufficient context

### DIFF
--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -127,7 +127,8 @@
     {% endfor %}
 {% endwith %}
 <button class="transcription__close hidden" id="closeButton" type="button">
-    Close
+    Close <span class="sr-only">images
+    {% if has_text %}and transcripts{% endif %}</span>
     {% include "static/images/fontawesome-svgs/x-mark.svg" with classes="transcription__icon" %}
 </button>
 </div>

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -127,8 +127,8 @@
     {% endfor %}
 {% endwith %}
 <button class="transcription__close hidden" id="closeButton" type="button">
-    Close <span class="sr-only">images
-    {% if has_text %}and transcripts{% endif %}</span>
+    Close images
+    {% if has_text %}and transcripts{% endif %}
     {% include "static/images/fontawesome-svgs/x-mark.svg" with classes="transcription__icon" %}
 </button>
 </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-563

## About these changes

Added sr-only span to provide context on the "close" button. This includes an if statement to include "transcripts" if there are transcripts (same as the open button).

## How to check these changes

Check the HTML on open/close button on the record revealed image gallery.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
