### PR TITLE
DF-611: location filter for archive

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -17,6 +17,7 @@ def forTemplate(cls):
 class BucketKeys(StrEnum):
     NONTNA = "nonTna"
     CREATOR = "creator"
+    ARCHIVE = "archive"
     INSIGHT = "insight"
     HIGHLIGHT = "highlight"
 
@@ -43,6 +44,7 @@ class Aggregation(StrEnum):
     HELD_BY = "heldBy"
     TYPE = "type"
     COUNTRY = "country"
+    LOCATION = "location"
 
 
 DEFAULT_AGGREGATIONS = (
@@ -150,6 +152,10 @@ CATALOGUE_BUCKETS = BucketList(
             key="archive",
             label="Find an archive",
             description="Results for archives in the UK and from across the world that match your search term.",
+            aggregations=(
+                Aggregation.GROUP + ":30",
+                Aggregation.LOCATION,
+            ),
         ),
     ]
 )

--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -178,6 +178,10 @@ class BaseCollectionSearchForm(forms.Form):
         label="Country",
         required=False,
     )
+    location = DynamicMultipleChoiceField(
+        label="Location",
+        required=False,
+    )
     opening_start_date = DateInputField(
         label="From",
         required=False,

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -93,6 +93,7 @@ class SelectedFiltersTest(SimpleTestCase):
                 "level": ["Division"],
                 "collection": ["WO", "AK"],
                 "country": ["England", "Yorkshire, North Riding"],
+                "location": ["Australia", "United States of America"],
             }
         )
 
@@ -113,6 +114,10 @@ class SelectedFiltersTest(SimpleTestCase):
                 "country": [
                     ("England", "England"),
                     ("Yorkshire, North Riding", "Yorkshire, North Riding"),
+                ],
+                "location": [
+                    ("Australia", "Australia"),
+                    ("United States of America", "United States of America"),
                 ],
             },
         )
@@ -176,6 +181,7 @@ class SelectedFiltersTest(SimpleTestCase):
                 "catalogue_source": ["catalogue-source-one"],  # valid
                 "collection": ["bar"],
                 "country": ["England", "Yorkshire, North Riding"],  # valid
+                "location": ["Australia", "United States of America"],  # valid
                 "level": ["foo"],  # invalid
             }
         )
@@ -198,6 +204,10 @@ class SelectedFiltersTest(SimpleTestCase):
                 "country": [
                     ("England", "England"),
                     ("Yorkshire, North Riding", "Yorkshire, North Riding"),
+                ],
+                "location": [
+                    ("Australia", "Australia"),
+                    ("United States of America", "United States of America"),
                 ],
             },
         )
@@ -1670,6 +1680,71 @@ class RecordCreatorsTestCase(WagtailTestUtils, TestCase):
                 "&template=details"
                 "&aggregations=country%3A100"
                 "&filterAggregations=group%3Acreator"
+                "&from=0"
+                "&size=20"
+            ),
+        )
+
+
+class ArchiveTestCase(WagtailTestUtils, TestCase):
+    maxDiff = None
+
+    @responses.activate
+    def test_archive_default_params(self):
+        test_url = reverse_lazy(
+            "search-catalogue",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/search",
+            json=create_search_response(),
+        )
+
+        self.client.get(test_url, data={"group": "archive"})
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            (
+                "https://kong.test/data/search"
+                "?stream=evidential"
+                "&sort="
+                "&sortOrder=asc"
+                "&template=details"
+                "&aggregations=group%3A30"
+                "&aggregations=location%3A10"
+                "&filterAggregations=group%3Aarchive"
+                "&from=0"
+                "&size=20"
+            ),
+        )
+
+    @responses.activate
+    def test_record_creators_country_long_filter(self):
+        test_url = reverse_lazy(
+            "search-catalogue-long-filter-chooser", kwargs={"field_name": "location"}
+        )
+
+        responses.add(
+            responses.GET,
+            "https://kong.test/data/search",
+            json=create_search_response(),
+        )
+
+        self.client.get(test_url, data={"group": "archive"})
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url,
+            (
+                "https://kong.test/data/search"
+                "?stream=evidential"
+                "&sort="
+                "&sortOrder=asc"
+                "&template=details"
+                "&aggregations=location%3A100"
+                "&filterAggregations=group%3Aarchive"
                 "&from=0"
                 "&size=20"
             ),

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -346,6 +346,7 @@ class BaseFilteredSearchView(BaseSearchView):
         "catalogue_source",
         "type",
         "country",
+        "location",
     )
 
     def get_form_defaults(self) -> Dict[str, Any]:

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -105,9 +105,13 @@
                 {% include "search/includes/filter.html" with field=form.type %}
                 {% include "search/includes/filter.html" with field=form.country %}
             {% endif %}
+
+            {% if form.group.value == bucketkeys.ARCHIVE.value %}
+                {% include "search/includes/filter.html" with field=form.location %}
+            {% endif %}
         </div>
 
-        {{ 'filter_keyword collection topic level closure opening_start_date opening_end_date catalogue_source held_by type country'|include_hidden_fields:form }}
+        {{ 'filter_keyword collection topic level closure opening_start_date opening_end_date catalogue_source held_by type country location'|include_hidden_fields:form }}
       
     </form>
     {% comment %} {% include './search_export_and_share.html' %} {% endcomment %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-611

## About these changes

Added location filter to `Find an archive` bucket.

## How to check these changes

As mentioned in the ticket.

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
