### PR TITLE
[DF-587] Remove extra (unneeded?) <form> element

### DIFF
--- a/templates/search/website_search.html
+++ b/templates/search/website_search.html
@@ -23,7 +23,6 @@
 {% block breadcrumb %}
 {% endblock %}
 {% block content %}
-    <form method="get" data-id="search-form" id="analytics-search-form">
         {{ form.non_field_errors }}
 
         {% with search_tab=searchtabs.WEBSITE.value %}
@@ -63,7 +62,6 @@
             {% endif %}
         
         {% endwith %}
-    </form>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION

Ticket URL: https://national-archives.atlassian.net/browse/DF-587

## About these changes

This removes the parent `<form>` element which contained another `<form>` child element (./blocks/search_results_hero.html) - this was throwing a validation error as it isn't valid HTML to contain a form inside another form.   The parent form did not include any form input fields inside it nor did it have any other indication it was needed (from what I could tell), so I have removed it. This is also now consistent with the `catalogue_search.html` template.

## How to check these changes

I felt a little uncertain removing this form as it seemed it could be required for analytics in some way (?) but I'm really not sure what I would need to test to make sure it hasn't broken anything as I'm not very familiar with the existing code or why the form was added to begin with. So, I'd just like to make sure this isn't likely to cause any issues - it may need to be checked by Beth and/or Helen too?

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
