### PR TITLE
UN-560: View the record CTA sr-only repeats the name of the full record which is very verbose

### DIFF
--- a/etna/records/tests/test_blocks.py
+++ b/etna/records/tests/test_blocks.py
@@ -158,7 +158,7 @@ class TestFeaturedRecordBlockIntegration(WagtailPageTestCase):
 
         # View the page to check rendering also
         response = self.client.get(self.article_page.get_url())
-        self.assertContains(response, "Test record")
+        self.assertContains(response, "C123456")
         self.assertEqual(len(responses.calls), 3)
         self.assertEqual(
             responses.calls[1].request.url,

--- a/templates/articles/blocks/featured_record.html
+++ b/templates/articles/blocks/featured_record.html
@@ -27,7 +27,7 @@
         </div>
 
         <div class="featured-record__action">
-            <a class="featured-record__button tna-button--yellow" href="{% record_url value.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Button" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>View <span class="sr-only">{{ value.record.summary_title }}</span> in the catalogue{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
+            <a class="featured-record__button tna-button--yellow" href="{% record_url value.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Button" data-link="View in the catalogue"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>View <span class="sr-only">{{ value.title }}</span> in the catalogue{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-560

## About these changes

Changed sr-only text on CTA label to use the title of the "record" component, instead of the actual record title.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
