### PR TITLE
[UN-547] Record revealed - only interactive elements should be focusable

### DIFF
--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -32,7 +32,7 @@
         <!--start of transcript element-->
         {% for item in gallery %}
             <div id="item-{{ forloop.counter }}">
-                <p class="transcription__image-counter" tabindex="0">Image {{ forloop.counter }} of {{ gallery_length }}</p>
+                <p class="transcription__image-counter">Image {{ forloop.counter }} of {{ gallery_length }}</p>
                 <div class="transcription__content {% if not item.image.transcription and not item.image.translation %}transcription__content--full-width{% endif %}">
                     <figure aria-labelledby="item-{{ forloop.counter }}-caption">
                         <picture class="transcription__figure-image">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-547

## About these changes

Removes `tabindex="0"` from the image counter element as this isn't part of the interactive tab content and so has no need to be focusable.

## How to check these changes

1. Review record revealed page
2. Tab through page content with tab key
3. Notice that the image counter content (Image 1/2) is not focusable with the keyboard

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
