### PR TITLE
[UN-534] [UN-548] Add boundary borders to featured content areas for high contrast mode

### DIFF
--- a/sass/includes/_featured-article.scss
+++ b/sass/includes/_featured-article.scss
@@ -32,6 +32,8 @@
     }
 
     &__description {
+        // provides visual boundary in high contrast mode
+        border: 1px solid transparent;
         background-color: #FFCC00;
         padding: 2rem 4rem 2rem 2rem;
         width: 50%;

--- a/sass/includes/_footer.scss
+++ b/sass/includes/_footer.scss
@@ -21,6 +21,9 @@
     }
 
     &__heading {
+        // provides visual boundary in high contrast mode
+        border-top: 1px solid transparent;
+
         &-main-title {
             font-size: 1.6rem;
         }

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -1,5 +1,7 @@
 .transcription {
   $root: &;
+  // provides visual boundary in high contrast mode
+  border: 1px solid transparent;
   background: $color__grey-2;
   color: $color__white;
   padding-bottom: 0.5rem;


### PR DESCRIPTION
Ticket URLs: 
https://national-archives.atlassian.net/browse/UN-534
https://national-archives.atlassian.net/browse/UN-548

## About these changes

Adds some transparent borders to key content areas - the transparent border appears as a solid border in high contrast mode and provides clear boundaries around sections of content so the layout is easier to distinguish for high contrast users.

## How to check these changes

1. Open stories or a record revealed page locally
3. Open devtools, click the 3 dots and open More Tools > Rendering:
![image](https://user-images.githubusercontent.com/8680557/234261633-39ecb7fc-2426-4b34-8dac-eb659d7003a3.png)
3. Change the forced-colors setting to 'forced-colors: active' to emulate high contrast mode - you can set this to 'light' or 'dark' theme by changing 'prefers-color-theme' setting as well:

![image](https://user-images.githubusercontent.com/8680557/234261728-e5e6609d-707b-48de-943c-67f6aad054fb.png)
![image](https://user-images.githubusercontent.com/8680557/234262146-b1ffe8f5-ea8d-4af3-810a-e6f6e595d4b8.png)

4. Review page and see that the image gallery and featured content components have visible borders around the content.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
