### PR TITLE
[UN-536] Multiple duplicate IDs for article descriptions

### DIFF
--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -65,9 +65,10 @@
 
             {% for article_page in article_pages %}
 
-                        {% with page=article_page.specific %}
-                         {% include 'includes/card-group-secondary-nav.html' with heading="Discover all stories" %}
-                        {% endwith %}
+                {% with page=article_page.specific %}
+                    {% comment %} instance id adds a unique id to stories if they're included twice on the page {% endcomment %}
+                    {% include 'includes/card-group-secondary-nav.html' with heading="Discover all stories" instance_id=forloop.counter %}
+                {% endwith %}
 
             {% endfor %}
         </ul>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -39,7 +39,7 @@
                                 href='{{ page.url }}'
                                 class="card-group-secondary-nav__title-link"
                                 data-card-type="card-group-secondary-nav"
-                                aria-describedby="article-desc{{page.id}}"
+                                aria-describedby="article-desc{{page.id}}{% if instance_id %}-{{ instance_id }}{% endif %}"
                                 {% if value.block.meta.label or heading %}
                                 data-component-name="{% if value.block.meta.label %}{{ value.block.meta.label }}: {{ heading }}{% else %}{{ heading }}{% endif %}"
                                 {% endif %}
@@ -54,7 +54,7 @@
 
                         {% endif %}
                     </h3>
-                <p id ="article-desc{{ page.id }}" class="aria-desc-card">This is a link to a story about {{ page.title }}</p>
+                <p id ="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">This is a link to a story about {{ page.title }}</p>
 
                 <p class="card-group-secondary-nav__paragraph">{{ page.teaser_text }}</p>
             </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-536

## About these changes

Adds an extra ID based on the card forloop, to ensure the second group of cards have unique IDs and don't conflict with the featured cards.

It might make sense to remove these` aria-labelledby` attributes in future, as I'm not sure they are necessary - but no harm in them being there right now. This fixes the validation errors for now.

## How to check these changes

1. Review stories landing page locally
2. Inspect code and see that the ID and aria-labelledby attributes are different for featured cards vs 'all stories' cards.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
