### PR TITLE
[UN-546] Remove unused aria-labelledby attribute

### DIFF
--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -77,7 +77,6 @@
                 {% if item.image.transcription or item.image.translation %}
                     <div>
                         <div role="tablist"
-                             aria-labelledby="tablist-1-{{ forloop.counter }}"
                              class="transcription__tablist hidden">
                             {% if item.image.transcription %}
                                 <button id="tab-1-{{ forloop.counter }}"


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-546

## About these changes

Remove aria-labelledby attribute from tablist as it was pointing to an element that didn't exist and doesn't add any value.

## How to check these changes

1. Open record revealed locally
2. Inspect the transcript tabs and see the tablist no longer has an `aria-labelledby` attribute

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
