### PR TITLE
[UN-562] Add aria-expanded attribute to gallery button

### DIFF
--- a/scripts/src/modules/image-gallery.js
+++ b/scripts/src/modules/image-gallery.js
@@ -32,6 +32,7 @@ class ImageGallery {
             }
             this.show(this.transcriptionPreview)
             this.show(this.openButton);
+            this.openButton.setAttribute('aria-expanded', 'false');
             this.hide(this.closeButton);
             this.transcriptionPreview.scrollIntoView();
         })
@@ -42,6 +43,7 @@ class ImageGallery {
             }
             this.hide(this.transcriptionPreview);
             this.hide(this.openButton);
+            this.openButton.setAttribute('aria-expanded', 'true');
             this.show(this.closeButton);
             this.transcriptionContentNode[0].scrollIntoView();
         })

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -23,7 +23,7 @@
                              {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
                     {% endwith %}
                 </picture>
-                <button id="showButton" class="transcription__open">
+                <button id="showButton" class="transcription__open" aria-expanded="false">
                     View images
                     {% if has_text %}and transcripts{% endif %}
                 </button>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-562

## About these changes

Appends an aria-expanded attribute to the expand/close button for the image gallery, so SR users understand the current state of the component.

## How to check these changes

- Review record revealed page
- Inspect Open button of image gallery
- See the `aria-expanded` tag responds to the open/closing of the image gallery

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
