### PR TITLE
UN-556: Featured Story CTA label is not descriptive enough

### DIFF
--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -48,7 +48,7 @@
                 <p id ="article-desc" class="aria-desc">This is a link to a new story about {{ page.featured_article.title }}</p>
 
                 <p>{{ page.featured_article.teaser_text }}</p>
-                <a class="tna-button--dark" href="{% pageurl page.featured_article %}" data-component-name="Featured Article: {{ page.featured_article.title }}" data-link-type="Button" data-link="Read" {% if page.featured_article.is_newly_published %}data-label="New"{%endif%}>Read more about {{ page.featured_article.title }}</a>
+                <a class="tna-button--dark" href="{% pageurl page.featured_article %}" data-component-name="Featured Article: {{ page.featured_article.title }}" data-link-type="Button" data-link="Read" {% if page.featured_article.is_newly_published %}data-label="New"{%endif%}>Read about {{ page.featured_article.title }}</a>
             </div>
         </div>
     </div>

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -48,7 +48,7 @@
                 <p id ="article-desc" class="aria-desc">This is a link to a new story about {{ page.featured_article.title }}</p>
 
                 <p>{{ page.featured_article.teaser_text }}</p>
-                <a class="tna-button--dark" href="{% pageurl page.featured_article %}" data-component-name="Featured Article: {{ page.featured_article.title }}" data-link-type="Button" data-link="Read" {% if page.featured_article.is_newly_published %}data-label="New"{%endif%}>Read <span class="sr-only">about {{ page.featured_article.title }}</span></a>
+                <a class="tna-button--dark" href="{% pageurl page.featured_article %}" data-component-name="Featured Article: {{ page.featured_article.title }}" data-link-type="Button" data-link="Read" {% if page.featured_article.is_newly_published %}data-label="New"{%endif%}>Read more about {{ page.featured_article.title }}</a>
             </div>
         </div>
     </div>

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -32,7 +32,7 @@
             <p id="article-desc" class="aria-desc">This is a link to a new story about {{ page.title }}</p>
 
             <p>{{ page.teaser_text }}</p>
-            <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Story: {{ page.title }}" data-link-type="Button" {% if page.is_newly_published %}data-label="New"{% endif %}>Read <span class="sr-only">about {{ page.title }}</span></a>
+            <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Story: {{ page.title }}" data-link-type="Button" {% if page.is_newly_published %}data-label="New"{% endif %}>Read more about {{ page.title }}</a>
         </div>
     </div>
 </div>

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -32,7 +32,7 @@
             <p id="article-desc" class="aria-desc">This is a link to a new story about {{ page.title }}</p>
 
             <p>{{ page.teaser_text }}</p>
-            <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Story: {{ page.title }}" data-link-type="Button" {% if page.is_newly_published %}data-label="New"{% endif %}>Read more about {{ page.title }}</a>
+            <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Story: {{ page.title }}" data-link-type="Button" {% if page.is_newly_published %}data-label="New"{% endif %}>Read about {{ page.title }}</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-556

## About these changes

Updated CTA links to show "Read about X"

## How to check these changes

Check anywhere the "featured story" is used and ensure that text is "read about (title)"

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
