### PR TITLE
UN-551: "Read more" and "Read less" button label not descriptive

### DIFF
--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -26,7 +26,7 @@
                             <button id="readMoreButton"
                                     class="record-matters__plain-button {% if about|length <= 300 %}hidden{% endif %}"
                                     aria-label="Expand to read more about this record">
-                                Read more
+                                Expand to read more
                                 {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}
                             </button>
                         {% endwith %}
@@ -37,7 +37,7 @@
                                 class="record-matters__plain-button hidden"
                                 type="button"
                                 aria-label="Close to read less about this record">
-                            Read less
+                            Collapse content
                             {% include "static/images/fontawesome-svgs/circle-x-mark.svg" with classes="record-matters__svg" %}
                         </button>
                     </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-551

## About these changes

Updated button text on the gallery

## How to check these changes

Check that the text has been updated

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
