### PR TITLE
CHORE: Changed content warning colour to `color__grey-2`

### DIFF
--- a/sass/includes/_content-warning.scss
+++ b/sass/includes/_content-warning.scss
@@ -43,7 +43,7 @@
 
   &__icon {
     display: none;
-    color: $color__grey-7;
+    color: $color__grey-2;
     width: 34px;
     height: 34px;
     flex-basis: 34px;


### PR DESCRIPTION
Ticket URL: N/A

## About these changes

I believe the colour was changed from some merge conflicts in a PR for UN-506, so I have re-added the new colour here.

## How to check these changes

Check that the colour of the content warning icon has changed

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
