### PR TITLE
[UN-538] Update semantics for record details component

### DIFF
--- a/templates/articles/blocks/featured_records.html
+++ b/templates/articles/blocks/featured_records.html
@@ -10,19 +10,19 @@
                 </p>
             {% endif %}
 
-            <dl class="featured-records__list" data-container-name="featured-records">
+            <ul class="featured-records__list" data-container-name="featured-records">
                 {% for item in value.items %}
-                    <div class="featured-records__list-item">
-                        <dt>
+                    <li class="featured-records__list-item">
+                        <h4 class="featured-records__link-heading">
                             <a class="featured-records__link" href="{% record_url item.record is_editorial=True %}" data-component-name="{{ value.block.meta.label }}" data-link-type="Links" data-position="{{ forloop.counter0 }}" data-link="{{ item.title }}"{% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} target="_blank"{% endif %}>
-                                <h4 class="featured-records__link-heading">{{ item.title }}</h4>
+                                {{ item.title }}
                                 {% if FEATURE_RECORD_LINKS_GO_TO_DISCOVERY %} <span class="sr-only">(link opens in a new window)</span>{% endif %}
                             </a>
-                        </dt>
-                        <dd class="featured-records__list-item-description">{{ item.record.summary_title }}</dd>
-                    </div>
+                        </h4>
+                        <p class="featured-records__list-item-description">{{ item.record.summary_title }}</p>
+                    </li>
                 {% endfor %}
-            </dl>
+            </ul>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-538

## About these changes

These changes remove the `<dt>` element and replaces with a `<ul>` as this is more semantically appropriate for this component. I've also moved the `<h4> `so it wraps the `<a>` as it is invalid HTML to put a `<h4>` inside an `<a>` tag.

## How to check these changes

- Add a 'record details' component to a story page and inspect it to see the new markup.
- Compare with dev to ensure styles are still showing as expected.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
