### PR TITLE
UN-470: Fix FeaturedRecordArticleBlock TemplateSyntaxError

### DIFF
--- a/templates/blocks/featured_record_article.html
+++ b/templates/blocks/featured_record_article.html
@@ -1,4 +1,4 @@
-{% load static wagtailimages_tags wagtailcore_tags %}
+{% load i18n static wagtailimages_tags wagtailcore_tags %}
 
 {% if value.page.live or request.is_preview %}
     <div class="featured-record-article u-margin-l container" data-container-name="featured-record-article">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-470

## About these changes

As reported on the ticket, using the block results in a `TemplateSyntaxError` in the preview panel. Technically, the FE ticket should resolve this, but there's no good reason to leave it erroring in the meantime.

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
