### PR TITLE
CHORE: Update dark mode develop theme

### DIFF
--- a/etna/core/wagtail_hooks.py
+++ b/etna/core/wagtail_hooks.py
@@ -22,5 +22,5 @@ def editor_js():
 @hooks.register("insert_global_admin_css")
 def global_admin_css():
     if settings.FEATURE_PLATFORM_ENVIRONMENT_TYPE != "production":
-        return "<style> @media (prefers-color-scheme: light) { :root {--w-color-primary: #00623B; --w-color-primary-200: #003c1e;} } @media (prefers-color-scheme: dark) { :root {--w-color-surface-menus: #002510; --w-color-surface-menu-item-active: #002010;} }</style>"
+        return "<style> @media (prefers-color-scheme: light) { :root {--w-color-primary: #00623B; --w-color-primary-200: #003c1e;} } @media (prefers-color-scheme: dark) { :root {--w-color-surface-menus: #002510; --w-color-surface-menu-item-active: #001810;} }</style>"
     return ""

--- a/etna/core/wagtail_hooks.py
+++ b/etna/core/wagtail_hooks.py
@@ -22,5 +22,5 @@ def editor_js():
 @hooks.register("insert_global_admin_css")
 def global_admin_css():
     if settings.FEATURE_PLATFORM_ENVIRONMENT_TYPE != "production":
-        return "<style> :root {--w-color-primary: #00623B; --w-color-primary-200: #003c1e;} </style>"
+        return "<style> @media (prefers-color-scheme: light) { :root {--w-color-primary: #00623B; --w-color-primary-200: #003c1e;} } @media (prefers-color-scheme: dark) { :root {--w-color-surface-menus: #002510; --w-color-surface-menu-item-active: #002010;} }</style>"
     return ""


### PR DESCRIPTION
## About these changes

I have made the side-bar on develop a dark green to fit in with the dark mode - this is so that the editors can tell the difference between develop and main.

## How to check these changes

Set `FEATURE_PLATFORM_ENVIRONMENT_TYPE = "development"` in your `local.py` and it will show you the styles that are meant for develop only.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
