### PR TITLE
UN-654: Add large link cards to HG page

### DIFF
--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -17,5 +17,9 @@
 
     {% if page.featured_article %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
-    {% endif %}    
+    {% endif %}
+
+    {% if page.primary_topic or page.time_period %}
+        {% include "includes/related_topic_timeline_cards.html" with topic=page.primary_topic time_period=page.primary_time_period title="More to explore" %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-654

## About these changes

Added the large link cards to the bottom of the Highlights Gallery page

## How to check these changes

Check a Highlights Gallery page that is tagged with a topic and time period. There should be two large link cards displaying the most relevant topic + time period.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
