### PR TITLE
Feature/un 623 article intro fe bug

### DIFF
--- a/sass/includes/_explore-intro.scss
+++ b/sass/includes/_explore-intro.scss
@@ -7,6 +7,7 @@
 
   &__image-container {
     display: flex;
+    align-self: flex-end;
   }
 
   &__image {


### PR DESCRIPTION
Ticket URL: [UN-623](https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-623)

## About these changes

Ensures the record revealed intro image retains it's ratio throughout breakpoints

<img width="1215" alt="Screenshot 2023-05-22 at 14 20 11" src="https://github.com/nationalarchives/ds-wagtail/assets/298766/fb0dc62d-7748-42e7-951f-1b08ed9696e4">
<img width="1636" alt="Screenshot 2023-05-22 at 14 20 07" src="https://github.com/nationalarchives/ds-wagtail/assets/298766/ef91ce09-de03-414c-bfe8-8d2d692a4ac9">


## How to check these changes

Locally you can check any record revealed article:
http://localhost:8000/explore-the-collection/a-letter-by-the-women-workers-at-fords-of-dagenham/

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-623]: https://national-archives.atlassian.net/browse/UN-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ