### PR TITLE
Updating jump link heading style

### DIFF
--- a/sass/includes/_jumplinks.scss
+++ b/sass/includes/_jumplinks.scss
@@ -13,7 +13,8 @@
 
   &__heading {
     @include font-size(xl);
-    font-family: $font__supria-sans;
+    font-family: $font__body;
+    font-weight: 700;
     margin: 0;
   }
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-627

## About these changes

Updates the sticky navigation heading to the correct font

<img width="1655" alt="Screenshot 2023-05-22 at 14 54 51" src="https://github.com/nationalarchives/ds-wagtail/assets/298766/d7aa330b-3e5f-478f-8f3d-931d0e394cab">

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
