### PR TITLE
UN-565: Adding pluralize to image/transcript text

### DIFF
--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -24,8 +24,8 @@
                     {% endwith %}
                 </picture>
                 <button id="showButton" class="transcription__open" aria-expanded="false">
-                    View images
-                    {% if has_text %}and transcripts{% endif %}
+                    View image{{ gallery_length|pluralize }}
+                    {% if has_text %}and transcript{{ gallery_length|pluralize }}{% endif %}
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-565

## About these changes

Adds an s to image and transcription when there's more than 1 image within the image gallery

<img width="1834" alt="Screenshot 2023-05-23 at 16 16 15" src="https://github.com/nationalarchives/ds-wagtail/assets/298766/4cc70f66-29c8-4136-9c70-d0cba6c3823c">

<img width="1834" alt="Screenshot 2023-05-23 at 16 16 11" src="https://github.com/nationalarchives/ds-wagtail/assets/298766/83070068-6bc0-4036-b37d-9deb2b00a3f0">


## How to check these changes

Locally http://localhost:8000/explore-the-collection/test/ and http://localhost:8000/explore-the-collection/printed-circular-produced-by-the-national-league-of-the-blind/ and avaliable with the staging data

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
