### PR TITLE
UN-566: Set cG1 on Highlight Gallery

### DIFF
--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -568,6 +568,8 @@ class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIn
         index.SearchField("teaser_text"),
     ]
 
+    gtm_content_group = "Highlight Gallery"
+
     @cached_property
     def highlights(self):
         """


### PR DESCRIPTION
Ticket URL: [paste URL here](https://national-archives.atlassian.net/browse/UN-566)

## About these changes

 Set `contentGroup1` on Highlight Gallery to "Highlight Gallery"

## How to check these changes

Open the console on a Highlight Gallery page, type `dataLayer` and check the `contentGroup1`. It should say "Highlight Gallery".

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
