### PR TITLE
chore-fix-featured-gallery-text-colour

### DIFF
--- a/sass/includes/_highlight-gallery.scss
+++ b/sass/includes/_highlight-gallery.scss
@@ -40,7 +40,7 @@
 
   &__intro {
     p {
-      color: $color__grey-800;
+      color:  $color__white;
       margin-bottom: 0;
 
       &:last-of-type {
@@ -52,7 +52,7 @@
   &__richtext {
     p {
       margin-bottom: 1rem;
-      color: $color__grey-800;
+      color:  $color__white;
     }
   }
 


### PR DESCRIPTION
Ticket URL: N/a

## About these changes

This change is needed due to the colours refactoring, simply it is too dark so I'm just updating back to the previous colour.

## How to check these changes

This can be seen with staging data; view the prize papers gallery [here](http://0.0.0.0:8000/explore-the-collection/explore-by-topic/british-state-and-citizens/the-prize-papers/). The rich-text intro and body should be white instead of grey.

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
