### PR TITLE
not displaying elements on 'All results' tab

### DIFF
--- a/sass/includes/search/_featured-search.scss
+++ b/sass/includes/search/_featured-search.scss
@@ -64,10 +64,14 @@
     }
     &-image {
       width: 100%;
+        display: none;
+
+
     }
   }
 
   &__interpretive-results {
+      display:none;
     margin-left: 1rem;
     margin-right: 1rem;
     margin-top: 2rem;
@@ -82,6 +86,7 @@
       grid-template-columns: 1fr 1fr 1fr;
       margin-left: 2rem;
       &-section {
+          display:none;
         margin-right: 2rem;
         &:nth-of-type(1) {
           -ms-grid-column: 1;


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/DF-683

## About these changes

Removed the placeholder thumbnail for Record Creators
Removed the results for Research Guides and Blogs

## How to check these changes

Perform a search, on the 'All Results' tab you should no longer see the placeholder thumbnail for Record Creators or Research Guides and Blogs. Please check across breakpoints.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
