### PR TITLE
UN-678: Updated Highlight Gallery font colour

### DIFF
--- a/sass/includes/_hero-image.scss
+++ b/sass/includes/_hero-image.scss
@@ -8,12 +8,13 @@
   }
 
   &__figcaption {
-    background-color: $color__grey-300;
+    background-color: $color__grey-800;
     padding: 1rem;
-    border-bottom: 0.1875rem solid $color__grey-400;
+    border-bottom: 0.1875rem solid $color__grey-900;
 
     p {
       margin-bottom: 0;
+      color: $color__grey-300;
     }
   }
 }

--- a/sass/includes/_hero-image.scss
+++ b/sass/includes/_hero-image.scss
@@ -8,7 +8,7 @@
   }
 
   &__figcaption {
-    background-color: $color__grey-800;
+    background-color: $color__grey-300;
     padding: 1rem;
     border-bottom: 0.1875rem solid $color__grey-400;
 

--- a/sass/includes/_highlight-gallery.scss
+++ b/sass/includes/_highlight-gallery.scss
@@ -40,7 +40,7 @@
 
   &__intro {
     p {
-      color: $color__grey-800;
+      color: $color__grey-300;
       margin-bottom: 0;
 
       &:last-of-type {

--- a/sass/includes/_highlight-gallery.scss
+++ b/sass/includes/_highlight-gallery.scss
@@ -52,7 +52,7 @@
   &__richtext {
     p {
       margin-bottom: 1rem;
-      color: $color__grey-800;
+      color: $color__grey-300;
     }
   }
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-678

## About these changes

Updated HG font colour to use color__grey-300

## How to check these changes


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
