### PR TITLE
UN-677: Article title label

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -144,6 +144,8 @@ class ArticlePage(
     # DataLayerMixin overrides
     gtm_content_group = "stories"
 
+    title_label = "THE STORY OF"
+
     template = "articles/article_page.html"
 
     class Meta:
@@ -334,6 +336,8 @@ class RecordArticlePage(TopicalPageMixin, ContentWarningMixin, BasePageWithIntro
 
     # DataLayerMixin overrides
     gtm_content_group = "Record articles"
+
+    title_label = "RECORD REVEALED"
 
     class Meta:
         verbose_name = _("record article")

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -28,6 +28,20 @@
       display: none;
     }
 
+    &__title-label {
+      color: $color__grey-700;
+      font-family: $font__roboto-mono;
+      // TODO: update global font sizes to match new style guide
+      margin-bottom: 0.3rem;
+      margin-top: 1.1rem;
+      text-transform: uppercase;
+      font-size: 0.875rem;
+  
+      @media only screen and (min-width: $screen__md) {
+        font-size: 0.9rem;
+      }
+    }
+
     &__title-link {
       font-family: $font__body;
       font-weight: $font-weight-bold;

--- a/sass/includes/related-article-cards.scss
+++ b/sass/includes/related-article-cards.scss
@@ -3,7 +3,7 @@
   margin: 1rem 0;
   font-family: $font__body;
 
-  &__subtitle {
+  &__title-label {
     color: $color__grey-700;
     font-family: $font__roboto-mono;
     // TODO: update global font sizes to match new style guide

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -38,7 +38,7 @@
 
             <div class="featured-article__description">
                 <h2 class="featured-article__heading">
-                    <small>{% trans "Spotlight on" %}</small>
+                    <small>{{ page.featured_article.title_label }}</small>
                     {{ page.featured_article.title }}
                     {% if page.featured_article.is_newly_published %}
                         <span aria-describedby="article-desc">NEW</span>

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -12,8 +12,8 @@
 {% block meta_tag %}
     {% meta_tags %}
 {% endblock %}
-{% block content %}
 
+{% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     <div class="container pt-2">
         <div class="row">
@@ -34,48 +34,6 @@
             {% endfor %}
         </div>
     </div>
-
-    {% if page.featured_article %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article title="Spotlight on" %}
-    {% endif %}
-
-    {% if page.featured_pages %}
-    <div class="container">
-        {% include_block page.featured_pages %}
-    </div>
-    {% endif %}
-
-    <div class="cta-banner-survey no-dots">
-        <div class="container py-3">
-            <div class="row justify-content-md-center text-center">
-                <div class="col-sm-12 col-lg-12">
-                    <a class="tna-button--dark" href="/articles/" rel="noopener noreferrer" target="_blank">Explore stories from the collection</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!--new survey element-->
-    <!--
-    <div class="cta-banner-survey">
-        <div class="container py-3">
-            <div class="row justify-content-md-center text-center">
-
-                <div class="col-sm-12 col-lg-12">
-                    <div class="survey-outline">
-                    <p>How would you rate this page?</p>
-                    <a class="tna-button--dark response-btn" href="https://www.smartsurvey.co.uk/s/SY13JD/" rel="noopener noreferrer" target="_blank">Very helpful</a>
-                    <a class="tna-button--dark response-btn" href="https://www.smartsurvey.co.uk/s/SY13JD/" rel="noopener noreferrer" target="_blank">Could be better</a>
-                    <p><a href="https://www.nationalarchives.gov.uk/contact-us/your-views/" target="_blank">Leave a comment</a></p>
-                    </div>
-                </div>
-
-            </div>
-        </div>
-    </div>
-    -->
-
-</div>
 {% endblock content %}
 
 {% block extra_js %}

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -22,7 +22,7 @@
 
         <div class="featured-article__description">
             <h2 class="featured-article__heading">
-                <small>{% trans "Spotlight on" %}</small>
+                <small>{{ page.title_label }}</small>
                 {{ page.title }}
                 {% if page.is_newly_published %}
                     <span aria-describedby="article-desc">NEW</span>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -41,7 +41,7 @@
                     href='{{ page.url }}'
                     class="card-group-secondary-nav__title-link"
                     data-card-type="card-group-secondary-nav"
-                    aria-describedby="article-desc{{page.id}}{% if instance_id %}-{{ instance_id }}{% endif %}"
+                    aria-describedby="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
                     {% if value.block.meta.label or heading %}
                     data-component-name="{% if value.block.meta.label %}{{ value.block.meta.label }}: {{ heading }}{% else %}{{ heading }}{% endif %}"
                     {% endif %}

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -33,7 +33,9 @@
             </div>
         </a>
         <div class="card-group-secondary-nav__body">
-            <p class="card-group-secondary-nav__title-label">{{ page.title_label }}</p>
+            {% if page.title_label %}
+                <p class="card-group-secondary-nav__title-label">{{ page.title_label }}</p>
+            {% endif %}
             <h3 class="card-group-secondary-nav__heading">
                 <a
                     href='{{ page.url }}'

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -32,32 +32,29 @@
                 </picture>
             </div>
         </a>
-            <div class="card-group-secondary-nav__body">
-
-                    <h3 class="card-group-secondary-nav__heading">
-                        <a
-                                href='{{ page.url }}'
-                                class="card-group-secondary-nav__title-link"
-                                data-card-type="card-group-secondary-nav"
-                                aria-describedby="article-desc{{page.id}}{% if instance_id %}-{{ instance_id }}{% endif %}"
-                                {% if value.block.meta.label or heading %}
-                                data-component-name="{% if value.block.meta.label %}{{ value.block.meta.label }}: {{ heading }}{% else %}{{ heading }}{% endif %}"
-                                {% endif %}
-                                data-link-type="Card text"
-                                data-card-title="{{ page.title }}"
-                                {% if page.is_newly_published %}
-                            data-label="New"
-                            {%endif%}
-                            >{{ page.title }}</a>
-                        {% if page.is_newly_published %}
-                        <span>NEW</span>
-
-                        {% endif %}
-                    </h3>
-                <p id ="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">This is a link to a story about {{ page.title }}</p>
-
-                <p class="card-group-secondary-nav__paragraph">{{ page.teaser_text }}</p>
-            </div>
-
+        <div class="card-group-secondary-nav__body">
+            <p class="card-group-secondary-nav__title-label">{{ page.title_label }}</p>
+            <h3 class="card-group-secondary-nav__heading">
+                <a
+                    href='{{ page.url }}'
+                    class="card-group-secondary-nav__title-link"
+                    data-card-type="card-group-secondary-nav"
+                    aria-describedby="article-desc{{page.id}}{% if instance_id %}-{{ instance_id }}{% endif %}"
+                    {% if value.block.meta.label or heading %}
+                    data-component-name="{% if value.block.meta.label %}{{ value.block.meta.label }}: {{ heading }}{% else %}{{ heading }}{% endif %}"
+                    {% endif %}
+                    data-link-type="Card text"
+                    data-card-title="{{ page.title }}"
+                    {% if page.is_newly_published %}
+                    data-label="New"
+                    {%endif%}
+                    >{{ page.title }}</a>
+                {% if page.is_newly_published %}
+                <span>NEW</span>
+                {% endif %}
+            </h3>
+            <p id ="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">This is a link to a story about {{ page.title }}</p>
+            <p class="card-group-secondary-nav__paragraph">{{ page.teaser_text }}</p>
+        </div>
     </div>
 </li>

--- a/templates/includes/related-article-cards.html
+++ b/templates/includes/related-article-cards.html
@@ -23,7 +23,7 @@
                     </picture>
                 </a>
                 <div class="related-article-cards__content">
-                    <p class="related-article-cards__subtitle">{{ article.title_label }}</p>
+                    <p class="related-article-cards__title-label">{{ article.title_label }}</p>
                     <h3 class="related-article-cards__title">
                         <a class="related-article-cards__title-link" href={% pageurl article %}>
                             {{ article.title }}

--- a/templates/includes/related-article-cards.html
+++ b/templates/includes/related-article-cards.html
@@ -23,8 +23,7 @@
                     </picture>
                 </a>
                 <div class="related-article-cards__content">
-                    {% comment %} BE needs adding for subtitle {% endcomment %}
-                    {% comment %} <p class="related-article-cards__subtitle">Record revealed</p> {% endcomment %}
+                    <p class="related-article-cards__subtitle">{{ article.title_label }}</p>
                     <h3 class="related-article-cards__title">
                         <a class="related-article-cards__title-link" href={% pageurl article %}>
                             {{ article.title }}


### PR DESCRIPTION
## Note to reviewer
### Please do not merge this PR when accepted

Ticket URL: https://national-archives.atlassian.net/browse/UN-677

## About these changes

Added `title_label` to `RecordArticlePage` and `ArticlePage` to pull through "RECORD REVEALED" or "THE STORY OF" in the front-end.

## How to check these changes

Check anywhere that "stories" or "record revealed" pages are used and see that "THE STORY OF" or "RECORD REVEALED" are being pulled through correctly depending on the page type.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
