### PR TITLE
[UN-651] Tracking data attributes for featured record article

### DIFF
--- a/templates/blocks/featured_record_article.html
+++ b/templates/blocks/featured_record_article.html
@@ -18,9 +18,10 @@
                 </picture>
             </a>
         {% endif %}
+
         <div class="featured-record-article__container">
             <p class="featured-record-article__meta u-margin-xxs">{% trans "Record Revealed" %}</p>
-            <a href="{% pageurl value.page %}" class="featured-record-article__link">
+            <a href="{% pageurl value.page %}" class="featured-record-article__link" data-component-name="{{ value.block.meta.label }}" data-link-type="Banner title" data-link="{{ value.page.title }}">
                 <h3 class="featured-record-article__title u-margin-xs">{{ value.page.title }}</h3>
             </a>
             {% if value.page.date_text %}<p class="featured-record-article__date u-margin-xs">{{ value.page.date_text }}</p>{% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-651

## About these changes

Adds tracking for featured record article component

## How to check these changes

Compare requirements against generated data attributes on the FE. 

Local testing link: http://localhost:8000/stories/alice-hawkins/#h2.when-did-working-women-get-the-vote 

Component to inspect for data attributes:
<img width="782" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/4d6f3b4e-9557-404d-a123-c51748295393">


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
