### PR TITLE
DF-695: Fix colour display issues on Archive level page

### DIFF
--- a/sass/includes/_archive-collections.scss
+++ b/sass/includes/_archive-collections.scss
@@ -8,7 +8,7 @@
   &__container {
     padding: 1rem;
     max-height: 15rem;
-    border: 0.125rem solid $color__cream;
+    border: 0.125rem solid $color__yellow;
     overflow: auto;
     margin: 0 0 4rem;
     background: $color__cream;

--- a/sass/includes/_archive-description.scss
+++ b/sass/includes/_archive-description.scss
@@ -13,7 +13,8 @@
   &__contact {
     padding: 2rem;
     font-family: $font__open-sans;
-    background: $color__grey-800;
+    background: $color__grey-200;
+    border: 0.125rem solid $color__grey-400;
 
     h2 {
       margin: 0 0 1rem;


### PR DESCRIPTION
## Ticket

[DF-695: Fix colour display issues on Archive level page](https://national-archives.atlassian.net/browse/DF-695?atlOrigin=eyJpIjoiNzM5YTgyM2UzZjQxNGM3NjljMGU2MjllYjQzZTc4MWMiLCJwIjoiaiJ9)

## About these changes

This is a task to fix some identified colour issues discovered on the Archive level details pages.

The background colour has been changed from dark grey to light grey. Borders have also been added to the boxes on these pages to help with visibility.

## How to check these changes

The reviewer should do a visual check of the page to ensure the page looks correct.

Contact panel:
![contact-information-panel-revised](https://github.com/nationalarchives/ds-wagtail/assets/7143978/51b82a22-c257-41a7-a479-6beacc2b2cb8)

Collections panel:
![collections-information-panel-revised](https://github.com/nationalarchives/ds-wagtail/assets/7143978/93548b0b-dffc-4917-8424-3df4b8866611)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
