### PR TITLE
[UN-532] Performance Metrics - FE requirements for Large link cards component 

### DIFF
--- a/templates/includes/related_topic_timeline_cards.html
+++ b/templates/includes/related_topic_timeline_cards.html
@@ -1,28 +1,58 @@
 {% load static wagtailimages_tags wagtailcore_tags %}
-<div class="container">
-    <h2 class="card-grid__title">{{ title|default:"You may be interested in" }}</h2>
-    <div class="card-grid card-grid__duo">
-        {% if topic %}
-            <a class="card" href="{% pageurl topic %}">
-                <div class="card__container card__container--dark">
-                    {% image topic.specific.teaser_image fill-540x350 as teaser_image %}
-                    <img height="350"
-                         width="540"
-                         src="{{ teaser_image.url }}"
-                         class="card__image"
-                         alt=""/>
-                    <p class="card__text">{{ topic.title }}</p>
+<div class="related-highlight-cards">
+    <div class="container">
+        <h2 class="card-grid__title">{{ title|default:"You may be interested in" }}</h2>
+        <div class="card-grid card-grid__duo">
+            {% if topic %}
+                <div class="related-highlight-cards__card">
+                    <a href="{% pageurl topic %}" aria-labelledby="topic-card-title" data-component-name="Navigation card: {{ title|default:"You may be interested in" }}" data-link-type="Card image" data-card-position="0" data-card-title="{{ topic.title }}">
+                        {% image topic.specific.teaser_image fill-540x350 as teaser_image %}
+                        <img height="350"
+                            width="540"
+                            src="{{ teaser_image.url }}"
+                            class="related-highlight-cards__image"
+                            alt=""/>
+                    </a>
+                    <div class="related-highlight-cards__content">
+                        <p class="related-highlight-cards__card-title" id="topic-card-title">
+                            <a href="{% pageurl topic %}" class="related-highlight-cards__card-title-link" data-component-name="Navigation card: {{ title|default:"You may be interested in" }}" data-link-type="Card title" data-card-position="0" data-card-title="{{ topic.title }}">
+                                {{ topic.title }}
+                            </a>
+                        </p>
+                    </div>
                 </div>
-            </a>
-        {% endif %}
-        {% if time_period %}
-            <a class="card" href="{% pageurl time_period %}">
-                <div class="card__container card__container--dark">
-                    {% image time_period.specific.teaser_image fill-540x350 as teaser_image %}
-                    <img height="350" width="540" class="card__image" src="{{ teaser_image.url }}" alt=""/>
-                    <p class="card__text">{{ time_period.title }}</p>
+            {% endif %}
+            {% if time_period %}
+                <div class="related-highlight-cards__card">
+                    <a 
+                    href="{% pageurl time_period %}"
+                    aria-labelledby="time-period-card-title" 
+                    data-component-name="Navigation card: {{ title|default:"You may be interested in" }}"
+                    data-link-type="Card image"
+                    data-card-position="1"
+                    data-card-title="{{ time_period.title }}">
+                        {% image time_period.specific.teaser_image fill-540x350 as teaser_image %}
+                        <img height="350" 
+                            width="540"
+                            class="related-highlight-cards__image"
+                            src="{{ teaser_image.url }}"
+                            alt=""/>
+                    </a>
+                    <div class="related-highlight-cards__content">      
+                        <p class="related-highlight-cards__card-title" id="time-period-card-title">
+                            <a href="{% pageurl time_period %}" class="related-highlight-cards__card-title-link" 
+                            data-component-name="Navigation card: {{ title|default:"You may be interested in" }}"
+                            data-link-type="Card title"
+                            data-card-position="1"
+                            data-card-title="{{ time_period.title }}">
+                                {{ time_period.title }}
+                            </a>
+                        </p>
+                    </div>
                 </div>
-            </a>
-        {% endif %}
+            {% endif %}
+        </div>
     </div>
 </div>
+
+


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-532

## About these changes

This PR adds required data attributes for performance metrics. It also updates the related_topic_timeline_cards.html template to be in line with the latest card design. 

I've created this new PR and closed the existing one (https://github.com/nationalarchives/ds-wagtail/pull/943) as that was outdated.

## How to check these changes

1. Review record article or highlight gallery page locally
2. Check the related topic/timeline cards are using the latest styles
3. Inspect the elements and see if the data attributes are displaying the expected values (cross-reference with ticket requirements)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
