### PR TITLE
UN-667: `card-group-secondary-nav` analytics

### DIFF
--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -63,7 +63,7 @@
 
                 {% with page=article_page.specific %}
                     {% comment %} instance id adds a unique id to stories if they're included twice on the page {% endcomment %}
-                    {% include 'includes/card-group-secondary-nav.html' with heading="Discover all stories" instance_id=forloop.counter %}
+                    {% include 'includes/card-group-secondary-nav.html' with heading="Discover all stories" instance_id=forloop.counter card_type="Featured" %}
                 {% endwith %}
 
             {% endfor %}

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -61,7 +61,7 @@
 
             {% for article_page in article_pages %}
 
-                {% with page=article_page.specific %}
+                {% with link_page=article_page.specific %}
                     {% comment %} instance id adds a unique id to stories if they're included twice on the page {% endcomment %}
                     {% include 'includes/card-group-secondary-nav.html' with heading="Discover all stories" instance_id=forloop.counter card_type="Featured" %}
                 {% endwith %}

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -34,7 +34,7 @@
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.similar_items %}
-                        {% include 'includes/card-group-secondary-nav.html' with page=item heading="You may also be interested in" %}
+                        {% include 'includes/card-group-secondary-nav.html' with page=item heading="You may also be interested in" card_type="Featured" %}
                     {% endfor %}
                 </ul>
             {% endif %}
@@ -50,7 +50,7 @@
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.latest_items %}
-                        {% include 'includes/card-group-secondary-nav.html' with page=item heading="More stories" %}
+                        {% include 'includes/card-group-secondary-nav.html' with page=item heading="More stories" card_type="Featured" %}
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -34,7 +34,7 @@
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.similar_items %}
-                        {% include 'includes/card-group-secondary-nav.html' with page=item heading="You may also be interested in" card_type="Featured" %}
+                        {% include 'includes/card-group-secondary-nav.html' with link_page=item heading="You may also be interested in" card_type="Featured" %}
                     {% endfor %}
                 </ul>
             {% endif %}
@@ -50,7 +50,7 @@
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.latest_items %}
-                        {% include 'includes/card-group-secondary-nav.html' with page=item heading="More stories" card_type="Featured" %}
+                        {% include 'includes/card-group-secondary-nav.html' with link_page=item heading="More stories" card_type="Featured" %}
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/templates/articles/blocks/featured_collection.html
+++ b/templates/articles/blocks/featured_collection.html
@@ -8,7 +8,7 @@
     <ul class="card-group--list-style-none">
         {% for item in value.items %}
             {% with page=item %}
-                {% include 'includes/card-group-secondary-nav.html' with heading=value.heading %}
+                {% include 'includes/card-group-secondary-nav.html' with heading=value.heading card_type="Featured" %}
             {% endwith %}
         {% endfor %}
     </ul>

--- a/templates/articles/blocks/featured_collection.html
+++ b/templates/articles/blocks/featured_collection.html
@@ -7,7 +7,7 @@
 
     <ul class="card-group--list-style-none">
         {% for item in value.items %}
-            {% with page=item %}
+            {% with link_page=item %}
                 {% include 'includes/card-group-secondary-nav.html' with heading=value.heading card_type="Featured" %}
             {% endwith %}
         {% endfor %}

--- a/templates/collections/blocks/featured_articles.html
+++ b/templates/collections/blocks/featured_articles.html
@@ -4,7 +4,7 @@
 <div class="featured-articles">
     <ul class="card-group--list-style-none">
         {% for item in value.items %}
-            {% include 'includes/card-group-secondary-nav.html' with heading=value.heading page=item.specific %}
+            {% include 'includes/card-group-secondary-nav.html' with heading=value.heading page=item.specific card_type="Featured" %}
         {% endfor %}
     </ul>
 </div>

--- a/templates/collections/blocks/featured_articles.html
+++ b/templates/collections/blocks/featured_articles.html
@@ -4,7 +4,7 @@
 <div class="featured-articles">
     <ul class="card-group--list-style-none">
         {% for item in value.items %}
-            {% include 'includes/card-group-secondary-nav.html' with heading=value.heading page=item.specific card_type="Featured" %}
+            {% include 'includes/card-group-secondary-nav.html' with heading=heading link_page=item.specific card_type="Featured" %}
         {% endfor %}
     </ul>
 </div>

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -14,7 +14,7 @@
             {% endfor %}
         </ul>
     </div>
-
+    
     <div class="container">
         <h2>{{ page.articles_title }}</h3>
 
@@ -26,7 +26,7 @@
     {% endif %}
 
     <div class="container">
-        {% include_block page.featured_articles %}
+        {% include_block page.featured_articles with heading=page.articles_title %}
 
         <div class="featured-articles__cta">
             {% comment %} TODO: update BEM button styles for consistency across site {% endcomment %}

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -12,7 +12,7 @@
             <h2 class="sr-only">Select a time period</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-time-period" id="analytics-select-a-time-period">
                 {% for child in page.time_period_explorer_pages %}
-                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
+                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific card_type="Navigation" %}
                 {% endfor %}
             </ul>
         </div>

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -12,7 +12,7 @@
             <h2 class="sr-only">Select a time period</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-time-period" id="analytics-select-a-time-period">
                 {% for child in page.time_period_explorer_pages %}
-                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific card_type="Navigation" %}
+                    {% include 'includes/card-group-secondary-nav.html' with link_page=child.specific card_type="Navigation" %}
                 {% endfor %}
             </ul>
         </div>

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -12,7 +12,7 @@
             <h2 class="sr-only">Select a topic</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-topic" id="analytics-select-a-topic">
                 {% for child in page.topic_explorer_pages %}
-                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific %}
+                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific card_type="Navigation" %}
                 {% endfor %}
             </ul>
         </div>

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -12,7 +12,7 @@
             <h2 class="sr-only">Select a topic</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-topic" id="analytics-select-a-topic">
                 {% for child in page.topic_explorer_pages %}
-                    {% include 'includes/card-group-secondary-nav.html' with page=child.specific card_type="Navigation" %}
+                    {% include 'includes/card-group-secondary-nav.html' with link_page=child.specific card_type="Navigation" %}
                 {% endfor %}
             </ul>
         </div>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -1,20 +1,20 @@
 {% load wagtailimages_tags %}
 
-{% image page.teaser_image fill-288x172 as teaser_image_small %}
-{% image page.teaser_image fill-328x196 as teaser_image_medium %}
-{% image page.teaser_image fill-348x208 as teaser_image_large %}
-{% image page.teaser_image fill-508x304 as teaser_image_extra_large %}
+{% image link_page.teaser_image fill-288x172 as teaser_image_small %}
+{% image link_page.teaser_image fill-328x196 as teaser_image_medium %}
+{% image link_page.teaser_image fill-348x208 as teaser_image_large %}
+{% image link_page.teaser_image fill-508x304 as teaser_image_extra_large %}
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
         <a
-            href="{{ page.url }}"
+            href="{{ link_page.url }}"
             class="card-group-secondary-nav__image-link"
             data-card-type="card-group-secondary-nav"
             data-component-name="{{ card_type }} card: {% if heading %}{{ heading }}{% else %}{{ page.title }}{% endif %}"
             data-link-type="Card image"
-            data-card-title="{{ page.title }}"
-            {% if page.is_newly_published %}
+            data-card-title="{{ link_page.title }}"
+            {% if link_page.is_newly_published %}
                 data-label="New"
             {%endif%}
             aria-hidden="true"
@@ -31,28 +31,28 @@
             </div>
         </a>
         <div class="card-group-secondary-nav__body">
-            {% if page.title_label %}
-                <p class="card-group-secondary-nav__title-label">{{ page.title_label }}</p>
+            {% if link_page.title_label %}
+                <p class="card-group-secondary-nav__title-label">{{ link_page.title_label }}</p>
             {% endif %}
             <h3 class="card-group-secondary-nav__heading">
                 <a
-                    href="{{ page.url }}"
+                    href="{{ link_page.url }}"
                     class="card-group-secondary-nav__title-link"
                     data-card-type="card-group-secondary-nav"
-                    aria-describedby="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
+                    aria-describedby="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
                     data-component-name="{{ card_type }} card: {% if heading %}{{ heading }}{% else %}{{ page.title }}{% endif %}"
                     data-link-type="Card text"
-                    data-card-title="{{ page.title }}"
-                    {% if page.is_newly_published %}
+                    data-card-title="{{ link_page.title }}"
+                    {% if link_page.is_newly_published %}
                     data-label="New"
                     {%endif%}
-                    >{{ page.title }}</a>
-                {% if page.is_newly_published %}
+                    >{{ link_page.title }}</a>
+                {% if link_page.is_newly_published %}
                 <span>NEW</span>
                 {% endif %}
             </h3>
-            <p id ="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">This is a link to a story about {{ page.title }}</p>
-            <p class="card-group-secondary-nav__paragraph">{{ page.teaser_text }}</p>
+            <p id ="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">This is a link to a story about {{ link_page.title }}</p>
+            <p class="card-group-secondary-nav__paragraph">{{ link_page.teaser_text }}</p>
         </div>
     </div>
 </li>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -49,6 +49,9 @@
                     {% if link_page.is_newly_published %}
                     data-label="New"
                     {%endif%}
+                    {% if forloop.counter %}
+                        data-card-position="{{ forloop.counter0 }}"
+                    {% endif %}
                     >{{ link_page.title }}</a>
                 {% if link_page.is_newly_published %}
                 <span>NEW</span>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -8,12 +8,10 @@
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
         <a
-            href='{{ page.url }}'
+            href="{{ page.url }}"
             class="card-group-secondary-nav__image-link"
             data-card-type="card-group-secondary-nav"
-            {% if value.block.meta.label or heading %}
-                data-component-name="{% if value.block.meta.label %}{{ value.block.meta.label }}: {{ heading }}{% else %}{{ heading }}{% endif %}"
-            {% endif %}
+            data-component-name="{{ card_type }} card: {% if heading %}{{ heading }}{% else %}{{ page.title }}{% endif %}"
             data-link-type="Card image"
             data-card-title="{{ page.title }}"
             {% if page.is_newly_published %}
@@ -38,13 +36,11 @@
             {% endif %}
             <h3 class="card-group-secondary-nav__heading">
                 <a
-                    href='{{ page.url }}'
+                    href="{{ page.url }}"
                     class="card-group-secondary-nav__title-link"
                     data-card-type="card-group-secondary-nav"
                     aria-describedby="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
-                    {% if value.block.meta.label or heading %}
-                    data-component-name="{% if value.block.meta.label %}{{ value.block.meta.label }}: {{ heading }}{% else %}{{ heading }}{% endif %}"
-                    {% endif %}
+                    data-component-name="{{ card_type }} card: {% if heading %}{{ heading }}{% else %}{{ page.title }}{% endif %}"
                     data-link-type="Card text"
                     data-card-title="{{ page.title }}"
                     {% if page.is_newly_published %}

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -19,6 +19,9 @@
             {%endif%}
             aria-hidden="true"
             tabindex="-1"
+            {% if forloop.counter %}
+                data-card-position="{{ forloop.counter0 }}"
+            {% endif %}
         >
             <div class="card-group-secondary-nav__image">
                 <picture>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-667

## About these changes

Updated `card-group-secondary-nav` to use `link_page` instead of `page` so that we can access `page`.

Updated tracking requirements to use `heading` or `page.title` as a fall-back if `heading` doesn't exist.

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
