### PR TITLE
[UN-659] Accessibility - update card image links

### DIFF
--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -19,8 +19,7 @@
             {% if page.is_newly_published %}
                 data-label="New"
             {%endif%}
-            aria-hidden="true"
-            tabindex="-1"
+            aria-describedby="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
         >
             <div class="card-group-secondary-nav__image">
                 <picture>

--- a/templates/includes/related-article-cards.html
+++ b/templates/includes/related-article-cards.html
@@ -4,7 +4,10 @@
     <div class="card-grid card-grid__trio card-grid__trio--large-gaps">
         {% for article in articles %}
             <div class="related-article-cards__card">
-                <a href={% pageurl article %}>
+                <a href={% pageurl article %}
+                {% comment %} remove image link from taborder and hide from screenreaders {% endcomment %}
+                aria-hidden="true"
+                tabindex="-1">
                     <picture>
                         {% image article.teaser_image fill-342x229-c100 format-webp as mobile_webp_image %}
                         <source media="(max-width: 390px)"

--- a/templates/includes/related-articles-highlight-cards.html
+++ b/templates/includes/related-articles-highlight-cards.html
@@ -5,7 +5,9 @@
         <div class="card-grid card-grid__quad">
             {% if featured_article %}
                 <div class="highlight-cards__card highlight-cards__card--highlight highlight-cards__link">
-                    <a href="{% pageurl featured_article %}">
+                    <a href="{% pageurl featured_article %}"
+                    aria-hidden="true"
+                    tabindex="-1">
                         {# Desktop/ tablet image #}
                         {% image featured_article.teaser_image fill-534x413-c100 format-webp as image_webp %}
                         <source srcset="{{ image_webp.url }}"
@@ -33,7 +35,9 @@
             {% endif %}
             {% for article in articles %}
                 <div class="highlight-cards__card highlight-cards__card--normal highlight-cards__link">
-                    <a href="{% pageurl article %}">
+                    <a href="{% pageurl article %}"
+                    aria-hidden="true"
+                    tabindex="-1">
                         {% image article.teaser_image fill-268x171-c100 format-webp as image_webp %}
                         <source srcset="{{ image_webp.url }}"
                                 type="image/webp"

--- a/templates/includes/related-highlight-cards.html
+++ b/templates/includes/related-highlight-cards.html
@@ -5,7 +5,10 @@
         <div class="card-grid card-grid__trio">
             {% for card in cards %}
                 <div class="related-highlight-cards__card">
-                    <a href="{{ card.url }}" aria-labelledby="related-highlight-card-title-{{ forloop.counter }}">
+                    <a href="{{ card.url }}"
+                    {% comment %} remove image link from taborder and hide from screenreaders {% endcomment %}
+                    aria-hidden="true"
+                    tabindex="-1">
                         <picture>
                         {% image card.teaser_image fill-374x370-c100 format-webp as mobile_webp_image %}
                         <source media="(max-width: 370px)"


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-659

## About these changes

This resolves the accessibility issue flagged when links wrapping images do not have link text - this occurs when an image doesn't have an alt tag or relevant aria-label.
This PR updates card image links to make sure they either:

-  have an `aria-describedby` attribute to point to the card title (this is if the link is used for GTM tracking, to make sure we are tracking SR and keyboard users interactions too)
- hides the link from SR and keyboard users by adding `aria-hidden` and `tabindex="-1"` to remove it from the taborder. This is only if the image is decorative and not necessary for context or tracking requirements.

## How to check these changes

Check the individual card types to make sure they are either reading the correct label (the card title) or are ignored by keyboards and screen readers.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
