### PR TITLE
[UN-684] Image gallery tracking

### DIFF
--- a/scripts/src/modules/analytics/record_tracking/image_gallery_tracking.js
+++ b/scripts/src/modules/analytics/record_tracking/image_gallery_tracking.js
@@ -1,0 +1,101 @@
+import push_to_data_layer from "../push_to_data_layer";
+
+export default function imageGalleryTracking() {
+    const imageGallery = document.querySelector("[data-image-gallery]");
+    const imageGalleryOpen = imageGallery.querySelector("[data-image-gallery-open]");
+    const imageGalleryClose = imageGallery.querySelector("[data-image-gallery-close]");
+    let imageGalleryTranscriptionTab = imageGallery.querySelectorAll("[data-transcription-tab]");
+    let imageGalleryTranslationTab = imageGallery.querySelectorAll("[data-translation-tab]");
+
+    // 'open gallery' button tracking - on click
+    imageGalleryOpen.addEventListener("click", e => {
+        push_to_data_layer({
+            "event": "Image gallery",
+            "data-component-name": e.target.getAttribute("data-component-name"),
+            "data-link-type": e.target.getAttribute("data-link-type"),
+            "data-link": e.target.getAttribute("data-link")
+        })
+    })
+
+    // 'open gallery' button tracking - on keypress
+    imageGalleryOpen.addEventListener("keyup", e => {
+        if(e.key === "Enter") {
+            push_to_data_layer({
+                "event": "Image gallery",
+                "data-component-name": e.target.getAttribute("data-component-name"),
+                "data-link-type": e.target.getAttribute("data-link-type"),
+                "data-link": e.target.getAttribute("data-link")
+            })
+        }
+    })
+
+    // 'close gallery' button tracking - on click
+    imageGalleryClose.addEventListener("click", e => {
+        push_to_data_layer({
+            "event": "Image gallery",
+            "data-component-name": e.target.getAttribute("data-component-name"),
+            "data-link-type": e.target.getAttribute("data-link-type"),
+            "data-link": e.target.getAttribute("data-link")
+        })
+    })
+
+    // 'close gallery' button tracking - on keypress
+    imageGalleryClose.addEventListener("keyup", e => {
+        if(e.key === "Enter") {
+            push_to_data_layer({
+                "event": "Image gallery",
+                "data-component-name": e.target.getAttribute("data-component-name"),
+                "data-link-type": e.target.getAttribute("data-link-type"),
+                "data-link": e.target.getAttribute("data-link")
+            })
+        }
+    })
+    
+    imageGalleryTranscriptionTab.forEach((tab) => {
+        // 'transcription' tab tracking - on click
+        tab.addEventListener("click", e => {
+            push_to_data_layer({
+                "event": "Transcript",
+                "data-component-name": e.target.getAttribute("data-component-name"),
+                "data-link-type": e.target.getAttribute("data-link-type"),
+                "data-link": e.target.getAttribute("data-link")
+            })
+        });
+
+        // 'transcription' tab tracking - on keypress
+        tab.addEventListener("keyup", e => {
+            if(e.key === "Enter") {
+                push_to_data_layer({
+                    "event": "Transcript",
+                    "data-component-name": e.target.getAttribute("data-component-name"),
+                    "data-link-type": e.target.getAttribute("data-link-type"),
+                    "data-link": e.target.getAttribute("data-link")
+                })
+            }
+        })
+    });
+
+    imageGalleryTranslationTab.forEach((tab) => {
+        // 'translation' tab tracking - on click
+        tab.addEventListener("click", e => {
+            push_to_data_layer({
+                "event": "Translation",
+                "data-component-name": e.target.getAttribute("data-component-name"),
+                "data-link-type": e.target.getAttribute("data-link-type"),
+                "data-link": e.target.getAttribute("data-link")
+            })
+        });
+
+        // 'translation' tab tracking - on keypress
+        tab.addEventListener("keyup", e => {
+            if(e.key === "Enter") {
+                push_to_data_layer({
+                    "event": "Translation",
+                    "data-component-name": e.target.getAttribute("data-component-name"),
+                    "data-link-type": e.target.getAttribute("data-link-type"),
+                    "data-link": e.target.getAttribute("data-link")
+                })
+            }
+        })
+    });
+}

--- a/scripts/src/record-article-page.js
+++ b/scripts/src/record-article-page.js
@@ -1,11 +1,13 @@
 
 import ImageGallery from './modules/image-gallery';
+import imageGalleryTracking from './modules/analytics/record_tracking/image_gallery_tracking';
 import RecordMatters from './modules/record-matter';
 
-const imageGallery = document.querySelector('.transcription')
+const imageGallery = document.querySelector('[data-image-gallery]')
 
 if (imageGallery) {
     new ImageGallery(imageGallery);
+    imageGalleryTracking();
 }
 
 const recordMatters = document.querySelector('.record-matters')

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -1,5 +1,5 @@
 {% load static wagtailimages_tags wagtailcore_tags records_tags %}
-<div class="transcription">
+<div class="transcription" data-image-gallery>
     <div class="transcription__preview hidden">
         <div class="transcription__container">
             {% with gallery_length=gallery|length %}
@@ -23,7 +23,10 @@
                              {% if first_gallery_item.alt_text %}alt="{{ first_gallery_item.alt_text }}"{% endif %}/>
                     {% endwith %}
                 </picture>
-                <button id="showButton" class="transcription__open" aria-expanded="false">
+                <button id="showButton" data-image-gallery-open class="transcription__open" aria-expanded="false" 
+                data-component-name="Image gallery"
+                data-link-type="Button"
+                data-link="View image{{ gallery_length|pluralize }}{% if has_text %} and transcript{{ gallery_length|pluralize }}{% endif %}">
                     View image{{ gallery_length|pluralize }}
                     {% if has_text %}and transcript{{ gallery_length|pluralize }}{% endif %}
                 </button>
@@ -84,8 +87,12 @@
                                         type="button"
                                         role="tab"
                                         aria-selected="true"
-                                        aria-controls="tabpanel-1-{{ forloop.counter }}">
-                                    <span>{{ item.image.get_transcription_heading_display }}</span>
+                                        aria-controls="tabpanel-1-{{ forloop.counter }}"
+                                        data-component-name="Image gallery"
+                                        data-link-type="Tab"
+                                        data-link="{{ item.image.get_transcription_heading_display }}"
+                                        data-transcription-tab>
+                                    {{ item.image.get_transcription_heading_display }}
                                 </button>
                             {% endif %}
                             {% if item.image.translation %}
@@ -95,8 +102,12 @@
                                         role="tab"
                                         aria-selected="false"
                                         aria-controls="tabpanel-2-{{ forloop.counter }}"
-                                        tabindex="-1">
-                                    <span>{{ item.image.get_translation_heading_display }}</span>
+                                        tabindex="-1"
+                                        data-component-name="Image gallery"
+                                        data-link-type="Tab"
+                                        data-link="{{ item.image.get_translation_heading_display }}"
+                                        data-translation-tab>
+                                    {{ item.image.get_translation_heading_display }}
                                 </button>
                             {% endif %}
                         </div>
@@ -124,7 +135,12 @@
         </div>
     {% endfor %}
 {% endwith %}
-<button class="transcription__close hidden" id="closeButton" type="button">
+<button class="transcription__close hidden" id="closeButton" 
+type="button"
+data-component-name="Image gallery"
+data-link-type="Button"
+data-link="Close images{% if has_text %} and transcripts{% endif %}"
+data-image-gallery-close>
     Close images
     {% if has_text %}and transcripts{% endif %}
     


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-684

## About these changes

Adds GTM data layer push for the Open and Close gallery button. Also adds tracking for the Transcript/Translation tabs inside the image gallery once opened.

## How to check these changes

1. Open record revealed page locally (e.g. http://localhost:8000/explore-the-collection/the-monteagle-letter/)
2. Open the image gallery
3. Click on the transcript and translate tabs
4. Open the dev console and check the datalayer to see if the correct GTM values have been pushed from each button click:
<img width="377" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/47e9d425-836e-4a77-ba7d-b3ec1e2d9bbe">
<img width="430" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/0677d901-9125-48d4-82c9-495594518535">
<img width="370" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/09bb65ae-e4df-488b-83fb-82862309a9c2">


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
