### PR TITLE
[UN-669] Record revealed body content performance metrics

### DIFF
--- a/scripts/src/modules/record-matter.js
+++ b/scripts/src/modules/record-matter.js
@@ -1,4 +1,4 @@
-
+import push_to_data_layer from "./analytics/push_to_data_layer";
 class RecordMatters {
     constructor(node) {
         this.node = node;
@@ -20,12 +20,26 @@ class RecordMatters {
             e.preventDefault();
             this.show(this.readMoreContent);
             this.hide(this.readLessContent);
+
+            push_to_data_layer({
+                "event": "Expand accordion",
+                "data-component-name": e.target.getAttribute("data-component-name"),
+                "data-link-type": e.target.getAttribute("data-link-type"),
+                "data-link": e.target.getAttribute("data-link")
+            })
         })
 
         this.readLessButton.addEventListener("click", (e) => {
             e.preventDefault();
             this.show(this.readLessContent);
             this.hide(this.readMoreContent);
+
+            push_to_data_layer({
+                "event": "Collapse accordion",
+                "data-component-name": e.target.getAttribute("data-component-name"),
+                "data-link-type": e.target.getAttribute("data-link-type"),
+                "data-link": e.target.getAttribute("data-link")
+            })
         })
     }
 

--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -14,7 +14,7 @@
                         {% if record.reference_number %}
                             <p class="record-matters__text">
                                 Catalogue reference: <a class="record-matters__text record-matters__text--bold"
-    href="{% record_url record is_editorial=True %}">{{ record.reference_number }}</a>
+    href="{% record_url record is_editorial=True %}" data-component-name="Record article body" data-link-type="Link" data-link="{{ record.reference_number }}">{{ record.reference_number }}</a>
                             </p>
                         {% endif %}
                     </div>
@@ -25,7 +25,10 @@
                             {{ about }}
                             <button id="readMoreButton"
                                     class="record-matters__plain-button {% if about|length <= 300 %}hidden{% endif %}"
-                                    aria-label="Expand to read more about this record">
+                                    aria-label="Expand to read more about this record"
+                                    data-component-name="Record article body"
+                                    data-link-type="Expand accordion"
+                                    data-link="Expand to read more">
                                 Expand to read more
                                 {% include "static/images/fontawesome-svgs/circle-plus.svg" with classes="record-matters__svg" %}
                             </button>
@@ -36,7 +39,10 @@
                         <button id="readLessButton"
                                 class="record-matters__plain-button hidden"
                                 type="button"
-                                aria-label="Close to read less about this record">
+                                aria-label="Close to read less about this record"
+                                data-component-name="Record article body"
+                                data-link-type="Collapse accordion"
+                                data-link="Collapse content">
                             Collapse content
                             {% include "static/images/fontawesome-svgs/circle-x-mark.svg" with classes="record-matters__svg" %}
                         </button>
@@ -48,17 +54,26 @@
                     {% if record %}
                         <a class="tna-button--yellow tna-button--full-width"
                            href="{% record_url record is_editorial=True %}"
-                           rel="noopener noreferrer">View record details</a>
+                           rel="noopener noreferrer"
+                           data-component-name="Record article body"
+                           data-link-type="Button"
+                           data-link="View record details">View record details</a>
                     {% endif %}
                     {% if page.image_library_link %}
                         <a class="tna-button--yellow tna-button--full-width"
                            href="{{ page.image_library_link }}"
-                           rel="noopener noreferrer">Use this image</a>
+                           rel="noopener noreferrer"
+                           data-component-name="Record article body"
+                           data-link-type="Button"
+                           data-link="Use this image">Use this image</a>
                     {% endif %}
                     {% if page.print_on_demand_link %}
                         <a class="tna-button--yellow tna-button--full-width"
                            href="{{ page.print_on_demand_link }}"
-                           rel="noopener noreferrer">Buy an art print</a>
+                           rel="noopener noreferrer"
+                           data-component-name="Record article body"
+                           data-link-type="Button"
+                           data-link="Buy an art print">Buy an art print</a>
                     {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-669

## About these changes

Adds tracking for:

1. Catalogue reference link
2. Expand/collapse button
3. Yellow buttons underneath body content

## How to check these changes

1. Check record revealed page locally (e.g. http://localhost:8000/explore-the-collection/the-monteagle-letter/)
2. Inspect elements (outlined above) for relevant data attributes and see the correct values pulling through
3. Check the datalayer after toggling expand/collapse button and see that the values for this button have been sent to the datalayer correctly

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
