### PR TITLE
DF-701: Gtm for record details page

### DIFF
--- a/etna/records/views/records.py
+++ b/etna/records/views/records.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.core.paginator import Page
 from django.shortcuts import Http404, render
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 
@@ -105,8 +106,4 @@ def record_detail_view(request, iaid):
         back_to_search_url=back_to_search_url,
     )
 
-    return render(
-        request,
-        template_name,
-        context,
-    )
+    return TemplateResponse(request=request, template=template_name, context=context)

--- a/etna/records/views/records.py
+++ b/etna/records/views/records.py
@@ -106,4 +106,5 @@ def record_detail_view(request, iaid):
         back_to_search_url=back_to_search_url,
     )
 
+    # Note: This page uses cookies to render GTM, please ensure to keep TemplateResponse or similar when changed.
     return TemplateResponse(request=request, template=template_name, context=context)


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-701

## About these changes

Update page rendering for record details page to allow GTM scripts to be included when Accepting cookies.

## How to check these changes

- Accept cookies when connecting to Etna
- Navigate to a record details page Ex: http://127.0.0.1:8000/catalogue/id/C11184/
- Check html source that it includes `gtm-script.html`  and `gtm-no-script.html`


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
