### PR TITLE
DF-703 : removal of duplicate message

### DIFF
--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -245,9 +245,7 @@ class EndToEndSearchTestCase(TestCase):
     bucket_links_html = (
         '<ul class="search-buckets__list" data-id="search-buckets-list">'
     )
-    current_bucket_description_html = (
-        '<p class="search-results__explainer search-results__explainer--bucket">'
-    )
+
     search_within_option_html = '<label for="id_filter_keyword" class="search-filters__label--block">Search within results:</label>'
     sort_order_options_html = '<label for="id_sort_by">Sort by</label>'
     filter_options_html = '<form method="GET" data-id="filters-form"'
@@ -275,12 +273,6 @@ class EndToEndSearchTestCase(TestCase):
 
     def assertBucketLinksNotRendered(self, response):
         self.assertNotIn(self.bucket_links_html, response)
-
-    def assertCurrentBucketDescriptionRendered(self, response):
-        self.assertIn(self.current_bucket_description_html, response)
-
-    def assertCurrentBucketDescriptionNotRendered(self, response):
-        self.assertNotIn(self.current_bucket_description_html, response)
 
     def assertSearchWithinOptionRendered(self, response):
         self.assertIn(self.search_within_option_html, response)
@@ -320,7 +312,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         They SHOULD NOT see:
         - Names, result counts and links for all buckets
-        - A description of the current bucket
         - A "Search within these results" option
         - Options to change sort order and display style of results
         - Filter options to refine the search
@@ -336,7 +327,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         # SHOULD NOT see
         self.assertBucketLinksNotRendered(content)
-        self.assertCurrentBucketDescriptionNotRendered(content)
         self.assertSearchWithinOptionNotRendered(content)
         self.assertSortOrderOptionsNotRendered(content)
         self.assertFilterOptionsNotRendered(content)
@@ -353,7 +343,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         - A "No results" message.
 
         They SHOULD NOT see:
-        - A description of the current bucket
         - A "Search within these results" option
         - Options to change sort order and display style of results
         - Filter options to refine the search
@@ -371,7 +360,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         self.assertNoResultsMessagingRendered(content)
 
         # SHOULD NOT see
-        self.assertCurrentBucketDescriptionNotRendered(content)
         self.assertSearchWithinOptionNotRendered(content)
         self.assertSortOrderOptionsNotRendered(content)
         self.assertFilterOptionsNotRendered(content)
@@ -386,7 +374,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         They SHOULD see:
         - Names, result counts and links for all buckets
-        - A description of the current bucket
         - A "Search within these results" option
         - Options to change sort order and display style of results
         - Filter options to refine the search
@@ -405,7 +392,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         # SHOULD see
         self.assertBucketLinksRendered(content)
-        self.assertCurrentBucketDescriptionRendered(content)
         self.assertSearchWithinOptionRendered(content)
         self.assertSortOrderOptionsRendered(content)
         self.assertNoResultsMessagingRendered(content)
@@ -423,7 +409,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         They SHOULD see:
         - Names, result counts and links for all buckets
-        - A description of the current bucket
         - A "Search within these results" option
         - Options to change sort order and display style of results
         - Filter options to refine the search
@@ -446,7 +431,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         # SHOULD see
         self.assertBucketLinksRendered(content)
-        self.assertCurrentBucketDescriptionRendered(content)
         self.assertSearchWithinOptionRendered(content)
         self.assertSortOrderOptionsRendered(content)
         self.assertFilterOptionsRendered(content)

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -245,7 +245,6 @@ class EndToEndSearchTestCase(TestCase):
     bucket_links_html = (
         '<ul class="search-buckets__list" data-id="search-buckets-list">'
     )
-
     search_within_option_html = '<label for="id_filter_keyword" class="search-filters__label--block">Search within results:</label>'
     sort_order_options_html = '<label for="id_sort_by">Sort by</label>'
     filter_options_html = '<form method="GET" data-id="filters-form"'

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -37,9 +37,7 @@
         {% endif %}
 
         {% if buckets.current.result_count > 0 %}
-            {% if buckets.current.description %}
-               
-            {% endif %}
+                
 
             {% include './blocks/search_sort_and_view_options.html' %}
         {% endif %}

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -37,11 +37,7 @@
         {% endif %}
 
         {% if buckets.current.result_count > 0 %}
-            {% if buckets.current.description %}
-                <p class="search-results__explainer search-results__explainer--bucket">
-                    {{ buckets.current.description }}
-                </p>
-            {% endif %}
+            
 
             {% include './blocks/search_sort_and_view_options.html' %}
         {% endif %}

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -37,7 +37,9 @@
         {% endif %}
 
         {% if buckets.current.result_count > 0 %}
-            
+            {% if buckets.current.description %}
+               
+            {% endif %}
 
             {% include './blocks/search_sort_and_view_options.html' %}
         {% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-703

## About these changes

Removal of duplicate message

## How to check these changes

Perform a search, In the Catalogue tab the message 'Results for records held at The National Archives and other archives that match your search term.' should only appear once.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
