### PR TITLE
UN-708: Featured HG display up to 5 highlights

### DIFF
--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -9,7 +9,7 @@
         {% include "includes/record-matters.html" with record=page.record title="Why this record matters" page=page %}
     {% endif %}
     {% if page.featured_highlight_gallery %}
-        {% include "includes/highlight_gallery_teaser.html" with title=page.featured_highlight_gallery.title cards=page.featured_highlight_gallery.page_highlights.all page=page.featured_highlight_gallery %}
+        {% include "includes/highlight_gallery_teaser.html" with title=page.featured_highlight_gallery.title cards=page.featured_highlight_gallery.page_highlights.all|slice:":5" page=page.featured_highlight_gallery %}
     {% endif %}
     {% if page.featured_article %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-708

## About these changes

Added `|slice:":5"` to only display the first 5 cards.

## How to check these changes

Add a featured highlight gallery to a record revealed page and then see if up to 5 cards are being displayed

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
