### PR TITLE
DF-718: Remove the 'N records' placeholder in the details page hierarchy 

### DIFF
--- a/sass/includes/_hierarchy-global-nav.scss
+++ b/sass/includes/_hierarchy-global-nav.scss
@@ -190,7 +190,7 @@
       background-color: $color__yellow-dark;
       padding: 0.5rem 0.75rem;
       display: inline-block;
-      min-height: 60px;
+      min-height: 75px;
       border: 2px solid $color__yellow;
       border-left: 0;
       width: 11.5%;

--- a/templates/includes/records/hierarchy-full-item.html
+++ b/templates/includes/records/hierarchy-full-item.html
@@ -15,10 +15,7 @@
 {% endif %}
 
 <div class="hierarchy-full-panel__bar-container-outer">
-    <div class="hierarchy-full-panel__bar-container-inner {% if is_current_item %} hierarchy-full-panel__bar-container-inner--active {% endif %} hierarchy-full-panel__bar-container-inner--level-{{forloop.counter|add:'1'}}">
-        <p><span class="hierarchy-full-panel__bar-number">N</span>
-        <span class="hierarchy-full-panel__bar-label">record(s)</span></p>
-    </div>
+    <div class="hierarchy-full-panel__bar-container-inner {% if is_current_item %} hierarchy-full-panel__bar-container-inner--active {% endif %} hierarchy-full-panel__bar-container-inner--level-{{forloop.counter|add:'1'}}"></div>
     <div class="hierarchy-full-panel__text-container">
         <p class="hierarchy-full-panel__text-level">{% if is_current_item %}You are currently looking at{% else %}Within{% endif %} the {% if hierarchy_level %}{{ hierarchy_level|lower }}{% else %}UNAVAILABLE{% endif %}: <a href="{% record_url item %}" data-link-type="Link" data-link="{{ item.reference_number }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{{ item.reference_number }}</a></p>
         <p class="hierarchy-full-panel__text-title">{{item.summary_title}}</p>

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -84,10 +84,7 @@
 
             <!-- Level 1 -->
             <div class="hierarchy-full-panel__bar-container-outer">
-                <div class="hierarchy-full-panel__bar-container-inner hierarchy-full-panel__bar-container-inner--level-1">
-                    <p><span class="hierarchy-full-panel__bar-number">N</span>
-                    <span class="hierarchy-full-panel__bar-label">records</span></p>
-                </div>
+                <div class="hierarchy-full-panel__bar-container-inner hierarchy-full-panel__bar-container-inner--level-1"></div>
                 <div class="hierarchy-full-panel__text-container">
                     <p class="hierarchy-full-panel__text-level">This record is held at: <a href="#" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy}}</a></p>
                     <p class="hierarchy-full-panel__text-title">Located at DATA TO GO HERE</p> <!--TODO API data needs to contain the location of the archive as well-->
@@ -101,10 +98,7 @@
                 {%endfor%}
             {% else %}
                 <div class="hierarchy-full-panel__bar-container-outer">
-                    <div class="hierarchy-full-panel__bar-container-inner hierarchy-full-panel__bar-container-inner--active hierarchy-full-panel__bar-container-inner--level-2">
-                        <p><span class="hierarchy-full-panel__bar-number">N</span>
-                    <span class="hierarchy-full-panel__bar-label">records</span></p>
-                    </div>
+                    <div class="hierarchy-full-panel__bar-container-inner hierarchy-full-panel__bar-container-inner--active hierarchy-full-panel__bar-container-inner--level-2"></div>
                     <div class="hierarchy-full-panel__text-container">
                         <p class="hierarchy-full-panel__text-level">You are currently looking at the department: <a href="{% record_url record %}" data-link-type="Link" data-link="{{record.reference_number}}" data-catalogue-level="1" data-component-name="Hierarchy links">{{record.reference_number}}</a></p>
                         <p class="hierarchy-full-panel__text-title">{{record.summary_title}}</p>


### PR DESCRIPTION
## Ticket

[DF-718: Remove the 'N records' placeholder in the details page hierarchy ](https://national-archives.atlassian.net/browse/DF-718?atlOrigin=eyJpIjoiNGRjOWFkMmYxOWMyNGY1YThjYmE0YTFlYzQwZmU1ZTAiLCJwIjoiaiJ9)

## About these changes

This task removes the 'N records' placeholder text from the hierarchy in the record details pages. As a result of removing this static text, there has been a small change to the hierarchy CSS to increase its height which ensures the container lines up correctly without an inner paragraph. 

## How to check these changes

The reviewer needs to ensure the code has been removed correctly in the two relevant include files, and also do a visual check of the page to ensure the height of the bar looks suitable now the text has been taken out and minimum height increased in the CSS.

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
