### PR TITLE
Update long filters refinement block colours

### DIFF
--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -66,7 +66,7 @@
   }
 
   &__search {
-    background-color: $color__grey-500;
+    background-color: $color__grey-200;
     border: 0.0625rem solid $color__grey-500;
     padding: 1rem;
     max-height: 14rem;


### PR DESCRIPTION
Ticket URL: n/a

## About these changes

Fixes colour contrast accessibility issue for refine filters block on long filters

## How to check these changes

Check long filters page and see that the background of the refine results block has been updated and there are no colour contrast issues.

Before:
<img width="397" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/5ee61421-73ff-4973-8083-a81b8c363f9f">

After:

<img width="367" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/6331794c-dff7-4090-81b9-249d55bd389e">


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
