### PR TITLE
DF-717: js enhancement to enable/disable submit button unless a sentiment is chosen

### DIFF
--- a/etna/feedback/templates/feedback/includes/prompt.html
+++ b/etna/feedback/templates/feedback/includes/prompt.html
@@ -13,7 +13,7 @@
 
                     {{ form.as_div }}
 
-                    <button class="tna-button--dark feedback__form__submit" type="submit">
+                    <button class="tna-button--dark feedback__form__submit" type="submit" id="feedbackSubmit" disabled>
                         {% trans "Submit feedback" %}
                     </button>
                 </form>
@@ -68,4 +68,18 @@ form.onsubmit = function () {
     });
 
 };
+
+// Enhancement for radio button / submit functionality
+
+let btns = document.querySelectorAll('[id^="id_response"]');
+
+for (i of btns) {
+    i.addEventListener('click', function() {
+        document.querySelector('#feedbackSubmit').disabled = false;
+        document.querySelector('#feedbackSubmit').style.opacity = "1";
+
+    });
+}
+
+
 </script>

--- a/sass/includes/_feedback.scss
+++ b/sass/includes/_feedback.scss
@@ -43,3 +43,8 @@
     }
   }
 }
+
+#feedbackSubmit:disabled {
+    opacity: 0.1;
+    pointer-events: none;
+}


### PR DESCRIPTION

Ticket URL: https://national-archives.atlassian.net/browse/DF-717

## About these changes

JS enhancements, the submit button is not available until a sentiment is chosen. Comments are optional

## How to check these changes

Test the feedback mechanism to check for expected behaviour.


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
