### PR TITLE
DF-699:Add archive link to record detail hierarchy

### DIFF
--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -315,6 +315,11 @@ class Record(DataLayerMixin, APIModel):
         return self.get("repository.summary.title", default="")
 
     @cached_property
+    def repository(self) -> Union["Record", None]:
+        if repository := self.get("repository", default=None):
+            return Record(repository)
+
+    @cached_property
     def repo_archon_value(self) -> str:
         for item in self.get("repository.identifier", ()):
             if item["type"] == "Archon number":

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -19,7 +19,8 @@ def record_url(record: Record, is_editorial: bool = False) -> str:
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return f"https://discovery.nationalarchives.gov.uk/details/r/{record.iaid}"
-    return record.url
+
+    return record.url if record is not None else ""
 
 
 @register.simple_tag

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -20,7 +20,7 @@ def record_url(
     returning more than one record
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
-        return f"https://discovery.nationalarchives.gov.uk/details/r/{record.iaid}"
+        return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
     if order_from_discovery:
         if record.custom_record_type == "ARCHON":

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -382,6 +382,10 @@ class RecordModelTests(SimpleTestCase):
             ),
         )
 
+    def test_repository_attr(self):
+        self.assertEqual(self.record.repository.iaid, "A13530124")
+        self.assertEqual(self.record.repository.url, "/catalogue/id/A13530124/")
+
 
 @override_settings(KONG_CLIENT_BASE_URL="https://kong.test")
 class UnexpectedParsingIssueTest(SimpleTestCase):

--- a/etna/records/tests/test_templatetags.py
+++ b/etna/records/tests/test_templatetags.py
@@ -7,13 +7,18 @@ from etna.records.templatetags.records_tags import record_url
 class TestRecordURLTag(SimpleTestCase):
     record_instance = Record(
         raw_data={
+            "repository": {
+                "@admin": {
+                    "id": "A13531109",
+                }
+            },
             "@template": {
                 "details": {
                     "iaid": "e7e92a0b-3666-4fd6-9dac-9d9530b0888c",
                     "referenceNumber": "2515/300/1",
                     "summaryTitle": "Test",
                 }
-            }
+            },
         }
     )
 
@@ -100,3 +105,12 @@ class TestRecordURLTag(SimpleTestCase):
                 self.assertEqual(
                     record_url(source, is_editorial=False), expected_result
                 )
+
+    def test_repository_links(self):
+        for attribute_name, expected_result in (
+            ("record_instance", "/catalogue/id/A13531109/"),
+            ("record_instance_no_reference", ""),
+        ):
+            with self.subTest(attribute_name):
+                source = getattr(self, attribute_name)
+                self.assertEqual(record_url(source.repository), expected_result)

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -22,7 +22,7 @@
                     {% if record.hierarchy|length <= 2 %}
                         <li class="hierarchy-short-panel__list-item">
                             <span class="hierarchy-short-panel__level">
-                                <a href="#" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
+                                <a href="{% record_url record.repository %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
                             </span>({{ record.template.heldBy }})
                         </li>
                     {% endif %}
@@ -60,7 +60,7 @@
                 {% else %}
                     <li class="hierarchy-short-panel__list-item">
                         <span class="hierarchy-short-panel__level">
-                            <a href="#">Archive</a>
+                            <a href="{% record_url record.repository %}">Archive</a>
                         </span>({{ record.template.heldBy }})
                     </li>
                     <li class="hierarchy-short-panel__list-item hierarchy--short-panel__list-item--current">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-699

## About these changes

Added Archive link for the record details page

## How to check these changes

- Open a record details page http://127.0.0.1:8000/catalogue/id/C11184/
- Click on the "Archive" link in records details page Hierarchy 
- The Archive details page http://127.0.0.1:8000/catalogue/id/A13530124/ should show

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
