### PR TITLE
DF-698: Convert template filters to tags and simplify hidden input rendering

### DIFF
--- a/etna/core/fields.py
+++ b/etna/core/fields.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from .validators import PositiveIntegerStringValidator
-from .widgets import DateInputWidget
+from .widgets import DateInputWidget, HiddenDateInputWidget
 
 END_OF_MONTH = "END_OF_MONTH"
 ERR_MSG_REAL_DATE = "Entered date must be a real date, for example 23 9 2017."
@@ -26,6 +26,7 @@ class DateInputField(forms.MultiValueField):
     """
 
     widget = DateInputWidget
+    hidden_widget = HiddenDateInputWidget
 
     def __init__(
         self,

--- a/etna/core/widgets.py
+++ b/etna/core/widgets.py
@@ -77,3 +77,36 @@ class DateInputWidget(forms.MultiWidget):
         if value:
             return value.day, value.month, value.year
         return None, None, None
+
+
+class HiddenDateInputWidget(forms.widgets.MultiWidget):
+    """
+    Allows DateField's to be rendered as a series of hidden inputs in a form,
+    with the separate hidden input for each component of the date value.
+    """
+
+    def __init__(
+        self,
+        attrs=None,
+    ):
+        widgets = (
+            forms.HiddenInput(attrs=attrs),
+            forms.HiddenInput(attrs=attrs),
+            forms.HiddenInput(attrs=attrs),
+        )
+        super().__init__(widgets, attrs)
+
+    def decompress(self, value):
+        """
+        Convert a ``date`` into values for the day, month and year so it can be
+        displayed in the widget's fields.
+
+        Args:
+            value (date): the date to be displayed
+
+        Returns:
+            a 3-tuple containing the day, month and year components of the date.
+        """
+        if value:
+            return [value.day, value.month, value.year]
+        return [None, None, None]

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -2,7 +2,6 @@ import json as json_module
 import unittest
 
 from typing import Any, Dict
-from unittest.mock import patch
 
 from django.conf import settings
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -515,103 +514,6 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
                 "<li>This date must be earlier than or equal to the &#x27;to&#x27; date.</li>",
                 content,
             )
-
-    @patch("etna.search.templatetags.search_tags.get_random_string")
-    @responses.activate
-    def test_render_html_for_escape_search_values(self, mock_get_random_string):
-        """tests html rendered for input values containing special chars ex double-quote for search term and search within results params"""
-
-        search_results_hero_suffix_ids = [
-            "fk1",
-            "pp1",
-            "so1",
-            "d01",
-            "g01",
-        ]
-        search_results_hero_hidden_html = '<input type="hidden" name="filter_keyword" value="&quot;kew&quot;" id="id_filter_keyword_fk1">  <input type="hidden" name="per_page" value="20" id="id_per_page_pp1">  <input type="hidden" name="sort_order" value="asc" id="id_sort_order_so1">  <input type="hidden" name="display" value="list" id="id_display_d01">  <input type="hidden" name="group" value="tna" id="id_group_g01">'
-
-        search_sort_and_view_options_suffix_ids = [
-            "q01",
-            "fk2",
-            "pp2",
-            "so2",
-            "d02",
-            "g02",
-        ]
-        search_sort_and_view_options_hidden_html = '<input type="hidden" name="q" value="&quot;wo 409&quot;" id="id_q_q01">  <input type="hidden" name="filter_keyword" value="&quot;kew&quot;" id="id_filter_keyword_fk2">  <input type="hidden" name="per_page" value="20" id="id_per_page_pp2">  <input type="hidden" name="sort_order" value="asc" id="id_sort_order_so2">  <input type="hidden" name="display" value="list" id="id_display_d02">  <input type="hidden" name="group" value="tna" id="id_group_g02">'
-
-        search_filters_1_suffix_ids = ["q02", "fk3", "pp3", "so3", "d03", "g03"]
-        search_filters_1_hidden_html = '<input type="hidden" name="q" value="&quot;wo 409&quot;" id="id_q_q02">  <input type="hidden" name="filter_keyword" value="&quot;kew&quot;" id="id_filter_keyword_fk3">  <input type="hidden" name="per_page" value="20" id="id_per_page_pp3">  <input type="hidden" name="sort_order" value="asc" id="id_sort_order_so3">  <input type="hidden" name="display" value="list" id="id_display_d03">  <input type="hidden" name="group" value="tna" id="id_group_g03">'
-
-        search_filters_2_suffix_ids = ["q03", "pp4", "so4", "d04", "g04"]
-        search_filters_2_hidden_html = '<input type="hidden" name="q" value="&quot;wo 409&quot;" id="id_q_q03">  <input type="hidden" name="per_page" value="20" id="id_per_page_pp4">  <input type="hidden" name="sort_order" value="asc" id="id_sort_order_so4">  <input type="hidden" name="display" value="list" id="id_display_d04">  <input type="hidden" name="group" value="tna" id="id_group_g04">'
-
-        # Note: side_effect assignment is in the order of the suffix ids that appears rendered in the html
-        mock_get_random_string.side_effect = (
-            search_results_hero_suffix_ids
-            + search_sort_and_view_options_suffix_ids
-            + search_filters_1_suffix_ids
-            + search_filters_2_suffix_ids
-        )
-
-        search_results_hero_text_html = '<input type="text" name="q" value="&quot;wo 409&quot;" class="search-results-hero__form-search-box" id="id_q"'
-        catalogue_search_bucket_hidden_html = (
-            '<input type="hidden" name="q" value="&quot;wo 409&quot;" id="id_q"'
-        )
-
-        responses.add(
-            responses.GET,
-            "https://kong.test/data/search",
-            json=create_search_response(
-                aggregations={"group": {"buckets": [{"key": "tna", "doc_count": 101}]}}
-            ),
-            status=200,
-        )
-        response = self.client.get(
-            self.test_url,
-            data={
-                "group": "tna",
-                "q": '"wo 409"',
-                "filter_keyword": '"kew"',
-            },
-        )
-
-        self.assertContains(
-            response,
-            search_results_hero_text_html,
-            count=1,
-            status_code=200,
-        )
-        self.assertContains(
-            response,
-            search_results_hero_hidden_html,
-            count=1,
-            status_code=200,
-        )
-        self.assertContains(
-            response,
-            search_sort_and_view_options_hidden_html,
-            count=1,
-            status_code=200,
-        )
-        self.assertContains(
-            response,
-            search_filters_1_hidden_html,
-            count=1,
-            status_code=200,
-        )
-        self.assertContains(
-            response,
-            search_filters_2_hidden_html,
-            count=1,
-            status_code=200,
-        )
-        self.assertContains(
-            response,
-            catalogue_search_bucket_hidden_html,
-            count=1,
-            status_code=200,
-        )
 
 
 class WebsiteSearchEndToEndTest(EndToEndSearchTestCase):

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -8,7 +8,8 @@
         {{ form.sort_by.errors }}
         {{ form.sort_by }}
 
-        {{ 'sort_by'|include_hidden_fields:form }}
+        {# render hidden inputs for fields controlled by other forms #}
+        {% render_fields_as_hidden form exclude='sort_by' %}
 
         <input type="submit" value="Update" class="search-sort-view__form-submit">
     </form>
@@ -113,7 +114,8 @@
             {% endif %}
         </div>
 
-        {{ 'filter_keyword collection topic level closure opening_start_date opening_end_date catalogue_source held_by type country location'|include_hidden_fields:form }}
+        {# render hidden inputs for fields controlled by other forms #}
+        {% render_fields_as_hidden form include='q group sort_by sort_order' %}
 
     </form>
     {% comment %} {% include './search_export_and_share.html' %} {% endcomment %}

--- a/templates/search/blocks/search_results_hero.html
+++ b/templates/search/blocks/search_results_hero.html
@@ -3,13 +3,12 @@
 <div class="search-results-hero">
     <h1 class="search-results-hero__heading">{{search_tab|search_title}}</h1>
     <form method="GET" class="search-results-hero__form" data-id="search-form" id="catalogue-search-form">
-        {{ form.q.errors }}
+
         <label for="{{form.q.id_for_label}}" class="sr-only">Search term</label>
+        {{ form.q.errors }}
         {{ form.q }}
-        
-        {% if search_tab == searchtabs.CATALOGUE.value or search_tab == searchtabs.WEBSITE.value %}
-            {{ 'q'|include_hidden_fields:form }}
-        {% endif %}
+
+        {% render_fields_as_hidden form exclude='q' %}
 
         <input type="submit" value="Search" class="search-results-hero__form-submit">
     </form>

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -7,11 +7,11 @@
         <h2 class="search-sort-view__heading">
            <label for="{{form.sort_by.id_for_label}}">Sort by</label>
         </h2>
-        
+
         {{ form.sort_by.errors }}
         {{ form.sort_by }}
 
-        {{ 'sort_by'|include_hidden_fields:form }}
+        {% render_fields_as_hidden form exclude='sort_by' %}
 
         <input type="submit" value="Update" class="search-sort-view__form-submit">
     </form>
@@ -50,4 +50,3 @@
     {{ form.display.errors }}
     {{ form.display.as_hidden }}
 </div>
-

--- a/templates/search/includes/filter.html
+++ b/templates/search/includes/filter.html
@@ -16,8 +16,6 @@
             <input type="submit" value="Update" class="search-filters__submit">
         </fieldset>
     </div>
-{% elif field.data and not field.errors %}
-    {% for value in field.data %}
-        <input type="hidden" name="{{ field.name }}" value="{{ value }}">
-    {% endfor %}
+{% else %}
+    {{ field.as_hidden }}
 {% endif %}

--- a/templates/search/long_filter_options.html
+++ b/templates/search/long_filter_options.html
@@ -11,7 +11,7 @@
     <div class="long-filters">
         <h1 class="long-filters__heading">Select filters to apply to your results</h1>
         <form method="get" action="{% url url_name %}" data-id="long-filter-form" id="analytics-long-filter-form" data-long-filters>
-            
+
             <div class="long-filters__options">
                 <input type="submit" value="Apply filters" class="search-filters__submit">
                 <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>
@@ -28,7 +28,7 @@
                 </fieldset>
             </div>
 
-            {{ field_name|include_hidden_fields:form }}
+            {% render_fields_as_hidden form exclude=field_name %}
 
             <div class="long-filters__submit-section">
                 <input type="submit" value="Apply filters" class="search-filters__submit">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-698

## About these changes

Follow up to #1041 to address some issues that occur when filtering by covering date, which happened due to the 'to' and 'from' date fields not being excluded from the hidden fields at the bottom of the form.

I realised the previous template tag code was a little ropey while reviewing #991, so have also refactored that to make better use of built-in Django stuff. I've also gone and added an 'include' option for the `search_filters.html` template to use so that we don't have to remember to add more field name strings there every time we add new filters.

## How to check these changes

1. With this branch active, head to [this URL](http://127.0.0.1:8000/search/catalogue/?filter_keyword=kew&covering_date_from_0=&covering_date_from_1=&covering_date_from_2=&covering_date_to_0=01&covering_date_to_1=01&covering_date_to_2=2000&collection=ADM&collection=AIR&level=Item&closure=Open+Document%2C+Open+Description&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=london&sort_by=&sort_order=asc&group=tna)
2. In the filter options on the form, clear the values for the 'Covering date (to)' field, then submit the form again
3. When the page reloads, the 'Covering date (to)' field inputs will be blank as expected (before these changes, they would retain their previous values)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
