### PR TITLE
[UN-721] Change to background shading on 'Blogs and Podcasts' media component

### DIFF
--- a/sass/includes/_promoted-pages.scss
+++ b/sass/includes/_promoted-pages.scss
@@ -1,5 +1,7 @@
 .promoted-pages {
-    background-color: $color__cream;
+    &--bg {
+        background-color: $color__cream;
+    }
 
     &__image {
         width: 100%;

--- a/templates/articles/blocks/promoted_pages.html
+++ b/templates/articles/blocks/promoted_pages.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags wagtailimages_tags i18n %}
-<section class="promoted-pages body-container body-container--short">
+<section class="promoted-pages body-container body-container--short{% if bg %} promoted-pages--bg{% endif %}">
     <div class="container">
         <h2 class="promoted-pages__heading">{% trans value.heading %}</h2>
         <ul class="card-grid card-grid__trio card-grid--list promoted-pages__cards"

--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -15,7 +15,12 @@
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     {% if page.promoted_links %}
-        {% include_block page.promoted_links %}
+        {% comment %} Checks if featured article exists then adds a bg to define the separate sections {% endcomment %}
+        {% if page.featured_article %}
+            {% include_block page.promoted_links with bg=True %}
+        {% else %}
+            {% include_block page.promoted_links with bg=False %}
+        {% endif %}
     {% endif %}
     {% if page.primary_topic or page.time_period %}
         {% include "includes/related_topic_timeline_cards.html" with topic=page.primary_topic time_period=page.primary_time_period %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-721

## About these changes

Adds an if statement to check if `featured_article` has been added to the page - if it has, add a cream bg to the 'blogs and podcasts' section - if not, don't add bg. 

## How to check these changes

Check a local record revealed page (e.g. /explore-the-collection/list-of-suffragettes-arrested-from-1906-1914/), add/remove featured article and blogs/podcasts components and make sure the cream bg is added or removed as appropriate. 

With featured article:

![etna-record-revealed-blogs-podcasts-bg](https://github.com/nationalarchives/ds-wagtail/assets/8680557/29f37f6a-529f-4e4d-a3ea-3233b880b6df)

Without featured article:

![etna-record-revealed-blogs-podcasts-no-bg](https://github.com/nationalarchives/ds-wagtail/assets/8680557/3620eb24-39e1-473c-bfcf-ba457028bdc2)


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
