### PR TITLE
[a11y] Add aria-labelledby for secondary card links

### DIFF
--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -16,8 +16,8 @@
             data-card-title="{{ link_page.title }}"
             {% if link_page.is_newly_published %}
                 data-label="New"
-            {%endif%}
-            aria-describedby="article-desc{{ page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
+            {% endif %}
+            aria-labelledby="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
             {% if forloop.counter %}
                 data-card-position="{{ forloop.counter0 }}"
             {% endif %}
@@ -41,13 +41,12 @@
                     href="{{ link_page.url }}"
                     class="card-group-secondary-nav__title-link"
                     data-card-type="card-group-secondary-nav"
-                    aria-describedby="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
                     data-component-name="{{ card_type }} card: {% if heading %}{{ heading }}{% else %}{{ page.title }}{% endif %}"
                     data-link-type="Card text"
                     data-card-title="{{ link_page.title }}"
                     {% if link_page.is_newly_published %}
                     data-label="New"
-                    {%endif%}
+                    {% endif %}
                     {% if forloop.counter %}
                         data-card-position="{{ forloop.counter0 }}"
                     {% endif %}
@@ -56,7 +55,9 @@
                 <span>NEW</span>
                 {% endif %}
             </h3>
-            <p id ="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">This is a link to a story about {{ link_page.title }}</p>
+            <p id="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" class="aria-desc-card">
+                Read about {{ link_page.title }}
+            </p>
             <p class="card-group-secondary-nav__paragraph">{{ link_page.teaser_text }}</p>
         </div>
     </div>


### PR DESCRIPTION
Ticket URL: n/a

## About these changes

Fix for secondary cards (e.g. /explore-the-collection/) to resolve issue of links without labels - specifically the images for each card.

## How to check these changes

- Check that aria-labelledby is returning the correct label
- Run an automated accessibility check on a page with secondary cards and make sure no errors are reported for links missing labels

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
