### PR TITLE
[a11y] Remove <ul> for collection explorer landing page

### DIFF
--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -8,11 +8,11 @@
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
     <div id="analytics-explorer-index" data-container-name="explorer-index">
-        <ul class="card-group--no-flex u-margin-m">
+        <div class="card-group--no-flex u-margin-m">
             {% for block in page.body %}
                 {% include_block block %}
             {% endfor %}
-        </ul>
+        </div>
     </div>
     
     <div class="container">


### PR DESCRIPTION
Ticket URL: n/a

## About these changes

This was raised in the accessibility audit. This fix removes the `<ul>` which is not needed in this context - there are no child `<li>` elements inside the` <ul>` so it isn't adding any value here and is causing some validation issues.

## How to check these changes

Review Collection Explorer and see that the <ul> has been removed and replaced with a <div> to fix the validation issue.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
