### PR TITLE
[a11y] Add missing </h2> tag on Collection Explorer landing page

### DIFF
--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -16,7 +16,7 @@
     </div>
     
     <div class="container">
-        <h2>{{ page.articles_title }}</h3>
+        <h2>{{ page.articles_title }}</h2>
 
         <p>{{ page.articles_introduction }}</p>
     </div>


### PR DESCRIPTION
Ticket URL: n/a

## About these changes

Fixes a validation issue for the `<h2>` heading as it had the wrong `</h3>` closing tag.

## How to check these changes

Open Collection Explorer landing page locally and see that the `<h2>` has the correct closing tag.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
