### PR TITLE
DF-737: Update error message for invalid dates

### DIFF
--- a/etna/core/fields.py
+++ b/etna/core/fields.py
@@ -9,7 +9,7 @@ from .validators import PositiveIntegerStringValidator
 from .widgets import DateInputWidget, HiddenDateInputWidget
 
 END_OF_MONTH = "END_OF_MONTH"
-ERR_MSG_REAL_DATE = "Entered date must be a real date, for example 23 9 2017."
+ERR_MSG_REAL_DATE = "Date must be in DD MM YYYY format, for example 31 12 1990."
 
 
 class DateInputField(forms.MultiValueField):


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-737

## About these changes

Update error message for invalid date range - when from date is after to date

## How to check these changes

[Link ](http://127.0.0.1:8000/search/catalogue/?filter_keyword=kew&covering_date_from_0=&covering_date_from_1=df&covering_date_from_2=&covering_date_to_0=&covering_date_to_1=&covering_date_to_2=sad&collection=ADM&collection=AIR&level=Item&closure=Open+Document%2C+Open+Description&opening_start_date_0=aa&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=ccc&q=london&sort_by=title&sort_order=asc&group=tna)to view updated message

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
