### PR TITLE
[UN-714] Fix position of 'new' label for secondary card links and adjust padding

### DIFF
--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -75,10 +75,10 @@
 
       span {
         background: green;
-        display: inline;
+        display: inline-block;
         font-size: 0.8rem;
         color: white;
-        padding: 3px 3px 0px 3px;
+        padding: 2px 3px 0px 3px;
         margin-left: 1px;
         vertical-align: middle;
       }

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -46,10 +46,8 @@
       font-family: $font__body;
       font-weight: $font-weight-bold;
       font-size: 1.125rem;
-      display: inline-block;
+      display: inline;
       color: $color__black;
-      margin-top: 0.3rem;
-      margin-bottom: 0.5rem;
       text-decoration-thickness: 1px;
 
       @media only screen and (min-width: $screen__md) {
@@ -71,14 +69,18 @@
     }
 
     &__heading {
-      display: inline;
+      display: block;
+      margin-top: 0.3rem;
+      margin-bottom: 0.5rem;
 
       span {
         background: green;
+        display: inline;
         font-size: 0.8rem;
         color: white;
         padding: 3px 3px 0px 3px;
         margin-left: 1px;
+        vertical-align: middle;
       }
     }
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-714

## About these changes

Adjusts the green 'new' label assigned to new stories/records in the secondary cards - makes sure the label doesn't drop below the title when the title is longer than 1 line.

## How to check these changes

Review /explore-the-collection/ locally, check a secondary card with a long title and see that the 'new' label stays on the same line as the title and doesn't drop to a new line. 

Before: 
![image](https://github.com/nationalarchives/ds-wagtail/assets/8680557/a845ebd5-9bef-4351-9966-59588a93a228)

After:
![image](https://github.com/nationalarchives/ds-wagtail/assets/8680557/a661fba9-141c-4089-926c-48ebc1ec71f9)


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
