### PR TITLE
CHORE: Remove birdbath from INSTALLED_APPS when testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,10 @@ jobs:
         run: poetry run coverage run manage.py test etna
       - name: Prepare coverage report
         run: poetry run coverage xml
+      - name: Run Django migrations
+        run: poetry run python manage.py migrate --noinput
+      - name: Check for missing migrations
+        run: poetry run python manage.py makemigrations --check --noinput
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -81,8 +85,6 @@ jobs:
           env_vars: OS,PYTHON_VERSION
           fail_ci_if_error: true
           move_coverage_to_trash: true
-      - name: Check for missing migrations
-        run: poetry run python manage.py makemigrations --check --noinput
 
   test-javascript:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,6 @@ jobs:
         run: poetry run coverage run manage.py test etna
       - name: Prepare coverage report
         run: poetry run coverage xml
-      - name: Run Django migrations
-        run: poetry run python manage.py migrate --noinput
       - name: Check for missing migrations
         run: poetry run python manage.py makemigrations --check --noinput
       - name: Upload coverage report to Codecov

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -17,7 +17,9 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",
 ]
 
-BIRDBATH_REQUIRED = False
+# Disable birdbath completely when testing
+INSTALLED_APPS = INSTALLED_APPS.copy()  # noqa: F405
+INSTALLED_APPS.remove("birdbath")
 
 # Allow integration tests to run without needing to collectstatic
 # See https://docs.djangoproject.com/en/3.1/ref/contrib/staticfiles/#staticfilesstorage


### PR DESCRIPTION
Birdbath has been raising warnings in test output and occasionally causing CI to fail, as is the case on https://github.com/nationalarchives/ds-wagtail/pull/1082. 

This PR uninstalls the app completely when testing, so that it can't cause any issues.