### PR TITLE
DF-726: Allow no-js users to add comments to feedback (BE)

### DIFF
--- a/docs/features/feedback-mechanism.md
+++ b/docs/features/feedback-mechanism.md
@@ -18,11 +18,11 @@ Feedback prompts are found and displayed on pages using the `etna.feedback.templ
 2. Use the prompt to generate a Django form (of type `etna.feedback.forms.FeedbackForm`) with the correct labels/options in place, and some initial field values set.
 3. Render the form to a template, so that users can interact with it.
 
-A separate 'comment' form is also included in the template, but cannot be interacted with by default.
+The HTML for separate 'comment' form is also included in the template, but requires updating (via JS) before it can be used.
 
 ## How feedback responses are collected
 
-When a user completes and submits a feedback form, the submission is posted to `FeedbackSubmitView`. The purpose of the view is to:
+When a user submits a feedback form, the submission is posted to `FeedbackSubmitView`. The purpose of the view is to:
 
 1. Using data from the submit URL (`prompt_id` and `prompt_revision`), find the relevant `FeedbackPrompt` instance for the request, and ensure we are using the same revision that was used to generate the form that the user submitted.
 2. Use the prompt to generate a Django form (exactly like the `render_feedback_prompt` tag does).
@@ -33,10 +33,9 @@ Then, if the submission was **valid**:
 4. Save a `FeedbackSubmission` instance to the database to represent it.
 5. Redirect to the `FeedbackSuccessView` or, if the request was submitted via AJAX, render a `JSONResponse` with some useful values in the response.
 
-Or, if the submission was **invalid**:
+Or, if the submission was **invalid** for some reason:
 
-4. Log an error with the form validation error details included in the body (which should by logged in Sentry).
-5. Fake a successful response using a randomly generated `uuid` value in place of `public_id`.
+Render a `JSONResponse` with a 400 (Bad Request) status code, including the validation error details from the form.
 
 ### What validation takes place?
 
@@ -47,21 +46,11 @@ For a thorough understanding of the validation that is applied to submissions, y
 3. That the `response` field value matches the `id` of one of the options defined on the `FeedbackPrompt`
 4. That the `page_id` and `page_revision` values match up to an existing revision for an existing page.
 
-### Do we store any personal data?
-
-If the user is signed in, we store the ID of the current Django user with the submission, which can be used to put a name to it. However, most feedback is submitted by unauthenticated users; In which case, only details about the submission itself are stored (the url they were on, the answers they gave, and when it was received). We do not save IP addresses or any other identifiable information.
-
-### Versioning of prompts
-
-Because feedback prompts are converted to forms and shown on most pages, having a single version of that `FeedbackPrompt` instance is tricky, because it's quite possible for changes to be saved to the database between the time the form is rendered and when it is proccessed.
-
-This is why the `FeedbackPrompt` model is revisible (has drafts and revisions in Wagtail). With the `prompt_id` and `prompt_revision` both included in submission URLs, we can recreate the `FeedbackPrompt` exactly as it was when the form was rendered to the user, and from that, can recreate a `FeedbackForm` instance that can be used for validation.
-
-## How comments are collected
+## How comments are collected (JS-enabled)
 
 After submitting their initial feedback response, most users (those with Javascript enabled) will be presented with a second form to allow them to post a comment.
 
-The comment form is initially hidden from all users, then modified and shown depending on the `JsonResponse` received from  `FeedbackSubmitView`. The response data is used in the following ways:
+The comment form that appears in prompts is hidden from all users initially, then modified and shown depending on the `JsonResponse` received from  `FeedbackSubmitView`. The response data is used in the following ways:
 
     `comment_prompt_text`:
         Used to populate the `label` text for the `comment` field. If the value is blank or missing, it is assumed that comments are not desired for the selected response option, and only the success message is displayed.
@@ -70,19 +59,35 @@ The comment form is initially hidden from all users, then modified and shown dep
     `signature`:
         Used to populate a hidden `signature` input value.
 
-The form is posted via Javascript to a view that validates the following things:
+## How comments are collected (no-JS)
 
-1. That `submission` and `signature` values are present
-2. That `submission` matches the ID of a `FeedbackSubmission` instance that doesn't yet have a comment stored for it
-3. That `signature` matches the supplied `submission` value
+After submitting their initial feedback response, no-JS users will be taken to a thank you page, where a second form allows them to add a supporting comment to their feedback.
 
-### How 'signature' validation works
+Unlike the comment form included in prompt output across the site, this version comes prepopulated with valid `submission` and `signature` values, allowing it to be posted without any further tinkering. While convenient for the user, it should this approach leaves these forms a little more open to abuse (by spammers), and so we are more dependant on infrastructure-level security measures here.
 
-Valid signatures are deterministic hashes, created from the `public_id` value from a `FeedbackSubmission` instance, and the `SECRET_KEY` value (which is unique to each environment).
+If the user chooses to submit the form, they are redirected to a new success page.
 
-The `FeedbackSubmitView` generates a signature value after succesfully saving the `FeedbackSumission` instance, and includes it in the `JsonResponse` to be picked up by JS and added to the comment form.
+## Comment validation and procesing
 
-Because the value is deterministic, the `FeedbackCommentForm` can regenerate the hash from the submitted `submission` value, then compare that to the submitted `signature` value. If the values match, the comment is considered 'safe' and added to the `FeedbackSumission` instance.
+Comment form data is posted to a view that validates the following things:
+
+1. That `submission` and `signature` values are present.
+2. That `submission` matches the ID of a `FeedbackSubmission` instance that doesn't yet have a comment stored for it.
+3. That `signature` matches the supplied `submission` value.
+
+'signatures' are deterministic hashes, created from the `public_id` value of a `FeedbackSubmission` instance, and the `SECRET_KEY` value set for the environment (which will always be kept private).
+
+Because the value is deterministic, the `FeedbackCommentForm` can regenerate the hash from the submitted `submission` value, then compare that to the value that was submitted. If the values match, the comment is considered 'safe' and added to the `FeedbackSumission` instance.
+
+### Versioning of prompts
+
+Because feedback prompts are converted to forms and shown on most pages, having a single version of that `FeedbackPrompt` instance is tricky, because it's quite possible for changes to be saved to the database between the time the form is rendered and when it is proccessed.
+
+This is why the `FeedbackPrompt` model is revisible (has drafts and revisions in Wagtail). With the `prompt_id` and `prompt_revision` both included in submission URLs, we can recreate the `FeedbackPrompt` exactly as it was when the form was rendered to the user, and from that, can recreate a `FeedbackForm` instance that can be used for validation.
+
+### Do we store any personal data?
+
+If the user is signed in, we store the ID of the current Django user with the submission, which can be used to put a name to it. However, most feedback is submitted by unauthenticated users; In which case, only details about the submission itself are stored (the url they were on, the answers they gave, and when it was received). We do not save IP addresses or any other identifiable information.
 
 ## Accessing and exporting submission data
 

--- a/etna/feedback/forms.py
+++ b/etna/feedback/forms.py
@@ -155,8 +155,13 @@ class FeedbackCommentForm(forms.Form):
         widget=forms.Textarea({"cols": 40, "rows": 5}),
     )
 
+    def __init__(self, *args, prompt_text: str | None = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if prompt_text:
+            self.fields["comment"].label = prompt_text
+
     def clean_comment(self) -> str:
-        # Strip HTML from comment submissions
+        # Strip HTML from all comment submissions
         value = self.cleaned_data.get("comment")
         if value is None:
             return ""

--- a/etna/feedback/templates/feedback/includes/prompt.html
+++ b/etna/feedback/templates/feedback/includes/prompt.html
@@ -17,7 +17,7 @@
                 <form
                     class="feedback__form feedback__form--comment"
                     id="feedback-comment-form"
-                    action="{% url 'feedback:submit_comment' %}"
+                    action="{% url 'feedback:comment_submit' prompt.public_id prompt.live_revision_id %}"
                     method="post"
                     data-feedback-form-comment
                 >
@@ -116,11 +116,16 @@ commentForm.onsubmit = function (e) {
     // Set a flag to avoid multiple posts
     comment_submitted = true;
 
+    // Gather data for posting
+    const body = new FormData(commentForm);
+    // Ensure the view responds with JSON
+    body.set("is_ajax", "true");
+
     fetch(
         commentForm.getAttribute("action"),
         {
             method: "post",
-            body: new FormData(commentForm),
+            body: body,
         }
     )
     .then((response) => response.json())

--- a/etna/feedback/templates/feedback/success.html
+++ b/etna/feedback/templates/feedback/success.html
@@ -7,25 +7,32 @@
 {% block breadcrumb %}{% endblock %}
 
 {% block content %}
-    <h1>{{ prompt.thank_you_heading }}</h1>
+<div class="container">
+    <div class="row">
+        <div class="col-12 text-center">
+            <h1>{{ prompt.thank_you_heading }}</h1>
 
-    {% if prompt.thank_you_message %}
-        {{ prompt.thank_you_message|richtext }}
-    {% endif %}
+            {% if prompt.thank_you_message %}
+                {{ prompt.thank_you_message|richtext }}
+            {% endif %}
 
-    {% if comment_form %}
-         <form
-            class="feedback__form"
-            id="feedback-comment-form"
-            action="{% url 'feedback:comment_submit' view.prompt_id view.version %}"
-            method="post"
-            data-feedback-form-comment
-        >
-            {{ comment_form.as_div }}
+            {% if comment_form %}
+                <form
+                    class="feedback__form feedback__form--success"
+                    id="feedback-comment-form"
+                    action="{% url 'feedback:comment_submit' view.prompt_id view.version %}"
+                    method="post"
+                    data-feedback-form-comment
+                >
+                    {{ comment_form.as_div }}
 
-            <button type="submit" class="feedback__form-submit tna-button--dark" data-feedback-form-submit>Submit</button>
-        </form>
-    {% endif %}
-
-    <p><a href="{{ next_url }}" class="tna-button--dark">{{ prompt.continue_link_text }}</a></p>
+                    <button type="submit" class="feedback__form-submit tna-button--dark tna-button--row-item" data-feedback-form-submit>Submit</button>
+                    <a href="{{ next_url }}" class="tna-button--dark tna-button--row-item">{{ prompt.continue_link_text }}</a>
+                </form>
+            {% else %}
+                <p><a href="{{ next_url }}" class="tna-button--dark">{{ prompt.continue_link_text }}</a></p>
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/etna/feedback/templates/feedback/success.html
+++ b/etna/feedback/templates/feedback/success.html
@@ -13,5 +13,19 @@
         {{ prompt.thank_you_message|richtext }}
     {% endif %}
 
+    {% if comment_form %}
+         <form
+            class="feedback__form"
+            id="feedback-comment-form"
+            action="{% url 'feedback:comment_submit' view.prompt_id view.version %}"
+            method="post"
+            data-feedback-form-comment
+        >
+            {{ comment_form.as_div }}
+
+            <button type="submit" class="feedback__form-submit tna-button--dark" data-feedback-form-submit>Submit</button>
+        </form>
+    {% endif %}
+
     <p><a href="{{ next_url }}" class="tna-button--dark">{{ prompt.continue_link_text }}</a></p>
 {% endblock %}

--- a/etna/feedback/tests/test_views.py
+++ b/etna/feedback/tests/test_views.py
@@ -381,7 +381,7 @@ class TestFeedbackSuccessView(TestCase):
         )
         self.assertContains(
             response,
-            f'<a href="{self.next_url}" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
+            f'<a href="{self.next_url}" class="tna-button--dark tna-button--row-item">{self.prompt.continue_link_text}</a>',
         )
 
     def test_comment_form_not_rendered_if_comment_already_detected(self):
@@ -430,7 +430,7 @@ class TestFeedbackSuccessView(TestCase):
         self.assertContains(response, self.prompt.thank_you_heading)
         self.assertContains(
             response,
-            f'<a href="/" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
+            f'<a href="/" class="tna-button--dark tna-button--row-item">{self.prompt.continue_link_text}</a>',
         )
 
 

--- a/etna/feedback/tests/test_views.py
+++ b/etna/feedback/tests/test_views.py
@@ -1,5 +1,3 @@
-import uuid
-
 from http import HTTPStatus
 
 from django.test import TestCase, override_settings
@@ -11,6 +9,7 @@ from wagtail.test.utils import WagtailTestUtils
 
 from etna.core.test_utils import prevent_request_warnings
 from etna.feedback.constants import SentimentChoices
+from etna.feedback.forms import FeedbackCommentForm
 from etna.feedback.models import FeedbackPrompt, FeedbackSubmission
 from etna.feedback.utils import sign_submission_id
 
@@ -198,7 +197,14 @@ class TestFeedbackCommentSubmitView(WagtailTestUtils, TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         super().setUpTestData()
-        cls.url = reverse("feedback:submit_comment")
+        cls.prompt = FeedbackPrompt.objects.get()
+        cls.url = reverse(
+            "feedback:comment_submit",
+            kwargs={
+                "prompt_id": cls.prompt.public_id,
+                "version": cls.prompt.live_revision_id,
+            },
+        )
         cls.prompt = FeedbackPrompt.objects.get()
 
         # Create a submission to comment on
@@ -217,10 +223,37 @@ class TestFeedbackCommentSubmitView(WagtailTestUtils, TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
 
-    def test_post_with_valid_data(self):
+    def test_post_valid_regular(self):
         response = self.client.post(
             self.url,
             data={
+                "comment": "This is a comment",
+                "submission": self.submission.public_id,
+                "signature": sign_submission_id(self.submission.public_id),
+            },
+        )
+
+        # Test view response
+        self.assertRedirects(
+            response,
+            reverse(
+                "feedback:comment_success",
+                kwargs={
+                    "prompt_id": self.prompt.public_id,
+                    "version": self.prompt.live_revision_id,
+                },
+            ),
+        )
+
+        # Test the comment was saved
+        self.submission.refresh_from_db()
+        self.assertEqual(self.submission.comment, "This is a comment")
+
+    def test_post_valid_ajax(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "is_ajax": "true",
                 "comment": "This is a comment",
                 "submission": self.submission.public_id,
                 "signature": sign_submission_id(self.submission.public_id),
@@ -313,19 +346,61 @@ class TestFeedbackSuccessView(TestCase):
             },
         )
         cls.next_url = "/some-path"
-        cls.valid_submission_id = uuid.uuid4()
+        cls.submission = FeedbackSubmission.objects.create(
+            site=Site.objects.first(),
+            full_url="",
+            path="",
+            prompt_text="prompt",
+            response_sentiment=SentimentChoices.POSITIVE,
+            response_label="Easy to use",
+            comment_prompt_text="Thank you! Can you tell us more about why you answered this way?",
+        )
+        cls.submission_with_comment = FeedbackSubmission.objects.create(
+            site=Site.objects.first(),
+            full_url="",
+            path="",
+            prompt_text="prompt",
+            response_sentiment=SentimentChoices.POSITIVE,
+            response_label="Easy to use",
+            comment_prompt_text="Thank you! Can you tell us more about why you answered this way?",
+            comment="I have a comment",
+        )
 
     def test_golden_path(self):
         response = self.client.get(
-            self.url, {"submission": self.valid_submission_id, "next": self.next_url}
+            self.url, {"submission": self.submission.public_id, "next": self.next_url}
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["prompt"], self.prompt)
         self.assertEqual(response.context["next_url"], self.next_url)
-        self.assertEqual(
-            response.context["submission_id"], str(self.valid_submission_id)
-        )
         self.assertContains(response, self.prompt.thank_you_heading)
+        self.assertIsInstance(response.context["comment_form"], FeedbackCommentForm)
+        self.assertContains(
+            response,
+            f'<label for="id_comment">{self.submission.comment_prompt_text}</label>',
+        )
+        self.assertContains(
+            response,
+            f'<a href="{self.next_url}" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
+        )
+
+    def test_comment_form_not_rendered_if_comment_already_detected(self):
+        response = self.client.get(
+            self.url,
+            {
+                "submission": self.submission_with_comment.public_id,
+                "next": self.next_url,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["prompt"], self.prompt)
+        self.assertEqual(response.context["next_url"], self.next_url)
+        self.assertContains(response, self.prompt.thank_you_heading)
+        self.assertIsNone(response.context["comment_form"])
+        self.assertNotContains(
+            response,
+            self.submission.comment_prompt_text,
+        )
         self.assertContains(
             response,
             f'<a href="{self.next_url}" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
@@ -340,21 +415,60 @@ class TestFeedbackSuccessView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["prompt"], self.prompt)
         self.assertEqual(response.context["next_url"], self.next_url)
-        self.assertIsNone(response.context["submission_id"])
+        self.assertContains(response, self.prompt.thank_you_heading)
+        self.assertIsNone(response.context["comment_form"])
+        self.assertContains(
+            response,
+            f'<a href="{self.next_url}" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
+        )
+
+    def test_missing_next_url_substituted_with_homepage_path(self):
+        response = self.client.get(self.url, {"submission": self.submission.public_id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["prompt"], self.prompt)
+        self.assertEqual(response.context["next_url"], "/")
+        self.assertContains(response, self.prompt.thank_you_heading)
+        self.assertContains(
+            response,
+            f'<a href="/" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
+        )
+
+
+class TestFeedbackCommentSuccessView(TestCase):
+    """
+    Integration tests for `etna.feedback.views.FeedbackCommentSuccessView`,
+    utilising Django's full request/response cycle, including URL resolution.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.prompt = FeedbackPrompt.objects.get()
+        cls.url = reverse(
+            "feedback:comment_success",
+            kwargs={
+                "prompt_id": cls.prompt.public_id,
+                "version": cls.prompt.live_revision_id,
+            },
+        )
+        cls.next_url = "/some-path"
+
+    def test_golden_path(self):
+        response = self.client.get(self.url, {"next": self.next_url})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["prompt"], self.prompt)
+        self.assertEqual(response.context["next_url"], self.next_url)
         self.assertContains(response, self.prompt.thank_you_heading)
         self.assertContains(
             response,
             f'<a href="{self.next_url}" class="tna-button--dark">{self.prompt.continue_link_text}</a>',
         )
 
-    def test_missing_next_url_substituded_with_homepage_path(self):
-        response = self.client.get(self.url, {"submission": self.valid_submission_id})
+    def test_missing_next_url_substituted_with_homepage_path(self):
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["prompt"], self.prompt)
         self.assertEqual(response.context["next_url"], "/")
-        self.assertEqual(
-            response.context["submission_id"], str(self.valid_submission_id)
-        )
         self.assertContains(response, self.prompt.thank_you_heading)
         self.assertContains(
             response,

--- a/etna/feedback/urls.py
+++ b/etna/feedback/urls.py
@@ -10,13 +10,18 @@ urlpatterns = [
         name="submit",
     ),
     path(
-        "submit/comment/",
-        views.FeedbackCommentSubmitView.as_view(),
-        name="submit_comment",
-    ),
-    path(
         "submit/<uuid:prompt_id>/<int:version>/success/",
         views.FeedbackSuccessView.as_view(),
         name="success",
+    ),
+    path(
+        "submit-comment/<uuid:prompt_id>/<int:version>/",
+        views.FeedbackCommentSubmitView.as_view(),
+        name="comment_submit",
+    ),
+    path(
+        "submit-comment/<uuid:prompt_id>/<int:version>/success/",
+        views.FeedbackCommentSuccessView.as_view(),
+        name="comment_success",
     ),
 ]

--- a/sass/includes/_buttons.scss
+++ b/sass/includes/_buttons.scss
@@ -72,6 +72,12 @@
     outline-offset: 0.125rem;
   }
 }
+
+.tna-button--row-item {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
 .response-btn {
   margin-right: 1em;
 }

--- a/sass/includes/_feedback.scss
+++ b/sass/includes/_feedback.scss
@@ -16,6 +16,11 @@
         &--comment {
             display: none;
         }
+
+        &--success {
+            border: none;
+            padding: 1rem 0 2rem 0;
+        }
     }
 
     &__response-button {


### PR DESCRIPTION
Ticket URL:  https://national-archives.atlassian.net/browse/DF-726

## About these changes

We want users to be able to add a supporting comment to their feedback  even when Javascript is disabled. The nicest way I can think to do this is by adding the comment form to the 'success' page that you are redirected to after giving feedback.

Tracking opportunities here are limited, so I feel the best I can do is redirect to a separate 'success' URL for after the comment is successfully processed from here.

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
