### PR TITLE
UN 748 breadcrumb cheveron displaying multiple times

### DIFF
--- a/sass/includes/_breadcrumb.scss
+++ b/sass/includes/_breadcrumb.scss
@@ -59,15 +59,24 @@ ul.breadcrumb li a:hover {
 
 //media query to truncate list on mobile : example : https://design-system.service.gov.uk/components/breadcrumbs/collapse-mobile/index.html
 @media (max-width: 768px) {
+  .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item,
   .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item {
     display: none;
+    + span {
+        display: none;
+    }
   }
+  
   .govuk-breadcrumbs--collapse-on-mobile
     .govuk-breadcrumbs__list-item:first-child,
   .govuk-breadcrumbs--collapse-on-mobile
     .govuk-breadcrumbs__list-item:last-child {
     display: inline-block;
-  }
+    
+    + span {
+        display: inline-block;
+    }
+  } 
 
   .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:before {
     top: 6px;

--- a/sass/includes/_breadcrumb.scss
+++ b/sass/includes/_breadcrumb.scss
@@ -66,6 +66,7 @@ ul.breadcrumb li a:hover {
   .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item,
   .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item {
     display: none;
+
     + span {
         display: none;
     }
@@ -76,15 +77,14 @@ ul.breadcrumb li a:hover {
   .govuk-breadcrumbs--collapse-on-mobile
     .govuk-breadcrumbs__list-item:last-child {
     display: inline-block;
+
+    + span {
+      display: inline-block;
+    }
   } 
 
   .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:before {
     top: 6px;
     margin: 0;
-  }
-  .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list {
-    display: -ms-flexbox;
-    display: -webkit-box;
-    display: flex;
   }
 }


### PR DESCRIPTION
Ticket URL: [UN 748](https://national-archives.atlassian.net/browse/UN-748)

## About these changes

Fixed the issue where additional chevrons were appearing on mobile in the breadcrumbs

## How to check these changes
Resize the viewport to mobile width
[Page to test](http://127.0.0.1:8000/explore-the-collection/explore-by-time-period/early-20th-century/edwardian-textile-designs/)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
