### PR TITLE
UN-735: RichText fields crashing on image and media edit views

### DIFF
--- a/etna/core/wagtail_hooks.py
+++ b/etna/core/wagtail_hooks.py
@@ -18,6 +18,10 @@ def editor_js():
         '<script src="{}"></script>', static("admin/js/inputLengthIndicators.js")
     )
 
+@hooks.register("insert_global_admin_js")
+def global_admin_js():
+    return "<script>window.chooserUrls = {'pageChooser': '/admin/choose-page/','externalLinkChooser': '/admin/choose-external-link/','emailLinkChooser': '/admin/choose-email-link/','phoneLinkChooser': '/admin/choose-phone-link/','anchorLinkChooser': '/admin/choose-anchor-link/',}; </script> <script src='/static/wagtailadmin/js/modal-workflow.js?v=4a9c2a53'></script>"
+
 
 @hooks.register("insert_global_admin_css")
 def global_admin_css():

--- a/etna/core/wagtail_hooks.py
+++ b/etna/core/wagtail_hooks.py
@@ -18,6 +18,7 @@ def editor_js():
         '<script src="{}"></script>', static("admin/js/inputLengthIndicators.js")
     )
 
+
 @hooks.register("insert_global_admin_js")
 def global_admin_js():
     return "<script>window.chooserUrls = {'pageChooser': '/admin/choose-page/','externalLinkChooser': '/admin/choose-external-link/','emailLinkChooser': '/admin/choose-email-link/','phoneLinkChooser': '/admin/choose-phone-link/','anchorLinkChooser': '/admin/choose-anchor-link/',}; </script> <script src='/static/wagtailadmin/js/modal-workflow.js?v=4a9c2a53'></script>"


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/UN-735

## About these changes

The RichText link tool wasn't functioning properly on image and media editing pages (e.g. http://localhost:8000/admin/media/edit/10/). This is a fix to enable those to work properly.

I inserted the extra JavaScript that the normal page edit view has, but was missing from the image and media views. This then enables those admin pages to use the RichText link editor without crashing.

## How to check these changes

Go to http://localhost:8000/admin/media/edit/10/ and try to add an in-text link to the description or transcript field.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
