### PR TITLE
UN-476: contentGroup1 naming for pages under Explore the collection

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -66,7 +66,7 @@ class ArticleIndexPage(BasePageWithIntro):
     )
 
     # DataLayerMixin overrides
-    gtm_content_group = "stories"
+    gtm_content_group = "Explore the collection"
 
     class Meta:
         verbose_name = _("article index page")
@@ -170,7 +170,7 @@ class ArticlePage(
     ]
 
     # DataLayerMixin overrides
-    gtm_content_group = "stories"
+    gtm_content_group = "Explore the collection"
 
     title_label = "THE STORY OF"
 
@@ -322,7 +322,7 @@ class FocusedArticlePage(
     ]
 
     # DataLayerMixin overrides
-    gtm_content_group = "focused articles"
+    gtm_content_group = "Explore the collection"
 
     title_label = "IN FOCUS"
 
@@ -452,7 +452,7 @@ class RecordArticlePage(
     )
 
     # DataLayerMixin overrides
-    gtm_content_group = "Record articles"
+    gtm_content_group = "Explore the collection"
 
     title_label = "RECORD REVEALED"
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -102,7 +102,7 @@ class ExplorerIndexPage(AlertMixin, BasePageWithIntro):
     ]
 
     # DataLayerMixin overrides
-    gtm_content_group = "Explorer"
+    gtm_content_group = "Explore the collection"
 
 
 class TopicExplorerIndexPage(RequiredHeroImageMixin, BasePageWithIntro):
@@ -122,7 +122,7 @@ class TopicExplorerIndexPage(RequiredHeroImageMixin, BasePageWithIntro):
     )
 
     # DataLayerMixin overrides
-    gtm_content_group = "Explorer"
+    gtm_content_group = "Explore the collection"
 
     @cached_property
     def featured_pages(self):
@@ -197,7 +197,7 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
     )
 
     # DataLayerMixin overrides
-    gtm_content_group = "Explorer"
+    gtm_content_group = "Explore the collection"
 
     parent_page_types = [
         "collections.TopicExplorerIndexPage",
@@ -307,7 +307,7 @@ class TimePeriodExplorerIndexPage(RequiredHeroImageMixin, BasePageWithIntro):
     )
 
     # DataLayerMixin overrides
-    gtm_content_group = "Explorer"
+    gtm_content_group = "Explore the collection"
 
     @cached_property
     def featured_pages(self):
@@ -374,7 +374,7 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
     settings_panels = BasePage.settings_panels + AlertMixin.settings_panels
 
     # DataLayerMixin overrides
-    gtm_content_group = "Explorer"
+    gtm_content_group = "Explore the collection"
 
     parent_page_types = [
         "collections.TimePeriodExplorerIndexPage",
@@ -633,7 +633,7 @@ class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIn
         index.SearchField("teaser_text"),
     ]
 
-    gtm_content_group = "Highlight Gallery"
+    gtm_content_group = "Explore the collection"
 
     @cached_property
     def highlights(self):


### PR DESCRIPTION
Ticket URL: [UN-476]

## About these changes

Updated contentGroup1 to match required naming for pages

## How to check these changes

Open a page type that has been changed, press F12 and enter the console. Type `dataLayer` and then open the result. It should then say "Explore the collection" in contentGroup1

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-476]: https://national-archives.atlassian.net/browse/UN-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ