### PR TITLE
UN-759: Unpublished pages still showing in Featured Article

### DIFF
--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -14,7 +14,7 @@
         <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>
 
-    {% if page.featured_article.public %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -14,7 +14,7 @@
         <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>
 
-    {% if page.featured_article %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -14,7 +14,7 @@
         <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>
 
-    {% if page.featured_article.live %}
+    {% if page.featured_article.public %}
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 

--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -11,12 +11,12 @@
     {% if page.featured_highlight_gallery %}
         {% include "includes/highlight_gallery_teaser.html" with title=page.featured_highlight_gallery.title cards=page.featured_highlight_gallery.page_highlights.all|slice:":5" page=page.featured_highlight_gallery %}
     {% endif %}
-    {% if page.featured_article.public %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     {% if page.promoted_links %}
         {% comment %} Checks if featured article exists then adds a bg to define the separate sections {% endcomment %}
-        {% if page.featured_article.public %}
+        {% if page.featured_article.live %}
             {% include_block page.promoted_links with bg=True %}
         {% else %}
             {% include_block page.promoted_links with bg=False %}

--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -11,12 +11,12 @@
     {% if page.featured_highlight_gallery %}
         {% include "includes/highlight_gallery_teaser.html" with title=page.featured_highlight_gallery.title cards=page.featured_highlight_gallery.page_highlights.all|slice:":5" page=page.featured_highlight_gallery %}
     {% endif %}
-    {% if page.featured_article %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     {% if page.promoted_links %}
         {% comment %} Checks if featured article exists then adds a bg to define the separate sections {% endcomment %}
-        {% if page.featured_article %}
+        {% if page.featured_article.live %}
             {% include_block page.promoted_links with bg=True %}
         {% else %}
             {% include_block page.promoted_links with bg=False %}

--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -11,12 +11,12 @@
     {% if page.featured_highlight_gallery %}
         {% include "includes/highlight_gallery_teaser.html" with title=page.featured_highlight_gallery.title cards=page.featured_highlight_gallery.page_highlights.all|slice:":5" page=page.featured_highlight_gallery %}
     {% endif %}
-    {% if page.featured_article.live %}
+    {% if page.featured_article.public %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
     {% if page.promoted_links %}
         {% comment %} Checks if featured article exists then adds a bg to define the separate sections {% endcomment %}
-        {% if page.featured_article.live %}
+        {% if page.featured_article.public %}
             {% include_block page.promoted_links with bg=True %}
         {% else %}
             {% include_block page.promoted_links with bg=False %}

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -21,7 +21,7 @@
         <p>{{ page.articles_introduction }}</p>
     </div>
 
-    {% if page.featured_article.live %}
+    {% if page.featured_article.public %}
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -21,7 +21,7 @@
         <p>{{ page.articles_introduction }}</p>
     </div>
 
-    {% if page.featured_article.public %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -21,7 +21,7 @@
         <p>{{ page.articles_introduction }}</p>
     </div>
 
-    {% if page.featured_article %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -12,11 +12,11 @@
         {% include 'includes/highlights-gallery.html' with highlights=page.highlights %}
     {% endif %}
 
-    {% if page.featured_record_article.public %}
+    {% if page.featured_record_article.live %}
         {% include 'includes/record-revealed.html' with record=page.featured_record_article %}
     {% endif %}
 
-    {% if page.featured_article.public %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
 

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -12,11 +12,11 @@
         {% include 'includes/highlights-gallery.html' with highlights=page.highlights %}
     {% endif %}
 
-    {% if page.featured_record_article.live %}
+    {% if page.featured_record_article.public %}
         {% include 'includes/record-revealed.html' with record=page.featured_record_article %}
     {% endif %}
 
-    {% if page.featured_article.live %}
+    {% if page.featured_article.public %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
 

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -12,11 +12,11 @@
         {% include 'includes/highlights-gallery.html' with highlights=page.highlights %}
     {% endif %}
 
-    {% if page.featured_record_article %}
+    {% if page.featured_record_article.live %}
         {% include 'includes/record-revealed.html' with record=page.featured_record_article %}
     {% endif %}
 
-    {% if page.featured_article %}
+    {% if page.featured_article.live %}
         {% include "includes/article-spotlight.html" with page=page.featured_article %}
     {% endif %}
 

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -8,7 +8,7 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.related_record_articles or page.featured_record_article %}
+    {% if page.related_record_articles or page.featured_record_article.live %}
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
@@ -24,9 +24,9 @@
             </div>
         </div>
     {% endif %}
-    {% if page.featured_article or page.related_articles %}
+    {% if page.featured_article.live or page.related_articles %}
         <div class="container">
-            {% if page.featured_article %}
+            {% if page.featured_article.live %}
                 {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
             {% endif %}
             {% if page.related_articles %}

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -8,7 +8,7 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.related_record_articles or page.featured_record_article.live %}
+    {% if page.related_record_articles or page.featured_record_article.public %}
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
@@ -24,9 +24,9 @@
             </div>
         </div>
     {% endif %}
-    {% if page.featured_article.live or page.related_articles %}
+    {% if page.featured_article.public or page.related_articles %}
         <div class="container">
-            {% if page.featured_article.live %}
+            {% if page.featured_article.public %}
                 {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
             {% endif %}
             {% if page.related_articles %}

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -8,7 +8,7 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.related_record_articles or page.featured_record_article.public %}
+    {% if page.related_record_articles or page.featured_record_article.live %}
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
@@ -24,9 +24,9 @@
             </div>
         </div>
     {% endif %}
-    {% if page.featured_article.public or page.related_articles %}
+    {% if page.featured_article.live or page.related_articles %}
         <div class="container">
-            {% if page.featured_article.public %}
+            {% if page.featured_article.live %}
                 {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
             {% endif %}
             {% if page.related_articles %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -8,7 +8,7 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.related_record_articles or page.featured_record_article %}
+    {% if page.related_record_articles or page.featured_record_article.live %}
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
@@ -24,9 +24,9 @@
             </div>
         </div>
     {% endif %}
-    {% if page.featured_article or page.related_articles %}
+    {% if page.featured_article.live or page.related_articles %}
         <div class="container">
-            {% if page.featured_article %}
+            {% if page.featured_article.live %}
                 {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
             {% endif %}
             {% if page.related_articles %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -8,7 +8,7 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.related_record_articles or page.featured_record_article.live %}
+    {% if page.related_record_articles or page.featured_record_article.public %}
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
@@ -24,9 +24,9 @@
             </div>
         </div>
     {% endif %}
-    {% if page.featured_article.live or page.related_articles %}
+    {% if page.featured_article.public or page.related_articles %}
         <div class="container">
-            {% if page.featured_article.live %}
+            {% if page.featured_article.public %}
                 {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
             {% endif %}
             {% if page.related_articles %}

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -8,7 +8,7 @@
     {% if page.related_highlight_gallery_pages %}
         {% include "includes/related-highlight-cards.html" with title=page.title cards=page.related_highlight_gallery_pages %}
     {% endif %}
-    {% if page.related_record_articles or page.featured_record_article.public %}
+    {% if page.related_record_articles or page.featured_record_article.live %}
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
@@ -24,9 +24,9 @@
             </div>
         </div>
     {% endif %}
-    {% if page.featured_article.public or page.related_articles %}
+    {% if page.featured_article.live or page.related_articles %}
         <div class="container">
-            {% if page.featured_article.public %}
+            {% if page.featured_article.live %}
                 {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
             {% endif %}
             {% if page.related_articles %}


### PR DESCRIPTION
Ticket URL: [UN-759]

## About these changes

I've chosen to just prevent pages from showing if they're not public (and by that, live) in the front-end. This is because editors can select a page as a featured article, and then make the page private/un-publish it. This then either takes the user to a password page, or to an error that the page doesn't exist. This eliminates that by checking if the selected page is public - if the page isn't public or live then it won't show.

## How to check these changes

Add a page to a featured article field, then unpublish the selected page or make it private - then view the original page where you added the featured article and see that it is missing.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-759]: https://national-archives.atlassian.net/browse/UN-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ