### PR TITLE
DF-754: Do not submit feedback comments on form close

### DIFF
--- a/etna/feedback/templates/feedback/includes/prompt.html
+++ b/etna/feedback/templates/feedback/includes/prompt.html
@@ -24,7 +24,7 @@
                     {{ comment_form.as_div }}
 
                     <button type="submit" class="feedback__form-submit tna-button--dark" data-feedback-form-submit>Submit</button>
-                    <button type="submit" class="feedback__form-close" aria-label="Submit and close feedback form" data-feedback-form-submit>
+                    <button class="feedback__form-close" aria-label="Close feedback form" data-feedback-form-close>
                         {% include "includes/icon.html" with name="x-mark" classname="feedback__form-close-icon" %}
                     </button>
                 </form>
@@ -49,8 +49,14 @@
 const form = document.getElementById("feedback-form");
 const commentForm = document.getElementById("feedback-comment-form");
 const successContent = document.getElementById("feedback-success");
+const closeButton = document.querySelector("button[data-feedback-form-close]");
 let submitted = false;
 let comment_submitted = false;
+
+function showSuccessContent() {
+    successContent.style.display = "block";
+    window.location.hash = successContent.id;
+}
 
 // submit via the fetch API instead
 form.onsubmit = function (e) {
@@ -95,8 +101,7 @@ form.onsubmit = function (e) {
             window.location.hash = commentForm.id;
         }
         else {
-            successContent.style.display = "block";
-            window.location.hash = successContent.id;
+            showSuccessContent();
         }
     })
     .catch((error) => {
@@ -131,11 +136,16 @@ commentForm.onsubmit = function (e) {
     .then((response) => response.json())
     .then((data) => {
         commentForm.remove();
-        successContent.style.display = "block";
-        window.location.hash = successContent.id;
+        showSuccessContent();
     })
     .catch((error) => {
         console.error("Error:", error);
     });
 };
+
+closeButton.onclick = function (e) {
+    commentForm.remove();
+    showSuccessContent();
+};
+
 </script>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-754

## About these changes

The 'Submit' and 'Close' buttons are currently implemented as `button` elements, both of which have the `submit` type value, so interacting with either results in form submission. This PR changes removes that attribute from the 'Close' option and adds some custom JS to handle hiding of the form and displaying of the success messaging without submitting comment text.

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
