### PR TITLE
UN-784 Made breadcrumbs on focused articles 100% width to fill background

### DIFF
--- a/sass/includes/_breadcrumb.scss
+++ b/sass/includes/_breadcrumb.scss
@@ -14,6 +14,7 @@
   // Styles for Focused Article templates
   .template-focused-article & {
     background-color: $color__grey-700;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Ticket URL: [UN-784](https://national-archives.atlassian.net/browse/UN-784)

## About these changes

Added a 100% width to fix the UI show the background colour fills the page

## How to check these changes

[Local page to test](http://127.0.0.1:8000/admin/pages/260/edit/preview/?mode=)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-784]: https://national-archives.atlassian.net/browse/UN-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ