### PR TITLE
UN-783: Remove publication date from Focused Article

### DIFF
--- a/templates/articles/focused_article_page.html
+++ b/templates/articles/focused_article_page.html
@@ -17,9 +17,6 @@
     {% if page.author or page.first_published_at %}
         <div class="generic-intro__meta">
             <ul class="generic-intro__meta-list container">
-                {% if page.first_published_at %}
-                    <li class="generic-intro__meta-item">{{ page.first_published_at|date:"l d F Y" }}</li>                    
-                {% endif %}
                 {% if page.author %}
                     <li class="generic-intro__meta-item">By {{ page.author }}</li>                    
                 {% endif %}


### PR DESCRIPTION
Ticket URL: [UN-783]

## About these changes

Removed the HTML for the publication date from the Focused Article page

## How to check these changes

Open a Focused Article page and see that there is no more publication date

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-783]: https://national-archives.atlassian.net/browse/UN-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ