### PR TITLE
DF-749: Only show publish dates for ephemeral pages in search results

### DIFF
--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -58,6 +58,8 @@ class BasePage(MetadataPageMixin, DataLayerMixin, Page):
     # DataLayerMixin overrides
     gtm_content_group = "Page"
 
+    show_publish_date_in_search_results = False
+
     # Overriding the default/core help_text set in MetadataPageMixin
     promote_panels = [
         MultiFieldPanel(

--- a/templates/search/blocks/native_website_result--grid.html
+++ b/templates/search/blocks/native_website_result--grid.html
@@ -24,15 +24,17 @@
                 {{ result.title }}
             </a>
         </h4>
+
         <p class="search-results__list-card-description">
             {{ result.teaser_text }}
         </p>
+
         <dl class="search-results__list-card-metadata">
             <dt class="search-results__list-card-metadata-item">
                 Page type:
             </dt>
             <dd>{{ result|public_page_type_label }}</dd>
-            {% if result.first_published_at %}
+            {% if result.show_publish_date_in_search_results and result.first_published_at %}
                 <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
                     Published:
                 </dt>

--- a/templates/search/blocks/native_website_result.html
+++ b/templates/search/blocks/native_website_result.html
@@ -16,7 +16,7 @@
                 Page type:
             </dt>
             <dd>{{ result|public_page_type_label }}</dd>
-            {% if result.first_published_at %}
+            {% if result.show_publish_date_in_search_results and result.first_published_at %}
                 <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
                     Published:
                 </dt>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-749

## How to check these changes

You shouldn't see the 'Published' date appear next to search results any longer, because all page types that appear in search results currently are considered 'evergreen' (not 'ephemeral').

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
