### PR TITLE
[UN-786] Remove dotted border from related articles on focused article page

### DIFF
--- a/templates/articles/focused_article_page.html
+++ b/templates/articles/focused_article_page.html
@@ -45,13 +45,13 @@
         </div>
     </div>
 
-    <div class="related-content">
-        <div class="container">
-            {% if page.primary_topic or page.primary_time_period %}
+    {% if page.primary_topic or page.primary_time_period %}
+        <div class="related-content related-content--borderless">
+            <div class="container">
                 {% include "includes/related_topic_timeline_cards.html" with topic=page.primary_topic time_period=page.primary_time_period title="Discover highlights from the collection" %}
-            {% endif %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-786

## About these changes

As per title of PR :)

## How to check these changes

Review focused article page locally and see there is no dotted border at the bottom of the page.
Ensure related articles still show as expected, without dotted top border.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
