### PR TITLE
UN 744 Removed redundant link wrapping the image

### DIFF
--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -7,31 +7,15 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
-        <a
-            href="{{ link_page.url }}"
-            class="card-group-secondary-nav__image-link"
-            data-card-type="card-group-secondary-nav"
-            data-component-name="{{ card_type }} card: {% if heading %}{{ heading }}{% else %}{{ page.title }}{% endif %}"
-            data-link-type="Card image"
-            data-card-title="{{ link_page.title }}"
-            {% if link_page.is_newly_published %}
-                data-label="New"
-            {% endif %}
-            aria-labelledby="article-desc{{ link_page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
-            {% if forloop.counter %}
-                data-card-position="{{ forloop.counter0 }}"
-            {% endif %}
-        >
-            <div class="card-group-secondary-nav__image">
-                <picture>
-                    <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
-                    <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
-                    <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
-                    <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
-                    <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
-                </picture>
-            </div>
-        </a>
+        <div class="card-group-secondary-nav__image">
+            <picture>
+                <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
+                <source media="(max-width: 991px)" srcset="{{ teaser_image_medium.url }}">
+                <source media="(max-width: 1199px)" srcset="{{ teaser_image_small.url }}">
+                <source media="(min-width: 1200px)" srcset="{{ teaser_image_large.url }}">
+                <img src="{{ teaser_image_extra_large.url }}" alt="" class="card-group-secondary-nav__image-fallback">
+            </picture>
+        </div>
         <div class="card-group-secondary-nav__body">
             {% if link_page.title_label %}
                 <p class="card-group-secondary-nav__title-label">{{ link_page.title_label }}</p>


### PR DESCRIPTION
Ticket URL: [UN 744](https://national-archives.atlassian.net/browse/UN-744)
## About these changes

Removed the additional redundant link wrapping the image in the card as flagged by WAVE

## How to check these changes

[Please review this page](http://127.0.0.1:8000/explore-the-collection/explore-by-topic/)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
