### PR TITLE
[UN-787] Update component widths for focused articles

### DIFF
--- a/sass/includes/_content-block.scss
+++ b/sass/includes/_content-block.scss
@@ -1,6 +1,13 @@
 .content-block {
   padding: 0.5rem 0;
 
+  @media (min-width: $screen__lg) {
+    .template-focused-article & {
+      padding-left: 10%;
+      padding-right: 10%;
+    }
+  }
+
   &__heading {
     font-size: 2rem;
     font-weight: 400;

--- a/sass/includes/_related-resources.scss
+++ b/sass/includes/_related-resources.scss
@@ -2,6 +2,13 @@
     margin: 2rem 0;
     padding-bottom: 1rem;
 
+    @media (min-width: $screen__lg) {
+        .template-focused-article & {
+            padding-left: 10%;
+            padding-right: 10%;
+        }
+    }
+
     &__heading {
         font-size: 2rem;
         font-weight: 400;

--- a/sass/includes/_section-separator.scss
+++ b/sass/includes/_section-separator.scss
@@ -6,6 +6,13 @@
     color: $color__grey-700;
     background: transparent;
 
+    @media (min-width: $screen__lg) {
+      .template-focused-article & {
+        padding-left: 10%;
+        padding-right: 10%;
+      }
+    }
+
     &-text {
       display: inline-block;
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-787

## About these changes

Adds styling to reduce width of specific content components on the focused article page type. This is to bring the content widths closer in line with the designs.

**Please note** - we could do with some more refinement for all common components shared between the article (story) and focused article pages. At the moment the padding is a little inconsistent between components - for example, some use `<div class="container">` while others don't, so the padding varies slightly between components.  This refinement is out of scope for this ticket but will need addressing to neaten things up longer term.

## How to check these changes

Review a focused article page and see that non-image components have been reduced in width on desktop to match the designs more closely. This gives the effect of images and media components extending beyond the container.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
