### PR TITLE
Fix for portrait images on mobile so they don't resize too small

### DIFF
--- a/templates/blocks/image-block-default.html
+++ b/templates/blocks/image-block-default.html
@@ -3,32 +3,46 @@
 
 {% if value.image %}
     {% if value.caption %}
-        <figure class="image-block">
+        <figure class="image-block u-margin-l">
             <picture>
                 {% image value.image max-832x591 format-webp as desktop_img %}
                 <source media="(min-width: 760px)" srcset="{{ desktop_img.url }}"/>
                 {% image value.image max-832x591 as desktop_image %}
                 <source media="(min-width: 760px)" srcset="{{ desktop_img.url }}"/>
-                {% image value.image max-390x265 format-webp as mobile_img %}
-                <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
-                {% image value.image max-390x265 as mobile_img %}
-                <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
-                <img class="image-block__image{% if value.is_portrait %} image-block__image--portrait{% endif %}" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{{ mobile_img.alt_text }}" />
+                {% if value.is_portrait %}
+                    {% image value.image max-265x390 format-webp as mobile_img %}
+                    <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+                    {% image value.image max-265x390 as mobile_img %}
+                    <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+                {% else %}
+                    {% image value.image max-390x265 format-webp as mobile_img %}
+                    <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+                    {% image value.image max-390x265 as mobile_img %}
+                    <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+                {% endif %}
+                <img class="image-block__image{% if value.is_portrait %} image-block__image--portrait{% endif %}" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{% if value.decorative %}{{ value.alt_text }}{% endif %}" />
             </picture>
             <figcaption class="image-block__caption">
                 {{ value.caption|richtext }}
             </figcaption>
         </figure>
     {% else %}
-        <picture class="image-block">
+        <picture class="image-block u-margin-l">
             {% image value.image max-832x591 format-webp as desktop_img %}
             <source media="(min-width: 760px)" srcset="{{ desktop_img.url }}"/>
             {% image value.image max-832x591 as desktop_image %}
             <source media="(min-width: 760px)" srcset="{{ desktop_img.url }}"/>
-            {% image value.image max-390x265 format-webp as mobile_img %}
-            <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
-            {% image value.image max-390x265 as mobile_img %}
-            <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+            {% if value.is_portrait %}
+                {% image value.image max-265x390 format-webp as mobile_img %}
+                <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+                {% image value.image max-265x390 as mobile_img %}
+                <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+            {% else %}
+                {% image value.image max-390x265 format-webp as mobile_img %}
+                <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+                {% image value.image max-390x265 as mobile_img %}
+                <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
+            {% endif %}
             <img class="image-block__image" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{% if value.decorative %}{{ value.alt_text }}{% endif %}" />
         </picture>
     {% endif %}


### PR DESCRIPTION
Ticket URL: TBC

## About these changes

No ticket yet but this was discussed this morning with Lauren - adds a fix for portrait images on article pages so they don't get resized too small on mobile.  Ensures the correct dimensions are maintained for mobile images.

## How to check these changes

Review portrait image on story page and resize to mobile - see that the image does not get squashed too small.

Before:

![image](https://github.com/nationalarchives/ds-wagtail/assets/8680557/84a743df-b6ab-4e6e-a615-dfe33d13d98c)

After: 

![image](https://github.com/nationalarchives/ds-wagtail/assets/8680557/9b34a3c6-5403-4344-bd8b-11a9e30a8efc)


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
