### PR TITLE
[UN-776] Topic and Time Period Explorer Pages zoom

### DIFF
--- a/sass/includes/_hero-image.scss
+++ b/sass/includes/_hero-image.scss
@@ -4,6 +4,7 @@
     &__image {
         width: 100%;
         height: auto;
+        max-height: 650px;
         object-fit: cover;
     }
 

--- a/sass/includes/_highlight-cards.scss
+++ b/sass/includes/_highlight-cards.scss
@@ -1,7 +1,8 @@
 .highlight-cards {
-  background-color: $color__cream;
   $root: &;
+  background-color: $color__cream;
   font-family: $font__supria-sans;
+  padding: 2em;
 
   &__link {
     text-decoration: none !important;

--- a/sass/includes/_highlight-intro.scss
+++ b/sass/includes/_highlight-intro.scss
@@ -6,6 +6,7 @@
     &__image {
         width: 100%;
         height: auto;
+        max-height: 650px;
         object-fit: cover;
     }
 

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -12,7 +12,7 @@
         {% include "includes/related-articles-highlight-cards.html" with featured_article=page.featured_record_article articles=page.related_record_articles title="Records revealed" %}
     {% endif %}
     {% if page.body %}
-        <div class="body-container"
+        <div class="container"
              data-container-name="topic-explorer"
              id="analytics-topic-explorer">
             <div class="row">

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -25,18 +25,18 @@
         </div>
     {% endif %}
     {% if page.featured_article.live or page.related_articles %}
-        <div class="container">
-            {% if page.featured_article.live %}
-                {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
-            {% endif %}
-            {% if page.related_articles %}
+        {% if page.featured_article.live %}
+            {% include "includes/article-spotlight.html" with page=page.featured_article title="Stories from the collection" %}
+        {% endif %}
+        {% if page.related_articles %}
+            <div class="container">
                 <ul class="card-group--list-style-none">
                     {% for item in page.related_articles %}
                         {% include 'includes/card-group-secondary-nav.html' with link_page=item heading="Stories from the collection" card_type="Featured" %}
                     {% endfor %}
                 </ul>
-            {% endif %}
-        </div>
+            </div>
+        {% endif %}
     {% endif %}
 {% endblock content %}
 {% block extra_js %}

--- a/templates/includes/related-articles-highlight-cards.html
+++ b/templates/includes/related-articles-highlight-cards.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 <div class="highlight-cards">
-    <div class="body-container">
+    <div class="container">
         <h2 class="highlight-cards__title">{{ title }}</h2>
         <div class="card-grid card-grid__quad">
             {% if featured_article %}

--- a/templates/includes/related-highlight-cards.html
+++ b/templates/includes/related-highlight-cards.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 <section class="related-highlight-cards">
-    <div class="body-container">
+    <div class="container">
         <h2 class="related-highlight-cards__title">{{ title }} highlights in pictures</h2>
         <div class="card-grid card-grid__trio">
             {% for card in cards %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-776

## About these changes

Updated the topic & time period page container to ensure content resizes correctly on browser zoom.

Also adds a max-height to full-width hero images to ensure they also resize as expected in browser zoom.

## How to check these changes

Review topic/time period index page locally and use browser zoom (both in and out) to check the content resizes correctly.
This also applies to hero images on article pages.

Before: 
![etna-topic-time-period-zoom-before](https://github.com/nationalarchives/ds-wagtail/assets/8680557/c4723760-a8b1-4d9c-a112-fb8d8bb9f786)

After:
![etna-topic-time-period-zoom-after](https://github.com/nationalarchives/ds-wagtail/assets/8680557/2734f290-e455-436f-b683-e4f1d69b88eb)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
