### PR TITLE
UN-785: Topic and Time Period pages to have related Focused Articles

### DIFF
--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -247,7 +247,7 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
         """Return a list of related pages for rendering in the related articles section
         of the page. To add another page type, add it to the `exact_type` query below.
         """
-        
+
         from wagtail.models import Page
 
         from etna.articles.models import ArticlePage, FocusedArticlePage

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -245,28 +245,23 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
     @cached_property
     def related_articles(self):
         """Return a list of related pages for rendering in the related articles section
-        of the page. To add another page type, import it and add it to the related_page_types list.
+        of the page. To add another page type, import it and add it to the list.
         """
 
         from etna.articles.models import ArticlePage, FocusedArticlePage
 
-        related_page_types = [ArticlePage, FocusedArticlePage]
         page_list = []
 
-        for page_type in related_page_types:
-            pages = (
+        for page_type in [ArticlePage, FocusedArticlePage]:
+            page_list.extend(
                 page_type.objects.exclude(pk=self.featured_article_id)
                 .filter(pk__in=self.related_page_pks)
                 .live()
                 .public()
                 .select_related("teaser_image")
             )
-            if pages:
-                page_list.extend(pages)
 
-        page_list.sort(key=lambda x: x.first_published_at, reverse=True)
-
-        return page_list
+        return sorted(page_list, key=lambda x: x.first_published_at, reverse=True)
 
     @cached_property
     def related_record_articles(self):
@@ -414,28 +409,23 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
     @cached_property
     def related_articles(self):
         """Return a list of related pages for rendering in the related articles section
-        of the page. To add another page type, import it and add it to the related_page_types list.
+        of the page. To add another page type, import it and add it to the list.
         """
 
         from etna.articles.models import ArticlePage, FocusedArticlePage
 
-        related_page_types = [ArticlePage, FocusedArticlePage]
         page_list = []
 
-        for page_type in related_page_types:
-            pages = (
+        for page_type in [ArticlePage, FocusedArticlePage]:
+            page_list.extend(
                 page_type.objects.exclude(pk=self.featured_article_id)
                 .filter(pk__in=self.related_page_pks)
                 .live()
                 .public()
                 .select_related("teaser_image")
             )
-            if pages:
-                page_list.extend(pages)
 
-        page_list.sort(key=lambda x: x.first_published_at, reverse=True)
-
-        return page_list
+        return sorted(page_list, key=lambda x: x.first_published_at, reverse=True)
 
     @cached_property
     def related_record_articles(self):

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -244,6 +244,10 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
 
     @cached_property
     def related_articles(self):
+        """Return a list of related pages for rendering in the related articles section
+        of the page. To add another page type, add it to the `exact_type` query below.
+        """
+        
         from wagtail.models import Page
 
         from etna.articles.models import ArticlePage, FocusedArticlePage
@@ -404,6 +408,10 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
 
     @cached_property
     def related_articles(self):
+        """Return a list of related pages for rendering in the related articles section
+        of the page. To add another page type, add it to the `exact_type` query below.
+        """
+
         from wagtail.models import Page
 
         from etna.articles.models import ArticlePage, FocusedArticlePage

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -244,15 +244,15 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
 
     @cached_property
     def related_articles(self):
-        from etna.articles.models import ArticlePage
+        from etna.articles.models import ArticleIndexPage, ArticlePage, FocusedArticlePage
 
+        article_index_page = ArticleIndexPage.objects.live().public().first()
+
+        if not article_index_page:
+            return []
+        
         return (
-            ArticlePage.objects.exclude(pk=self.featured_article)
-            .live()
-            .public()
-            .filter(pk__in=self.related_page_pks)
-            .order_by("-first_published_at")
-            .select_related("teaser_image")
+            article_index_page.get_children().exclude(pk=self.featured_article.pk).exact_type(ArticlePage, FocusedArticlePage).filter(pk__in=self.related_page_pks).live().public().order_by("-first_published_at").specific().select_related("teaser_image")
         )
 
     @cached_property

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -259,6 +259,7 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
                 .live()
                 .public()
                 .select_related("teaser_image")
+                .prefetch_related("teaser_image__renditions")
             )
 
         return sorted(page_list, key=lambda x: x.first_published_at, reverse=True)
@@ -423,6 +424,7 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
                 .live()
                 .public()
                 .select_related("teaser_image")
+                .prefetch_related("teaser_image__renditions")
             )
 
         return sorted(page_list, key=lambda x: x.first_published_at, reverse=True)

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -245,22 +245,22 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
     @cached_property
     def related_articles(self):
         """Return a list of related pages for rendering in the related articles section
-        of the page. To add another page type, add it to the `exact_type` query below.
+        of the page. To add another page type, import it and add it to the related_page_types list.
         """
-
-        from wagtail.models import Page
 
         from etna.articles.models import ArticlePage, FocusedArticlePage
 
-        return (
-            Page.objects.exclude(pk=self.featured_article.pk)
-            .live()
-            .public()
-            .exact_type(ArticlePage, FocusedArticlePage)
-            .filter(pk__in=self.related_page_pks)
-            .order_by("-first_published_at")
-            .specific()
-        )
+        related_page_types = [ArticlePage, FocusedArticlePage]
+        page_list = []
+
+        for page_type in related_page_types:
+            pages = page_type.objects.exclude(pk=self.featured_article_id).filter(pk__in=self.related_page_pks).live().public().prefetch_related("teaser_image__renditions")
+            if pages:
+                page_list.extend(pages)
+
+        page_list.sort(key=lambda x: x.first_published_at, reverse=True)
+
+        return page_list
 
     @cached_property
     def related_record_articles(self):
@@ -408,22 +408,22 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
     @cached_property
     def related_articles(self):
         """Return a list of related pages for rendering in the related articles section
-        of the page. To add another page type, add it to the `exact_type` query below.
+        of the page. To add another page type, import it and add it to the related_page_types list.
         """
-
-        from wagtail.models import Page
 
         from etna.articles.models import ArticlePage, FocusedArticlePage
 
-        return (
-            Page.objects.exclude(pk=self.featured_article.pk)
-            .live()
-            .public()
-            .exact_type(ArticlePage, FocusedArticlePage)
-            .filter(pk__in=self.related_page_pks)
-            .order_by("-first_published_at")
-            .specific()
-        )
+        related_page_types = [ArticlePage, FocusedArticlePage]
+        page_list = []
+
+        for page_type in related_page_types:
+            pages = page_type.objects.exclude(pk=self.featured_article_id).filter(pk__in=self.related_page_pks).live().public().prefetch_related("teaser_image__renditions")
+            if pages:
+                page_list.extend(pages)
+
+        page_list.sort(key=lambda x: x.first_published_at, reverse=True)
+
+        return page_list
 
     @cached_property
     def related_record_articles(self):

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -254,7 +254,13 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
         page_list = []
 
         for page_type in related_page_types:
-            pages = page_type.objects.exclude(pk=self.featured_article_id).filter(pk__in=self.related_page_pks).live().public().prefetch_related("teaser_image__renditions")
+            pages = (
+                page_type.objects.exclude(pk=self.featured_article_id)
+                .filter(pk__in=self.related_page_pks)
+                .live()
+                .public()
+                .prefetch_related("teaser_image__renditions")
+            )
             if pages:
                 page_list.extend(pages)
 
@@ -417,7 +423,13 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
         page_list = []
 
         for page_type in related_page_types:
-            pages = page_type.objects.exclude(pk=self.featured_article_id).filter(pk__in=self.related_page_pks).live().public().prefetch_related("teaser_image__renditions")
+            pages = (
+                page_type.objects.exclude(pk=self.featured_article_id)
+                .filter(pk__in=self.related_page_pks)
+                .live()
+                .public()
+                .prefetch_related("teaser_image__renditions")
+            )
             if pages:
                 page_list.extend(pages)
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -244,17 +244,20 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
 
     @cached_property
     def related_articles(self):
+        from wagtail.models import Page
+
         from etna.articles.models import ArticlePage, FocusedArticlePage
 
-        article_pages = ArticlePage.objects.exclude(pk=self.featured_article).filter(pk__in=self.related_page_pks).live().public().order_by("-first_published_at").select_related("teaser_image")
-        focused_article_pages = FocusedArticlePage.objects.exclude(pk=self.featured_article).filter(pk__in=self.related_page_pks).live().public().order_by("-first_published_at").select_related("teaser_image")
-        
-        page_list = []
-        page_list.extend(article_pages)
-        page_list.extend(focused_article_pages)
-        page_list.sort(key=lambda x: x.first_published_at, reverse=True)
-
-        return page_list
+        return (
+            Page.objects.exclude(pk=self.featured_article.pk)
+            .live()
+            .public()
+            .exact_type(ArticlePage, FocusedArticlePage)
+            .filter(pk__in=self.related_page_pks)
+            .order_by("-first_published_at")
+            .specific()
+            .select_related("teaser_image")
+        )
 
     @cached_property
     def related_record_articles(self):
@@ -401,14 +404,18 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
 
     @cached_property
     def related_articles(self):
-        from etna.articles.models import ArticlePage
+        from wagtail.models import Page
+
+        from etna.articles.models import ArticlePage, FocusedArticlePage
 
         return (
-            ArticlePage.objects.exclude(pk=self.featured_article)
+            Page.objects.exclude(pk=self.featured_article.pk)
             .live()
             .public()
+            .exact_type(ArticlePage, FocusedArticlePage)
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
+            .specific()
             .select_related("teaser_image")
         )
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -259,7 +259,7 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
                 .filter(pk__in=self.related_page_pks)
                 .live()
                 .public()
-                .prefetch_related("teaser_image__renditions")
+                .select_related("teaser_image")
             )
             if pages:
                 page_list.extend(pages)
@@ -428,7 +428,7 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
                 .filter(pk__in=self.related_page_pks)
                 .live()
                 .public()
-                .prefetch_related("teaser_image__renditions")
+                .select_related("teaser_image")
             )
             if pages:
                 page_list.extend(pages)

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -260,7 +260,6 @@ class TopicExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithIntro):
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
             .specific()
-            .select_related("teaser_image")
         )
 
     @cached_property
@@ -424,7 +423,6 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, AlertMixin, BasePageWithInt
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
             .specific()
-            .select_related("teaser_image")
         )
 
     @cached_property


### PR DESCRIPTION
Ticket URL: [UN-785]

## About these changes

Re-written the `related_articles` attribute for the Topic and Time Period pages to include `ArticlePage` and `FocusedArticlePage`.

Added docstrings for a bit of explanation :) 

## How to check these changes

Go to http://localhost:8000/explore-the-collection/explore-by-topic/migration-and-citizenship/ or http://localhost:8000/explore-the-collection/explore-by-time-period/early-20th-century/ and ensure that Focused Articles are also in the articles section

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-785]: https://national-archives.atlassian.net/browse/UN-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ