### PR TITLE
[UN-731] Fix font families for headings across the site

### DIFF
--- a/sass/tna-toolkit/_typography.scss
+++ b/sass/tna-toolkit/_typography.scss
@@ -17,7 +17,6 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: $font__heading;
   font-weight: 700;
   line-height: 1.6;
   margin-top: 20px;
@@ -26,21 +25,25 @@ h6,
 
 h1,
 .h1 {
+  font-family: $font__heading;
   font-size: 2.4em;
 }
 
 h2,
 .h2 {
+  font-family: $font__heading;
   font-size: 1.6em;
 }
 
 h3,
 .h3 {
+  font-family: $font__open-sans;
   font-size: 1.3em;
 }
 
 h4,
 .h4 {
+  font-family: $font__open-sans;
   font-size: 1.16em;
 }
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-731

## About these changes

Updates the font family for headings to match up with the design system.

## How to check these changes

Check an article page with headings & subheading fields (or add your own) and see the fonts match those in the design system. 

Design: https://www.figma.com/file/uo8YY98lLws8E1HEfpdn5X/TNA-Etna---Design-system?type=design&node-id=7-272&mode=design&t=5RsJEfSMh7NLevVv-0

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
