### PR TITLE
[UN-795] Fix alt text for streamfield images and add TODO for heros

### DIFF
--- a/templates/blocks/image-block-default.html
+++ b/templates/blocks/image-block-default.html
@@ -20,7 +20,7 @@
                     {% image value.image max-390x265 as mobile_img %}
                     <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
                 {% endif %}
-                <img class="image-block__image{% if value.is_portrait %} image-block__image--portrait{% endif %}" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{% if value.decorative %}{{ value.alt_text }}{% endif %}" />
+                <img class="image-block__image{% if value.is_portrait %} image-block__image--portrait{% endif %}" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{% if not value.decorative %}{{ value.alt_text }}{% endif %}" />
             </picture>
             <figcaption class="image-block__caption">
                 {{ value.caption|richtext }}
@@ -43,7 +43,7 @@
                 {% image value.image max-390x265 as mobile_img %}
                 <source media="(max-width: 759px)" srcset="{{ mobile_img.url }}"/>
             {% endif %}
-            <img class="image-block__image" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{% if value.decorative %}{{ value.alt_text }}{% endif %}" />
+            <img class="image-block__image" width={{ mobile_img.width }} height={{ mobile_img.height }} src="{{ mobile_img.url }}" alt="{% if not value.decorative %}{{ value.alt_text }}{% endif %}" />
         </picture>
     {% endif %}
 {% endif %}

--- a/templates/includes/hero-img.html
+++ b/templates/includes/hero-img.html
@@ -27,6 +27,7 @@
                  width="1440"
                  height="500"
                  class="hero-image__image"
+                 {% comment %} TODO: Add alt text option in Wagtail - this field doesn't exist for stories/articles {% endcomment %}
                  {% if hero_image.alt_text %}alt="{{ hero_image.alt_text }}"{% endif %}/>
         </picture>
         {% if caption %}

--- a/templates/includes/hero-img.html
+++ b/templates/includes/hero-img.html
@@ -28,7 +28,7 @@
                  height="500"
                  class="hero-image__image"
                  {% comment %} TODO: Add alt text option in Wagtail - this field doesn't exist for stories/articles {% endcomment %}
-                 {% if hero_image.alt_text %}alt="{{ hero_image.alt_text }}"{% endif %}/>
+                 alt="{% if hero_image.alt_text %}{{ hero_image.alt_text }}{% endif %}"/>
         </picture>
         {% if caption %}
             <figcaption class="hero-image__figcaption">

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -25,7 +25,7 @@
              width="1440"
              class="highlight-intro__image"
              {% comment %} TODO: Add alt text option in Wagtail - this field doesn't exist for topic/time period {% endcomment %}
-             {% if background_image.alt_text %}alt="{{ background_image.alt_text }}"{% endif %}/>
+             alt="{% if background_image.alt_text %}{{ background_image.alt_text }}{% endif %}"/>
     </picture>
     <div class="container">
         <div class="highlight-intro__standout-container">

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -24,8 +24,7 @@
              height="500"
              width="1440"
              class="highlight-intro__image"
-             {% comment %} TODO: Add alt text option in Wagtail - this field doesn't exist for topic/time period {% endcomment %}
-             alt="{% if background_image.alt_text %}{{ background_image.alt_text }}{% endif %}"/>
+             alt=""/>
     </picture>
     <div class="container">
         <div class="highlight-intro__standout-container">

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -24,6 +24,7 @@
              height="500"
              width="1440"
              class="highlight-intro__image"
+             {% comment %} TODO: Add alt text option in Wagtail - this field doesn't exist for topic/time period {% endcomment %}
              {% if background_image.alt_text %}alt="{{ background_image.alt_text }}"{% endif %}/>
     </picture>
     <div class="container">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-795

## About these changes

Fixes if statement for streamfield images so the alt text shows if they are _not_ marked as decorative
Add TODO comment for BE to add alt text field for hero images (both for article pages and topic/time period pages)

## How to check these changes

Review any story page and see that the alt text is being pulled through correctly to the FE for any images with alt text

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer.
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [ ] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
