### PR TITLE
UN-780: Record, Focused, and Article page types in "More Stories"

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -271,13 +271,17 @@ class ArticlePage(
             return ()
 
         # Identify other live pages with tags in common
-        return tuple(
+        related_tags = (
             Page.objects.live()
             .public()
             .not_page(self)
             .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
             .filter(tagged_items__tag_id__in=tag_ids)
-            .specific()[:3]
+        )
+
+        return Page.objects.filter(id__in=related_tags).search(
+            self.article_tag_names,
+            operator="or",
         )
 
     @cached_property

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -279,10 +279,10 @@ class ArticlePage(
             .filter(tagged_items__tag_id__in=tag_ids)
         )
 
-        return Page.objects.filter(id__in=related_tags).search(
+        return tuple(Page.objects.filter(id__in=related_tags).search(
             self.article_tag_names,
             operator="or",
-        )
+        )[:3])
 
     @cached_property
     def latest_items(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -302,8 +302,8 @@ class ArticlePage(
             )
 
         return sorted(
-                latest_query_set, key=lambda x: x.first_published_at, reverse=True
-            )[:3]
+            latest_query_set, key=lambda x: x.first_published_at, reverse=True
+        )[:3]
 
 
 class FocusedArticlePage(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -253,7 +253,9 @@ class ArticlePage(
         super().save(*args, **kwargs)
 
     @cached_property
-    def similar_items(self) -> Tuple["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]:
+    def similar_items(
+        self,
+    ) -> Tuple["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]:
         """
         Returns a maximum of three ArticlePages that are tagged with at least
         one of the same ArticleTags. Items should be ordered by the number
@@ -300,7 +302,9 @@ class ArticlePage(
         return tuple(relevant_pages[:3])
 
     @cached_property
-    def latest_items(self) -> Tuple["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]:
+    def latest_items(
+        self,
+    ) -> Tuple["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]:
         """
         Return the three most recently published ArticlePages,
         excluding this object.
@@ -323,9 +327,11 @@ class ArticlePage(
             page for page in latest_query_set if page not in similar_query_set
         ]
 
-        return tuple(sorted(
-            filter_latest_pages, key=lambda x: x.first_published_at, reverse=True
-        )[:3])
+        return tuple(
+            sorted(
+                filter_latest_pages, key=lambda x: x.first_published_at, reverse=True
+            )[:3]
+        )
 
 
 class FocusedArticlePage(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, Union
 
 from django.conf import settings
 from django.db import models
@@ -254,7 +254,7 @@ class ArticlePage(
     @cached_property
     def similar_items(
         self,
-    ) -> Tuple["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]:
+    ) -> Tuple[Union["ArticlePage", "FocusedArticlePage", "RecordArticlePage"], ...]:
         """
         Returns a maximum of three ArticlePages that are tagged with at least
         one of the same ArticleTags. Items should be ordered by the number
@@ -285,7 +285,7 @@ class ArticlePage(
     @cached_property
     def latest_items(
         self,
-    ) -> Tuple["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]:
+    ) -> Tuple[Union["ArticlePage", "FocusedArticlePage", "RecordArticlePage"], ...]:
         """
         Return the three most recently published ArticlePages,
         excluding this object.

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -270,28 +270,14 @@ class ArticlePage(
             # Avoid unncecssary lookups
             return ()
 
-        # Identify 'other' live pages with tags in common
-
-        matching_page_ids = (
+        # Identify other live pages with tags in common
+        return tuple(
             Page.objects.live()
             .public()
             .not_page(self)
             .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
             .filter(tagged_items__tag_id__in=tag_ids)
-            .values_list("id", flat=True)
-        )
-
-        if not matching_page_ids:
-            # Avoid unncecssary lookups
-            return ()
-
-        # Use search() to prioritise items with the highest number of matches
-        return tuple(
-            Page.objects.filter(id__in=matching_page_ids).search(
-                self.article_tag_names,
-                fields=["article_tag_names"],
-                operator="or",
-            )[:3]
+            .specific()[:3]
         )
 
     @cached_property
@@ -318,11 +304,9 @@ class ArticlePage(
             page for page in latest_query_set if page not in self.similar_items
         ]
 
-        return tuple(
-            sorted(
+        return sorted(
                 filter_latest_pages, key=lambda x: x.first_published_at, reverse=True
             )[:3]
-        )
 
 
 class FocusedArticlePage(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, Union, List
+from typing import Any, Dict, List, Tuple, Union
 
 from django.conf import settings
 from django.db import models

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -279,10 +279,7 @@ class ArticlePage(
         )
 
         return tuple(
-            Page.objects.filter(id__in=related_tags).search(
-                self.article_tag_names,
-                operator="or",
-            )[:3]
+            Page.objects.filter(id__in=related_tags).order_by("-first_published_at")[:3]
         )
 
     @cached_property

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Tuple, Union, List
 
 from django.conf import settings
 from django.db import models
@@ -285,7 +285,7 @@ class ArticlePage(
     @cached_property
     def latest_items(
         self,
-    ) -> Tuple[Union["ArticlePage", "FocusedArticlePage", "RecordArticlePage"], ...]:
+    ) -> List[Union["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]]:
         """
         Return the three most recently published ArticlePages,
         excluding this object.

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -286,18 +286,13 @@ class ArticlePage(
             return ()
 
         # Use search() to prioritise items with the highest number of matches
-        relevant_pages = []
-
-        for page_type in [ArticlePage, FocusedArticlePage, RecordArticlePage]:
-            relevant_pages.extend(
-                page_type.objects.filter(id__in=matching_page_ids).search(
-                    self.article_tag_names,
-                    fields=["article_tag_names"],
-                    operator="or",
-                )
-            )
-
-        return tuple(relevant_pages[:3])
+        return tuple(
+            Page.objects.filter(id__in=matching_page_ids).search(
+                self.article_tag_names,
+                fields=["article_tag_names"],
+                operator="or",
+            )[:3]
+        )
 
     @cached_property
     def latest_items(
@@ -307,8 +302,6 @@ class ArticlePage(
         Return the three most recently published ArticlePages,
         excluding this object.
         """
-
-        similar_query_set = list(self.similar_items)
 
         latest_query_set = []
 
@@ -322,7 +315,7 @@ class ArticlePage(
             )
 
         filter_latest_pages = [
-            page for page in latest_query_set if page not in similar_query_set
+            page for page in latest_query_set if page not in self.similar_items
         ]
 
         return tuple(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -279,10 +279,12 @@ class ArticlePage(
             .filter(tagged_items__tag_id__in=tag_ids)
         )
 
-        return tuple(Page.objects.filter(id__in=related_tags).search(
-            self.article_tag_names,
-            operator="or",
-        )[:3])
+        return tuple(
+            Page.objects.filter(id__in=related_tags).search(
+                self.article_tag_names,
+                operator="or",
+            )[:3]
+        )
 
     @cached_property
     def latest_items(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -271,17 +271,15 @@ class ArticlePage(
             return ()
 
         # Identify 'other' live pages with tags in common
-        matching_page_ids = []
 
-        for page_type in [ArticlePage, FocusedArticlePage, RecordArticlePage]:
-            matching_page_ids.extend(
-                page_type.objects.live()
-                .public()
-                .not_page(self)
-                .filter(tagged_items__tag_id__in=tag_ids)
-                .values_list("id", flat=True)
-                .distinct()
-            )
+        matching_page_ids = (
+            Page.objects.live()
+            .public()
+            .not_page(self)
+            .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
+            .filter(tagged_items__tag_id__in=tag_ids)
+            .values_list("id", flat=True)
+        )
 
         if not matching_page_ids:
             # Avoid unncecssary lookups

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -295,17 +295,14 @@ class ArticlePage(
             latest_query_set.extend(
                 page_type.objects.live()
                 .public()
+                .exclude(id__in=[page.id for page in self.similar_items])
                 .not_page(self)
                 .select_related("teaser_image")
                 .prefetch_related("teaser_image__renditions")
             )
 
-        filter_latest_pages = [
-            page for page in latest_query_set if page not in self.similar_items
-        ]
-
         return sorted(
-                filter_latest_pages, key=lambda x: x.first_published_at, reverse=True
+                latest_query_set, key=lambda x: x.first_published_at, reverse=True
             )[:3]
 
 

--- a/etna/articles/tests/test_similar_items.py
+++ b/etna/articles/tests/test_similar_items.py
@@ -71,16 +71,17 @@ class TestArticlePageSimilarItems(TestCase):
         self.different_tags_page.save()
 
     def test_similar_items_ranking(self):
-        # Items should be in 'best match' order
+        # Items should be in 'most recent' order
         # No draft items should be included
         test_page = ArticlePage.objects.get(id=self.original_page.id)
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(3):
+            print(self.three_matches_page.__dir__())
             self.assertEqual(
-                list(test_page.similar_items),
+                list(page.id for page in test_page.similar_items),
                 [
-                    self.three_matches_page,
-                    self.two_matches_page,
-                    self.single_match_page,
+                    self.three_matches_page.id,
+                    self.two_matches_page.id,
+                    self.single_match_page.id,
                 ],
             )
 

--- a/etna/articles/tests/test_similar_items.py
+++ b/etna/articles/tests/test_similar_items.py
@@ -74,7 +74,7 @@ class TestArticlePageSimilarItems(TestCase):
         # Items should be in 'best match' order
         # No draft items should be included
         test_page = ArticlePage.objects.get(id=self.original_page.id)
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(10):
             self.assertEqual(
                 list(test_page.similar_items),
                 [
@@ -98,5 +98,5 @@ class TestArticlePageSimilarItems(TestCase):
 
     def test_search_prevented_if_no_tag_matches_identified(self):
         test_page = ArticlePage.objects.get(id=self.different_tags_page.id)
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(7):
             self.assertFalse(test_page.similar_items)

--- a/etna/articles/tests/test_similar_items.py
+++ b/etna/articles/tests/test_similar_items.py
@@ -98,5 +98,5 @@ class TestArticlePageSimilarItems(TestCase):
 
     def test_search_prevented_if_no_tag_matches_identified(self):
         test_page = ArticlePage.objects.get(id=self.different_tags_page.id)
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(4):
             self.assertFalse(test_page.similar_items)

--- a/sass/tna-toolkit/_typography.scss
+++ b/sass/tna-toolkit/_typography.scss
@@ -17,7 +17,6 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: $font__heading;
   font-weight: 700;
   line-height: 1.6;
   margin-top: 20px;
@@ -26,21 +25,25 @@ h6,
 
 h1,
 .h1 {
+  font-family: $font__heading;
   font-size: 2.4em;
 }
 
 h2,
 .h2 {
+  font-family: $font__heading;
   font-size: 1.6em;
 }
 
 h3,
 .h3 {
+  font-family: $font__open-sans;
   font-size: 1.3em;
 }
 
 h4,
 .h4 {
+  font-family: $font__open-sans;
   font-size: 1.16em;
 }
 

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -34,7 +34,7 @@
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.similar_items %}
-                        {% include 'includes/card-group-secondary-nav.html' with link_page=item heading="You may also be interested in" card_type="Featured" %}
+                        {% include 'includes/card-group-secondary-nav.html' with link_page=item.specific heading="You may also be interested in" card_type="Featured" %}
                     {% endfor %}
                 </ul>
             {% endif %}


### PR DESCRIPTION
Ticket URL: [UN-780]

## About these changes

Added the three page types to the "More Stories" and "You may also be interested in" sections.

## How to check these changes

Open an article page, scroll to the bottom and see that the new page types are being included.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-780]: https://national-archives.atlassian.net/browse/UN-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ