### PR TITLE
DF-723: FIX Tracking when a user selects a record Covering date filter

### DIFF
--- a/scripts/src/modules/analytics/search/search_filters_tracking.js
+++ b/scripts/src/modules/analytics/search/search_filters_tracking.js
@@ -24,8 +24,10 @@ const pushActiveFilterData = (filterList) => {
         let value = filter.getAttribute('data-filter-value');
         const name = filter.getAttribute('data-filter-name');
 
-        // if filter is a start or end date, set its value to 'Yes'
-        if (name === 'opening_start_date' || name === 'opening_end_date') {
+        // list of filters to ignore the value of (i.e. return 'Yes' instead of the actual value)
+        const ignore_value_filters = ['opening_start_date', 'opening_end_date', 'covering_date_from', 'covering_date_to'];
+
+        if (ignore_value_filters.includes(name)) {
             value = 'Yes';
         }
 


### PR DESCRIPTION
Ticket URL: [DF-723]

## About these changes

Created a list of filters to return "Yes" instead of the filter value. This makes it easier to add/remove the filter values we want to default to "yes" with :)

## How to check these changes

Do a search [(here's one I made earlier!)](http://localhost:8000/search/catalogue/?filter_keyword=&covering_date_from_0=1&covering_date_from_1=2&covering_date_from_2=1000&covering_date_to_0=2&covering_date_to_1=2&covering_date_to_2=2000&collection=WO&opening_start_date_0=&opening_start_date_1=&opening_start_date_2=&opening_end_date_0=&opening_end_date_1=&opening_end_date_2=&q=&sort_by=&sort_order=asc&group=tna) and check the `dataLayer` command in the console. There should be a "Yes" in place of the `search_filter_value` on the `covering_date` and `opening_date` filters.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[DF-723]: https://national-archives.atlassian.net/browse/DF-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ