### PR TITLE
[UN-744] Re-instate card image links to the taborder

### DIFF
--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -24,10 +24,6 @@
       @include explorer-link;
     }
 
-    .aria-desc-card {
-      display: none;
-    }
-
     &__title-label {
       color: $color__grey-700;
       font-family: $font__roboto-mono;
@@ -213,4 +209,8 @@
       margin: 0;
     }
   }
+}
+
+.aria-desc-card {
+    display: none;
 }

--- a/templates/articles/blocks/related_item.html
+++ b/templates/articles/blocks/related_item.html
@@ -7,7 +7,12 @@
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
-        <a href="{{ value.url }}" class="card-group-secondary-nav__image-link" data-card-title="{{ value.title }}" data-card-type="card-group-secondary-nav" aria-hidden="true" tabindex="-1">
+        <a href="{{ value.url }}" 
+        class="card-group-secondary-nav__image-link" 
+        data-card-title="{{ value.title }}" 
+        data-card-type="card-group-secondary-nav"
+        aria-labelledby="card-group-secondary-nav__desc{{ value.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
+        >
             <div class="card-group-secondary-nav__image">
                 <picture>
                     <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
@@ -19,9 +24,15 @@
             </div>
         </a>
             <div class="card-group-secondary-nav__body">
-                <a href="{{ value.url }}" class="card-group-secondary-nav__title-link" data-card-title="{{ value.title }}" data-card-type="card-group-secondary-nav">
-                    <{{ heading_level }} class="card-group-secondary-nav__heading">{{ value.title }}</{{ heading_level }}>
-                </a>
+                <{{ heading_level }} class="card-group-secondary-nav__heading">
+                    <a href="{{ value.url }}" 
+                    class="card-group-secondary-nav__title-link" 
+                    data-card-title="{{ value.title }}" 
+                    data-card-type="card-group-secondary-nav"
+                    id="card-group-secondary-nav__desc{{ value.id }}{% if instance_id %}-{{ instance_id }}{% endif %}">
+                        {{ value.title }}
+                    </a>
+                </{{ heading_level }}>
                 <span class="card-group-secondary-nav__span">{{ value.description|linebreaks }}</span>
             </div>
     </div>

--- a/templates/collections/blocks/promoted_pages.html
+++ b/templates/collections/blocks/promoted_pages.html
@@ -23,7 +23,11 @@
 
         <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
             <div class="card-group-secondary-nav">
-                <a href="{{ promoted_item.url }}" class="card-group-secondary-nav__image-link" data-card-type="card-group-secondary-nav" data-card-title="{{ promoted_item.title }}" aria-hidden="true" tabindex="-1">
+                <a href="{{ promoted_item.url }}" 
+                class="card-group-secondary-nav__image-link" 
+                data-card-type="card-group-secondary-nav" 
+                data-card-title="{{ promoted_item.title }}" 
+                aria-labelledby="card-group-secondary-nav__desc{{ promoted_item.id }}{% if instance_id %}-{{ instance_id }}{% endif %}">
                     <div class="card-group-secondary-nav__image">
                         <picture>
                             <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
@@ -35,9 +39,15 @@
                     </div>
                 </a>
                 <div class="card-group-secondary-nav__body">
-                    <a href="{{ promoted_item.url }}" class="card-group-secondary-nav__title-link" data-card-type="card-group-secondary-nav" data-card-title="{{ promoted_item.title }}">
-                        <h3 class="card-group-secondary-nav__heading">{{ promoted_item.title }}</h3>
-                    </a>
+                    <h3 class="card-group-secondary-nav__heading">
+                        <a href="{{ promoted_item.url }}" 
+                        class="card-group-secondary-nav__title-link" 
+                        data-card-type="card-group-secondary-nav" 
+                        data-card-title="{{ promoted_item.title }}"
+                        id="card-group-secondary-nav__desc{{ promoted_item.id }}{% if instance_id %}-{{ instance_id }}{% endif %}">
+                            {{ promoted_item.title }}
+                        </a>
+                    </h3>
                     <p class="card-group-secondary-nav__paragraph">{{ promoted_item.description }}</p>
                 </div>
             </div>

--- a/templates/home/blocks/featured_external_page.html
+++ b/templates/home/blocks/featured_external_page.html
@@ -17,7 +17,11 @@ from a block for containing external page data or Wagtail page via its URL
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
-        <a href='{{ value.url }}' class="card-group-secondary-nav__image-link" data-card-type="card-group-secondary-nav" data-card-title="{{ value.title }}" tabindex="-1" aria-hidden="true">
+        <a href='{{ value.url }}' 
+        class="card-group-secondary-nav__image-link" 
+        data-card-type="card-group-secondary-nav" 
+        data-card-title="{{ value.title }}"
+        aria-labelledby="card-group-secondary-nav__desc{{ value.id }}{% if instance_id %}-{{ instance_id }}{% endif %}">
             <div class="card-group-secondary-nav__image">
                 <picture>
                     <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
@@ -28,10 +32,17 @@ from a block for containing external page data or Wagtail page via its URL
                 </picture>
             </div>
         </a>
-            <div class="card-group-secondary-nav__body">
-                <a href='{{ value.url }}' class="card-group-secondary-nav__title-link" data-card-type="card-group-secondary-nav" data-card-title="{{ value.title }}"><h3 class="card-group-secondary-nav__heading">{{ value.title }}</h3></a>
-                <p class="card-group-secondary-nav__paragraph">{{ value.description }}</p>
-            </div>
-
+        <div class="card-group-secondary-nav__body">
+            <h3 class="card-group-secondary-nav__heading">
+                <a href='{{ value.url }}'
+                id="card-group-secondary-nav__desc{{ value.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" 
+                class="card-group-secondary-nav__title-link" 
+                data-card-type="card-group-secondary-nav" 
+                data-card-title="{{ value.title }}">
+                    {{ value.title }}
+                </a>
+            </h3>
+            <p class="card-group-secondary-nav__paragraph">{{ value.description }}</p>
+        </div>
     </div>
 </li>

--- a/templates/home/blocks/featured_page.html
+++ b/templates/home/blocks/featured_page.html
@@ -16,7 +16,11 @@ containging a page with fields to optionally override some fields.
 
 <li class="col-sm-12 col-md-6 col-lg-4 mb-3">
     <div class="card-group-secondary-nav">
-        <a href='{{ value.page.url }}' class="card-group-secondary-nav__image-link" data-card-type="card-group-secondary-nav" data-card-title="{{ value.title | default:value.page.title }}" aria-hidden="true" tabindex="-1">
+        <a href='{{ value.page.url }}' 
+        class="card-group-secondary-nav__image-link" 
+        data-card-type="card-group-secondary-nav" 
+        data-card-title="{{ value.title | default:value.page.title }}"
+        aria-labelledby="card-group-secondary-nav__desc{{ value.id | default:value.page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}">
             <div class="card-group-secondary-nav__image">
                 <picture>
                     <source media="(max-width: 768px)" srcset="{{ teaser_image_extra_large.url }}">
@@ -28,9 +32,15 @@ containging a page with fields to optionally override some fields.
             </div>
         </a>
         <div class="card-group-secondary-nav__body">
-            <a href='{{ value.page.url }}' class="card-group-secondary-nav__title-link" data-card-type="card-group-secondary-nav" data-card-title="{{ value.title | default:value.page.title }}">
-                <h3 class="card-group-secondary-nav__heading">{{ value.title | default:value.page.title }}</h3>
-            </a>
+            <h3 class="card-group-secondary-nav__heading">
+                <a href='{{ value.page.url }}'
+                id="card-group-secondary-nav__desc{{ value.id | default:value.page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
+                class="card-group-secondary-nav__title-link"
+                data-card-type="card-group-secondary-nav"
+                data-card-title="{{ value.title | default:value.page.title }}">
+                    {{ value.title | default:value.page.title }}
+                </a>
+            </h3>
             <p class="card-group-secondary-nav__paragraph">{{ value.description }}</p>
         </div>
     </div>

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -6,7 +6,11 @@
     {% endif %}
     <div class="featured-article u-margin-m">
         {% if page.teaser_image %}
-            <a href="{% pageurl page %}" class="featured-article__image-link" tabindex="-1" aria-hidden="true" data-component-name="Featured Article: {{ page.title }}" data-link-type="Image" {% if page.is_newly_published %}data-label="New"{% endif %}>
+            <a href="{% pageurl page %}"
+            class="featured-article__image-link"
+            aria-labelledby="article-desc{{ page.id }}"
+            data-component-name="Featured Article: {{ page.title }}"
+            data-link-type="Image" {% if page.is_newly_published %}data-label="New"{% endif %}>
                 <picture>
                     {% image page.teaser_image fill-500x400-c100 as teaser %}
                     <source media="(max-width: 768px)" srcset="{{ teaser.url }}"/>
@@ -29,7 +33,7 @@
                 {% endif %}
             </h2>
 
-            <p id="article-desc" class="aria-desc">This is a link to a new story about {{ page.title }}</p>
+            <p id="article-desc{{ page.id }}" class="aria-desc">Read about {{ page.title }}</p>
 
             <p>{{ page.teaser_text }}</p>
             <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Article: {{ page.title }}" data-link-type="Button" data-link="Read" {% if page.is_newly_published %}data-label="New"{% endif %}>Read about {{ page.title }}</a>

--- a/templates/includes/related-articles-highlight-cards.html
+++ b/templates/includes/related-articles-highlight-cards.html
@@ -6,12 +6,11 @@
             {% if featured_article %}
                 <div class="highlight-cards__card highlight-cards__card--highlight highlight-cards__link">
                     <a href="{% pageurl featured_article %}"
-                    aria-hidden="true"
-                    tabindex="-1"
                     data-component-name="Featured card: {{ title }} Featured record article"
                     data-link-type="Card image"
                     data-card-position="0"
-                    data-card-title="{{ featured_article.title }}">
+                    data-card-title="{{ featured_article.title }}"
+                    aria-labelledby="highlight-cards__card-desc{{ featured_article.id }}">
                         {# Desktop/ tablet image #}
                         {% image featured_article.teaser_image fill-534x413-c100 format-webp as image_webp %}
                         <source srcset="{{ image_webp.url }}"
@@ -27,6 +26,7 @@
                     <div class="highlight-cards__content">
                         <h3 class="highlight-cards__card_title">
                             <a href="{% pageurl featured_article %}"
+                            id="highlight-cards__card-desc{{ featured_article.id }}"
                             class="highlight-cards__card-title-link"
                             data-component-name="Featured card: {{ title }} Featured record article"
                             data-link-type="Card text"
@@ -45,8 +45,7 @@
             {% for article in articles %}
                 <div class="highlight-cards__card highlight-cards__card--normal highlight-cards__link">
                     <a href="{% pageurl article %}"
-                    aria-hidden="true"
-                    tabindex="-1"
+                    aria-labelledby="highlight-cards__card-desc{{ article.id }}"
                     data-component-name="Featured card: {{ title }}"
                     data-link-type="Card image"
                     {% if featured_article %}
@@ -69,6 +68,7 @@
                     <div class="highlight-cards__card__content">
                         <h3 class="highlight-cards__card_title">
                             <a href="{% pageurl article %}"
+                            id="highlight-cards__card-desc{{ article.id }}"
                             class="highlight-cards__card-title-link"
                             data-component-name="Featured card: {{ title }}"
                             data-link-type="Card text"

--- a/templates/includes/related-highlight-cards.html
+++ b/templates/includes/related-highlight-cards.html
@@ -6,13 +6,11 @@
             {% for card in cards %}
                 <div class="related-highlight-cards__card">
                     <a href="{{ card.url }}"
-                    {% comment %} remove image link from taborder and hide from screenreaders {% endcomment %}
-                    aria-hidden="true"
-                    tabindex="-1"
                     data-component-name="Featured card: {{ title }} highlights in pictures"
                     data-link-type="Card image"
                     data-card-position="{{ forloop.counter0 }}"
-                    data-card-title="{{ card.title }}">
+                    data-card-title="{{ card.title }}"
+                    aria-labelledby="related-highlight-cards__card-desc{{ card.id }}{% if instance_id %}-{{ instance_id }}{% endif %}">
                         <picture>
                         {% image card.teaser_image fill-374x370-c100 format-webp as mobile_webp_image %}
                         <source media="(max-width: 370px)"
@@ -34,7 +32,7 @@
                     <div class="related-highlight-cards__content">
                         <h3 class="related-highlight-cards__card-title" id="related-highlight-card-title-{{ forloop.counter }}">
                             <a href="{{ card.url }}"
-                                class="related-highlight-cards__card-title-link"
+                                id="related-highlight-cards__card-desc{{ card.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"                                class="related-highlight-cards__card-title-link"
                                 data-component-name="Featured card: {{ title }} highlights in pictures"
                                 data-link-type="Card text"
                                 data-card-position="{{ forloop.counter0 }}"


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/UN/boards/75?modal=detail&selectedIssue=UN-744

## About these changes

This removes `aria-hidden` and `tabindex="-1"` and replaces them with an `aria-labelledby` attribute for card image links, to make sure they are accessible to keyboard users. 

## How to check these changes

Check instances of cards and ensure the image links can be accessed via keyboard using the tab key and that the aria-label is working correctly. In most cases the aria-label is pointing to the title of the card, unless an alternative is provided. As long as the link text is not ambigious and is the same as the title link, this should not be an accessibility issue. 

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [ ] Waited for all CI jobs to pass before requesting a review.
- [ ] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
