### PR TITLE
Reinstate frontend styles, fix issues, update footer classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.1.0",
       "license": "ISC",
       "dependencies": {
+        "@nationalarchives/frontend": "^0.1.8-prerelease",
         "jest": "~29.5",
         "jquery": "~3.7",
         "openseadragon": "~4.1"
@@ -2385,6 +2386,15 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
+    "node_modules/@nationalarchives/frontend": {
+      "version": "0.1.8-prerelease",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/frontend/-/frontend-0.1.8-prerelease.tgz",
+      "integrity": "sha512-/7LqmZdGVKvhwVl9hjAqbRq6d6oGICp2cQQwPjxQttRjEpq3UIr4oV7K44kPBCkRDaLZXLwbB4kQXOK8tZp1Lw==",
+      "engines": {
+        "node": "18.x",
+        "npm": "9.x"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "## Local development",
   "private": true,
   "scripts": {
-    "compile:css": "sass --watch sass/etna.scss:templates/static/css/dist/etna.css",
+    "compile:css": "sass --watch --quiet-deps --load-path=node_modules sass/etna.scss:templates/static/css/dist/etna.css",
     "start": "npx webpack --config webpack.config.js --mode=development --watch",
     "test": "jest --coverage"
   },
@@ -29,6 +29,7 @@
     "webpack-cli": "~5.1"
   },
   "dependencies": {
+    "@nationalarchives/frontend": "^0.1.8-prerelease",
     "jest": "~29.5",
     "jquery": "~3.7",
     "openseadragon": "~4.1"

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -1,3 +1,5 @@
+@use '../node_modules/@nationalarchives/frontend/nationalarchives/tools/media';
+
 /*
 
 ==============
@@ -105,7 +107,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import 'includes/new_cards';
 @import 'includes/highlight-gallery';
 @import 'includes/highlight-cards';
-@import "includes/highlight-intro";
+// @import "includes/highlight-intro";
 @import 'includes/utilities';
 @import "includes/archive-description";
 @import "includes/archive-collections";
@@ -126,8 +128,32 @@ New styles
 
 Modified to match the existing site (for now)
 
+*/
 
 $largest-small-device: 992px;
+
+@import '@nationalarchives/frontend/nationalarchives/all';
+
+*:focus {
+    outline: none !important;
+}
+
+a,
+button,
+select,
+input[type="checkbox"],
+input[type="radio"],
+input[type="button"],
+input[type="submit"] {
+    &:focus {
+        outline: 0.3125rem solid #004c7e !important;
+        outline-offset: 0.125rem !important;
+    }
+
+    [class*="--dark"] & {
+        outline-color: #00b0ff !important;
+    }
+}
 
 .tna-hero {
     margin-bottom: 2rem;
@@ -165,4 +191,3 @@ $largest-small-device: 992px;
         margin-bottom: 0;
     }
 }
-*/

--- a/sass/includes/_buttons.scss
+++ b/sass/includes/_buttons.scss
@@ -86,4 +86,5 @@
   height: 25px;
   //margin-left:1em;
   margin-right: 0.5em;
+  display: inline-block;
 }

--- a/sass/includes/_footer.scss
+++ b/sass/includes/_footer.scss
@@ -1,9 +1,9 @@
-.tna-footer {
+.etna-footer {
     background:white !important;
     color:black !important;
     /*AJ to address as part of workflow streamlining piece */
     &__body {
-        .tna-footer__list-item {
+        .etna-footer__list-item {
             margin-bottom: .25rem;
         }
         &-heading {
@@ -15,7 +15,7 @@
 
         font-size: 0.85rem;
 
-        .tna-footer__social-media-icon {
+        .etna-footer__social-media-icon {
             height: 2.187rem;
             padding: .5rem;
             box-sizing: content-box;
@@ -29,6 +29,10 @@
         &-main-title {
             font-size: 1.6rem;
         }
+    }
+
+    img {
+        display: inline-block;
     }
 }
 

--- a/sass/includes/_record-matters.scss
+++ b/sass/includes/_record-matters.scss
@@ -39,6 +39,7 @@
     width: 1.5rem;
     height: 1.5rem;
     margin-left: 0.5rem;
+    display: inline-block;
   }
 
   &__content {

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,105 +1,105 @@
 {% load static feedback_tags %}
-<footer class="tna-footer" data-container-name="footer">
+<footer class="etna-footer" data-container-name="footer">
     <h2 class="sr-only">Footer</h2>
 
     {% render_feedback_prompt %}
 
-    <div class="tna-footer__heading tna-bg--dark">
+    <div class="etna-footer__heading tna-bg--dark">
         <div class="container">
             <div class="row">
                 <div class="col-md-12 text-center">
-                    <h3 class="tna-footer__heading-main-title"><span class="sr-only">Address for </span>The National Archives</h3>
+                    <h3 class="etna-footer__heading-main-title"><span class="sr-only">Address for </span>The National Archives</h3>
                     <p>Kew, Richmond TW9 4DU</p>
                 </div>
             </div>
         </div>
     </div>
 
-    <div class="tna-footer__body tna-bg--dark">
+    <div class="etna-footer__body tna-bg--dark">
         <div class="container pb-3">
             <div class="row">
                 <div class="col-6 col-md-3">
-                    <h3 class="tna-footer__body-heading">Find out more</h3>
+                    <h3 class="etna-footer__body-heading">Find out more</h3>
                     <ul class="tna-ul--no-bullet">
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/contact-us/" data-link="Contact us">Contact us</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/about/press-room/" data-link="Press room">Press room</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/about/jobs/" data-link="Jobs and careers">Jobs and careers</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/about/get-involved/friends-of-the-national-archives/" data-link="Friends of The National Archives">Friends of The National Archives</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/contact-us/" data-link="Contact us">Contact us</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/about/press-room/" data-link="Press room">Press room</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/about/jobs/" data-link="Jobs and careers">Jobs and careers</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/about/get-involved/friends-of-the-national-archives/" data-link="Friends of The National Archives">Friends of The National Archives</a></li>
                     </ul>
                 </div>
                 <div class="col-6 col-md-3">
-                    <h3 class="tna-footer__body-heading">Site help</h3>
+                    <h3 class="etna-footer__body-heading">Site help</h3>
                     <ul class="tna-ul--no-bullet">
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/help/" data-link="Help">Help</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/help/a-to-z/" data-link="Website A-Z index">Website A-Z index</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/help/web-accessibility/" data-link="Accessibility">Accessibility</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/help/" data-link="Help">Help</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/help/a-to-z/" data-link="Website A-Z index">Website A-Z index</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/help/web-accessibility/" data-link="Accessibility">Accessibility</a></li>
                     </ul>
                 </div>
                 <div class="col-6 col-md-3">
-                    <h3 class="tna-footer__body-heading">Websites</h3>
+                    <h3 class="etna-footer__body-heading">Websites</h3>
                     <ul class="tna-ul--no-bullet">
-                        <li class="tna-footer__list-item"><a href="https://blog.nationalarchives.gov.uk/" data-link="Blog">Blog</a></li>
-                        <li class="tna-footer__list-item"><a href="https://media.nationalarchives.gov.uk/" data-link="Podcasts and videos">Podcasts and videos</a></li>
-                        <li class="tna-footer__list-item"><a href="https://shop.nationalarchives.gov.uk/" data-link="Shop">Shop</a></li>
-                        <li class="tna-footer__list-item"><a href="https://images.nationalarchives.gov.uk/" data-link="Image library">Image library</a></li>
+                        <li class="etna-footer__list-item"><a href="https://blog.nationalarchives.gov.uk/" data-link="Blog">Blog</a></li>
+                        <li class="etna-footer__list-item"><a href="https://media.nationalarchives.gov.uk/" data-link="Podcasts and videos">Podcasts and videos</a></li>
+                        <li class="etna-footer__list-item"><a href="https://shop.nationalarchives.gov.uk/" data-link="Shop">Shop</a></li>
+                        <li class="etna-footer__list-item"><a href="https://images.nationalarchives.gov.uk/" data-link="Image library">Image library</a></li>
                     </ul>
                 </div>
                 <div class="col-6 col-md-3">
-                    <h3 class="tna-footer__body-heading">Legal</h3>
+                    <h3 class="etna-footer__body-heading">Legal</h3>
                     <ul class="tna-ul--no-bullet">
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/" data-link="Terms of use">Terms of use</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/privacy.htm" data-link="Privacy policy">Privacy policy</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/cookies/" data-link="Cookies">Cookies</a></li>
-                        <li class="tna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/our-fees.htm" data-link="Our fees">Our fees</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/" data-link="Terms of use">Terms of use</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/privacy.htm" data-link="Privacy policy">Privacy policy</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/cookies/" data-link="Cookies">Cookies</a></li>
+                        <li class="etna-footer__list-item"><a href="https://www.nationalarchives.gov.uk/legal/our-fees.htm" data-link="Our fees">Our fees</a></li>
                     </ul>
                 </div>
             </div>
         </div>
     </div>
-    <div class="tna-footer__social-media-links tna-bg--dark">
+    <div class="etna-footer__social-media-links tna-bg--dark">
         <div class="container pb-3">
             <div class="row justify-content-md-center text-center">
                 <h3 class="sr-only">Follow us on social media</h3>
                 <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://twitter.com/UKNatArchives" class="d-inline-block" target="_blank" rel="noopener noreferrer">
-                        <img src="{% static 'images/fontawesome-svgs/twitter.svg' %}" class="tna-footer__social-media-icon" alt="" width="35" height="35"/><br>
+                        <img src="{% static 'images/fontawesome-svgs/twitter.svg' %}" class="etna-footer__social-media-icon" alt="" width="35" height="35"/><br>
                         <span>Twitter</span>
                     </a>
                 </div>
                 <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://www.youtube.com/c/TheNationalArchivesUK" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="YouTube">
-                        <img src="{% static 'images/fontawesome-svgs/youtube.svg' %}" class="tna-footer__social-media-icon" alt="" width="40" height="35"/><br>
+                        <img src="{% static 'images/fontawesome-svgs/youtube.svg' %}" class="etna-footer__social-media-icon" alt="" width="40" height="35"/><br>
                         <span>YouTube</span>
                     </a>
                 </div>
                 <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://www.flickr.com/photos/nationalarchives" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Flickr">
-                        <img src="{% static 'images/fontawesome-svgs/flickr.svg' %}" class="tna-footer__social-media-icon" alt="" width="31" height="35"/><br>
+                        <img src="{% static 'images/fontawesome-svgs/flickr.svg' %}" class="etna-footer__social-media-icon" alt="" width="31" height="35"/><br>
                         <span>Flickr</span>
                     </a>
                 </div>
                 <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://www.facebook.com/TheNationalArchives" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Facebook">
-                        <img src="{% static 'images/fontawesome-svgs/facebook.svg' %}" class="tna-footer__social-media-icon" alt="" width="35" height="35"/><br>
+                        <img src="{% static 'images/fontawesome-svgs/facebook.svg' %}" class="etna-footer__social-media-icon" alt="" width="35" height="35"/><br>
                         <span>Facebook</span>
                     </a>
                 </div>
                 <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://www.instagram.com/nationalarchivesuk/" class="d-inline-block" target="_blank" rel="noopener noreferrer" data-link="Instagram">
-                        <img src="{% static 'images/fontawesome-svgs/instagram.svg' %}" class="tna-footer__social-media-icon" alt="" width="31" height="35"/><br>
+                        <img src="{% static 'images/fontawesome-svgs/instagram.svg' %}" class="etna-footer__social-media-icon" alt="" width="31" height="35"/><br>
                         <span>Instagram</span>
                     </a>
                 </div>
                 <div class="col-4 col-sm-4 col-md-2">
                     <a href="https://www.nationalarchives.gov.uk/rss/" class="d-inline-block" data-link="RSS">
-                        <img src="{% static 'images/fontawesome-svgs/rss.svg' %}" class="tna-footer__social-media-icon" alt="" width="31" height="35"/><br>
+                        <img src="{% static 'images/fontawesome-svgs/rss.svg' %}" class="etna-footer__social-media-icon" alt="" width="31" height="35"/><br>
                         <span>RSS</span>
                     </a>
                 </div>
             </div>
         </div>
     </div>
-    <div class="tna-footer__base tna-bg--dark">
+    <div class="etna-footer__base tna-bg--dark">
         <div class="container pb-3">
             <div class="row justify-content-md-center">
                 <div class="col-md-2 text-center">

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags wagtailcore_tags %}
-<div class="highlight-intro">
+<!-- <div class="highlight-intro">
     <picture>
         {% image background_image fill-1440x500 format-webp as webp_img %}
         <source srcset="{{ webp_img.url }}"
@@ -34,10 +34,8 @@
             </div>
         </div>
     </div>
-</div>
+</div> -->
 
-{% comment %}
-Removed until front-end toolkit is fixed
 <!-- NEW -->
 
 <!-- <header class="tna-hero">
@@ -97,6 +95,3 @@ Removed until front-end toolkit is fixed
         </div>
     </div>
 </header>
-
-
-{% endcomment %}


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/UN-742

## About these changes

Reinstates updates from https://github.com/nationalarchives/ds-wagtail/pull/1127 (undone in https://github.com/nationalarchives/ds-wagtail/pull/1138) but fixes issues:

- `tna-footer` namespace updated to `etna-footer` so as not to cause conflicts
- Images requiring `display: inline-block;` fixed
- Focus styles fixed

This should then allow us to move forward with making a first stable version (`v1.0.0`) of `@nationalarchives/frontend`

Also added `load-path` parameter into the SASS compilation to allow import not to have to use relative `../node_modules` path.