### PR TITLE
DF-740: Fix archive links details page and search results

### DIFF
--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -10,14 +10,17 @@ register = template.Library()
 
 @register.simple_tag
 def record_url(
-    record: Record, is_editorial: bool = False, order_from_discovery: bool = False
+    record: Record,
+    is_editorial: bool = False,
+    order_from_discovery: bool = False,
+    use_non_reference_number_url: bool = False,
 ) -> str:
     """
     Return the URL for the provided `record`, which should always be a
     fully-transformed `etna.records.models.Record` instance.
 
-    Handling of Iaid as priority to allow Iaid in disambiguation pages when
-    returning more than one record
+    use_non_reference_number_url: set True to override refernce number to disambiguation page
+    (multiple iaid share the same refernce number) when its not required.
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
@@ -30,7 +33,12 @@ def record_url(
         else:
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
-    return record.url if record is not None else ""
+    if record:
+        if use_non_reference_number_url:
+            return record.non_reference_number_url
+        else:
+            return record.url
+    return ""
 
 
 @register.simple_tag

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -19,8 +19,8 @@ def record_url(
     Return the URL for the provided `record`, which should always be a
     fully-transformed `etna.records.models.Record` instance.
 
-    use_non_reference_number_url: set True to override refernce number to disambiguation page
-    (multiple iaid share the same refernce number) when its not required.
+    use_non_reference_number_url: set True to override reference number to disambiguation page
+    (multiple iaid share the same reference number) when its not required.
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -408,6 +408,9 @@ class RecordModelTests(SimpleTestCase):
     def test_repository_attr(self):
         self.assertEqual(self.record.repository.iaid, "A13530124")
         self.assertEqual(self.record.repository.url, "/catalogue/ref/66/")
+        self.assertEqual(
+            self.record.repository.non_reference_number_url, "/catalogue/id/A13530124/"
+        )
 
 
 @override_settings(KONG_CLIENT_BASE_URL="https://kong.test")

--- a/etna/records/tests/test_templatetags.py
+++ b/etna/records/tests/test_templatetags.py
@@ -10,7 +10,16 @@ class TestRecordURLTag(SimpleTestCase):
             "repository": {
                 "@admin": {
                     "id": "A13531109",
-                }
+                },
+                "identifier": [
+                    {
+                        "primary": True,
+                        "reference_number": "66",
+                        "type": "reference number",
+                        "value": "66",
+                    },
+                    {"type": "Archon number", "value": "66"},
+                ],
             },
             "@template": {
                 "details": {
@@ -224,9 +233,37 @@ class TestRecordURLTag(SimpleTestCase):
 
     def test_repository_links(self):
         for attribute_name, expected_result in (
-            ("record_instance", "/catalogue/id/A13531109/"),
+            ("record_instance", "/catalogue/ref/66/"),
             ("record_instance_no_reference", ""),
         ):
             with self.subTest(attribute_name):
                 source = getattr(self, attribute_name)
                 self.assertEqual(record_url(source.repository), expected_result)
+
+    def test_non_reference_number_url(self):
+        # tests using raw source
+        for attribute_name, expected_result in (
+            ("record_instance", "/catalogue/id/e7e92a0b-3666-4fd6-9dac-9d9530b0888c/"),
+            (
+                "record_instance_no_reference",
+                "/catalogue/id/e7e92a0b-3666-4fd6-9dac-9d9530b0888c/",
+            ),
+        ):
+            with self.subTest(attribute_name):
+                source = getattr(self, attribute_name)
+                self.assertEqual(
+                    record_url(source, use_non_reference_number_url=True),
+                    expected_result,
+                )
+
+        # tests using repository attribute
+        for attribute_name, expected_result in (
+            ("record_instance", "/catalogue/id/A13531109/"),
+            ("record_instance_no_reference", ""),
+        ):
+            with self.subTest(attribute_name):
+                source = getattr(self, attribute_name)
+                self.assertEqual(
+                    record_url(source.repository, use_non_reference_number_url=True),
+                    expected_result,
+                )

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -22,7 +22,7 @@
                     {% if record.hierarchy|length <= 2 %}
                         <li class="hierarchy-short-panel__list-item">
                             <span class="hierarchy-short-panel__level">
-                                <a href="{% record_url record.repository %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
+                                <a href="{% record_url record.repository use_non_reference_number_url=True %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
                             </span>({{ record.template.heldBy }})
                         </li>
                     {% endif %}
@@ -60,7 +60,7 @@
                 {% else %}
                     <li class="hierarchy-short-panel__list-item">
                         <span class="hierarchy-short-panel__level">
-                            <a href="{% record_url record.repository %}">Archive</a>
+                            <a href="{% record_url record.repository use_non_reference_number_url=True %}">Archive</a>
                         </span>({{ record.template.heldBy }})
                     </li>
                     <li class="hierarchy-short-panel__list-item hierarchy--short-panel__list-item--current">
@@ -86,7 +86,7 @@
             <div class="hierarchy-full-panel__bar-container-outer">
                 <div class="hierarchy-full-panel__bar-container-inner hierarchy-full-panel__bar-container-inner--level-1"></div>
                 <div class="hierarchy-full-panel__text-container">
-                    <p class="hierarchy-full-panel__text-level">This record is held at: <a href="{% record_url record.repository %}" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy}}</a></p>
+                    <p class="hierarchy-full-panel__text-level">This record is held at: <a href="{% record_url record.repository use_non_reference_number_url=True %}" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy}}</a></p>
                     <p class="hierarchy-full-panel__text-title">Located at DATA TO GO HERE</p> <!--TODO API data needs to contain the location of the archive as well-->
                 </div>
             </div>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -27,7 +27,7 @@
                     </picture>
                 </div>
             {% endif %}
-            <a href="{% record_url record %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record use_non_reference_number_url=True %}{% else %}{% record_url record %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}<span class="sr-only">{{ record.reference_number }}</span>{% endif %}
                 {{ record.summary_title }}
             </a>

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -13,7 +13,7 @@
 <li class="search-results__list-card" data-iaid="{{ record.iaid }}" data-score="{{ record.score }}">
     <div class="search-results__list-card-details">
         <h3 class="search-results__list-card-heading">
-            <a href="{% record_url record %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record use_non_reference_number_url=True %}{% else %}{% record_url record %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}
                 <span class="sr-only">Reference number {{ record.reference_number }}: </span>
                 {% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-740

## About these changes

Show Archive links with iaid's in Record Details page and Search results

## How to check these changes

1) Select records from the results from Catalogue buckets
or
View Archive links on the record details pages in these sections of Hierarchy
- You are here - Archive link
- Detailed catalogue location (visible from show detailed view) - This record is held At link
Ex: using refs and ids
http://127.0.0.1:8000/catalogue/ref/ADM/
http://127.0.0.1:8000/catalogue/ref/J/77/3417/4284/
http://127.0.0.1:8000/catalogue/id/e48bb766-1199-4e23-8bd8-b179338cd831/
http://127.0.0.1:8000/catalogue/id/C4122893/

2) View archive records with iaid's in the results area from Find an Archive bucket
http://127.0.0.1:8000/search/catalogue/?group=archive
http://127.0.0.1:8000/search/catalogue/?group=archive&display=grid

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
