### PR TITLE
DF-505: Hide available to download for closed records, show closure status

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -749,3 +749,8 @@ ARCHIVE_NRA_RECORDS_COLLECTION = [
         "long_display_name": "Paper catalogues available to view at The National Archives",
     },
 ]
+
+CLOSURE_CLOSED_STATUS = [
+    "Closed Or Retained Document, Closed Description",
+    "Closed Or Retained Document, Open Description",
+]

--- a/etna/ciim/tests/fixtures/record.json
+++ b/etna/ciim/tests/fixtures/record.json
@@ -349,6 +349,7 @@
                     "@template": {
                         "details": {
                             "accessCondition": "Open unless otherwise stated",
+                            "closureStatus": "Fake value:Open Document, Open Description",
                             "arrangement": "<span class=\"arrangement\"><p>The files are registered in a numbered series according to their subject and these numbers are listed in the appendix to the series list.</p></span>",
                             "dateCreated": "1885-1979",
                             "description": "<span class=\"scopecontent\"><p>This series contains papers concering a wide variety of legal matters referred to the Law Officers for their advice or approval and includes applications for the Attorney General's General Fiat for leave to appeal to the House of Lords in criminal cases.</p><p>Also included are a number of opinions, more of which can be found in <a class=\"extref\" href=\"C10298\">LO 3</a></p></span>",

--- a/etna/records/field_labels.py
+++ b/etna/records/field_labels.py
@@ -16,4 +16,5 @@ FIELD_LABELS = {
     "related_records": "Related records",
     "related_articles": "Related content",
     "related_materials": "Related material",
+    "closure": "Closure Status",
 }

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -901,6 +901,10 @@ class Record(DataLayerMixin, APIModel):
                     return former_name_authority_reference
         return ""
 
+    @cached_property
+    def closure_status(self) -> str:
+        return extract(self.get("@template", {}), "details.closureStatus", default="")
+
 
 @dataclass
 class Image:

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -413,6 +413,11 @@ class RecordModelTests(SimpleTestCase):
             self.record.repository.non_reference_number_url, "/catalogue/id/A13530124/"
         )
 
+    def test_closure_status(self):
+        self.assertEqual(
+            self.record.closure_status, "Fake value:Open Document, Open Description"
+        )
+
 
 @override_settings(KONG_CLIENT_BASE_URL="https://kong.test")
 class UnexpectedParsingIssueTest(SimpleTestCase):

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -25,6 +25,7 @@ from ..articles.models import ArticleIndexPage, ArticlePage
 from ..ciim.client import Aggregation, SortBy, SortOrder, Stream, Template
 from ..ciim.constants import (
     CATALOGUE_BUCKETS,
+    CLOSURE_CLOSED_STATUS,
     FEATURED_BUCKETS,
     WEBSITE_BUCKETS,
     Bucket,
@@ -360,6 +361,7 @@ class BaseSearchView(SearchDataLayerMixin, KongAPIMixin, GETFormView):
             result_count=self.get_result_count(),
             bucketkeys=BucketKeys,
             searchtabs=SearchTabs,
+            closure_closed_status=CLOSURE_CLOSED_STATUS,
             **kwargs,
         )
 

--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -52,6 +52,12 @@
                     <td>{{ record.legal_status }}</td>
                 </tr>
             {% endif %}
+            {% if record.closure_status %}
+                <tr>
+                    <th scope="row">{{ 'closure'|as_label }}</th>
+                    <td>{{ record.closure_status }}</td>
+                </tr>
+            {% endif %}
             {% if record.access_condition %}
                 <tr>
                     <th scope="row">{{ 'access_condition'|as_label }}</th>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -95,22 +95,21 @@
         </dl>
 
 
-        {% if record.is_digitised %}
-            {% if record.closure_status not in closure_closed_status %}
-                <div class="search-results__list-card-delivery-options--grid">
+    {% if record.is_digitised %}
+        {% if record.closure_status not in closure_closed_status %}
+            <div class="search-results__list-card-delivery-options--grid">
 
-                    <a href="{% record_url record %}" aria-hidden="true" tabindex="-1" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search result thumbnail link" data-position="{{forloop.counter0}}" search-bucket="{{ buckets.current.label }}">
+                <a href="{% record_url record %}" aria-hidden="true" tabindex="-1" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search result thumbnail link" data-position="{{forloop.counter0}}" search-bucket="{{ buckets.current.label }}">
 
-                        <img src="{% static 'images/grid-placeholder.png' %}"  class="search-results__list-card-delivery-options-img search-image-grid" alt="" />
-                    </a>
-                    <a href="{% record_url record %}" class="search-results__list-card-delivery-options-link">
-                        <p class="search-results__list-card-delivery-options-desc search-results-grid">
-                            <span class="sr-only">{{ record.reference_prefixed_summary_title }} is</span>
-                            Available online
-                        </p>
-                    </a>
-                </div>
-            {% endif %}
+                    <img src="{% static 'images/grid-placeholder.png' %}"  class="search-results__list-card-delivery-options-img search-image-grid" alt="" />
+                </a>
+                <a href="{% record_url record %}" class="search-results__list-card-delivery-options-link">
+                    <p class="search-results__list-card-delivery-options-desc search-results-grid">
+                        <span class="sr-only">{{ record.reference_prefixed_summary_title }} is</span>
+                        Available online
+                    </p>
+                </a>
+            </div>
         {% endif %}
     {% endif %}
 </li>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -95,19 +95,22 @@
         </dl>
 
 
-    {% if record.is_digitised %}
-    <div class="search-results__list-card-delivery-options--grid">
+        {% if record.is_digitised %}
+            {% if record.closure_status not in closure_closed_status %}
+                <div class="search-results__list-card-delivery-options--grid">
 
-        <a href="{% record_url record %}" aria-hidden="true" tabindex="-1" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search result thumbnail link" data-position="{{forloop.counter0}}" search-bucket="{{ buckets.current.label }}">
+                    <a href="{% record_url record %}" aria-hidden="true" tabindex="-1" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search result thumbnail link" data-position="{{forloop.counter0}}" search-bucket="{{ buckets.current.label }}">
 
-            <img src="{% static 'images/grid-placeholder.png' %}"  class="search-results__list-card-delivery-options-img search-image-grid" alt="" />
-        </a>
-        <a href="{% record_url record %}" class="search-results__list-card-delivery-options-link">
-            <p class="search-results__list-card-delivery-options-desc search-results-grid">
-                <span class="sr-only">{{ record.reference_prefixed_summary_title }} is</span>
-                Available online
-            </p>
-        </a>
-    </div>
+                        <img src="{% static 'images/grid-placeholder.png' %}"  class="search-results__list-card-delivery-options-img search-image-grid" alt="" />
+                    </a>
+                    <a href="{% record_url record %}" class="search-results__list-card-delivery-options-link">
+                        <p class="search-results__list-card-delivery-options-desc search-results-grid">
+                            <span class="sr-only">{{ record.reference_prefixed_summary_title }} is</span>
+                            Available online
+                        </p>
+                    </a>
+                </div>
+            {% endif %}
+        {% endif %}
     {% endif %}
 </li>

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -67,17 +67,19 @@
     {% if record.is_digitised or apply_teaser_image %}
     <div class="search-results__list-card-image">
         {% if record.is_digitised %}
-        <div class="search-results__list-card-delivery-options">
-            <a href="{% record_url record %}" class="search-results__list-card-image-anchor" aria-hidden="true" tabindex="-1" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search result thumbnail link" data-position="{{forloop.counter0}}" search-bucket="{{ buckets.current.label }}">
-                <img src="{% static 'images/list-placeholder.png' %}" class="search-results__list-card-delivery-options-img" alt="" />
-            </a>
-            <a href="{% record_url record %}" class="search-results__list-card-delivery-options-link">
-                <p class="search-results__list-card-delivery-options-desc">
-                    <span class="sr-only">{{ record.reference_prefixed_summary_title }} is</span>
-                    Available online
-                </p>
-            </a>
-        </div>
+            {% if record.closure_status not in closure_closed_status %}
+                <div class="search-results__list-card-delivery-options">
+                    <a href="{% record_url record %}" class="search-results__list-card-image-anchor" aria-hidden="true" tabindex="-1" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search result thumbnail link" data-position="{{forloop.counter0}}" search-bucket="{{ buckets.current.label }}">
+                        <img src="{% static 'images/list-placeholder.png' %}" class="search-results__list-card-delivery-options-img" alt="" />
+                    </a>
+                    <a href="{% record_url record %}" class="search-results__list-card-delivery-options-link">
+                        <p class="search-results__list-card-delivery-options-desc">
+                            <span class="sr-only">{{ record.reference_prefixed_summary_title }} is</span>
+                            Available online
+                        </p>
+                    </a>
+                </div>
+            {% endif %}
         {% endif %}
         {% if apply_teaser_image %}
         <picture>


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-505

## About these changes

- Changes to hide view download for closed records in search
- Added Closure status to record details page

## How to check these changes

1) search
- Navigate to Online records at the National Archives
- View results for Closed and Open records - see Image icon hidden for Closed records

2) record details page
- Navigate to record details page
- View a new Closure status field added (will appear only if present in the API)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
