### PR TITLE
DF-774:Fix hierarchy and search results links for various record levels

### DIFF
--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -13,14 +13,15 @@ def record_url(
     record: Record,
     is_editorial: bool = False,
     order_from_discovery: bool = False,
-    use_non_reference_number_url: bool = False,
+    level_or_archive: str = "",
 ) -> str:
     """
     Return the URL for the provided `record`, which should always be a
     fully-transformed `etna.records.models.Record` instance.
 
-    use_non_reference_number_url: set True to override reference number to disambiguation page
-    (multiple iaid share the same reference number) when its not required.
+    level_or_archive: Use api level name or "Archive" name. This value is checked
+    with a set of values in order to override reference number that show
+    disambiguation page (multiple iaid share the same reference number).
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
@@ -33,8 +34,16 @@ def record_url(
         else:
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
+    reference_number_override_list = (
+        level_name(level_code=1, is_tna=True),
+        level_name(level_code=2, is_tna=True),
+        level_name(level_code=4, is_tna=True),
+        level_name(level_code=5, is_tna=True),
+        "Lettercode",  # same as Department, but returned in API response
+        "Archive",  # no level specified for this value
+    )
     if record:
-        if use_non_reference_number_url:
+        if level_or_archive in reference_number_override_list:
             return record.non_reference_number_url
         else:
             return record.url

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -34,7 +34,7 @@ def record_url(
         else:
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
-    # actual level names as theirs code are differ between tna and nonTna
+    # actual level names as level codes defined differ between tna and nonTna
     reference_number_override_list = (
         "Lettercode",  # same as Department, but returned in API response
         "Department",

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -14,6 +14,7 @@ def record_url(
     is_editorial: bool = False,
     order_from_discovery: bool = False,
     level_or_archive: str = "",
+    base_record: Record = None,
 ) -> str:
     """
     Return the URL for the provided `record`, which should always be a
@@ -22,6 +23,10 @@ def record_url(
     level_or_archive: Use api level name or "Archive" name. This value is checked
     with a set of values in order to override reference number that show
     disambiguation page (multiple iaid share the same reference number).
+
+    base_record: is the original record; use when record is not the original record
+    and record is a subset of the original record along with level_or_archive
+    in order to determine reference number override
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
@@ -34,16 +39,28 @@ def record_url(
         else:
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
-    # actual level names as level codes defined differ between tna and nonTna
-    reference_number_override_list = (
-        "Lettercode",  # same as Department, but returned in API response
-        "Department",
-        "Division",
-        "Sub-series",
-        "Sub-sub-series",
-        "Archive",  # no level specified for this value
-    )
     if record:
+        is_tna = record.is_tna
+        if base_record:
+            is_tna = base_record.is_tna
+        if is_tna:
+            reference_number_override_list = [
+                "Lettercode",  # same as Department, but returned in API response
+                level_name(level_code=1, is_tna=is_tna),
+                level_name(level_code=2, is_tna=is_tna),
+                level_name(level_code=4, is_tna=is_tna),
+                level_name(level_code=5, is_tna=is_tna),
+                "Archive",  # no level specified for this value
+            ]
+        else:
+            reference_number_override_list = [
+                level_name(level_code=1, is_tna=is_tna),
+                level_name(level_code=9, is_tna=is_tna),
+                level_name(level_code=10, is_tna=is_tna),
+                level_name(level_code=11, is_tna=is_tna),
+                "Archive",  # no level specified for this value
+            ]
+
         if level_or_archive in reference_number_override_list:
             return record.non_reference_number_url
         else:

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -34,12 +34,13 @@ def record_url(
         else:
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
+    # actual level names as theirs code are differ between tna and nonTna
     reference_number_override_list = (
-        level_name(level_code=1, is_tna=True),
-        level_name(level_code=2, is_tna=True),
-        level_name(level_code=4, is_tna=True),
-        level_name(level_code=5, is_tna=True),
         "Lettercode",  # same as Department, but returned in API response
+        "Department",
+        "Division",
+        "Sub-series",
+        "Sub-sub-series",
         "Archive",  # no level specified for this value
     )
     if record:

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -15,6 +15,7 @@ def record_url(
     order_from_discovery: bool = False,
     level_or_archive: str = "",
     base_record: Record = None,
+    form_group: str = "",
 ) -> str:
     """
     Return the URL for the provided `record`, which should always be a
@@ -27,6 +28,8 @@ def record_url(
     base_record: is the original record; use when record is not the original record
     and record is a subset of the original record along with level_or_archive
     in order to determine reference number override
+
+    form_group: use with results from search queries, value determinnes tna, nonTna results
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
@@ -40,9 +43,18 @@ def record_url(
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
     if record:
-        is_tna = record.is_tna
-        if base_record:
-            is_tna = base_record.is_tna
+        if form_group == "archive":
+            return record.non_reference_number_url
+        if form_group == "nonTna":
+            is_tna = False
+        elif form_group in ("tna", "digitised", "creator"):
+            is_tna = True
+        else:
+            is_tna = record.is_tna
+
+            if base_record:
+                is_tna = base_record.is_tna
+
         if is_tna:
             reference_number_override_list = [
                 "Lettercode",  # same as Department, but returned in API response

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -29,7 +29,7 @@ def record_url(
     and record is a subset of the original record along with level_or_archive
     in order to determine reference number override
 
-    form_group: use with results from search queries, value determinnes tna, nonTna results
+    form_group: use with results from search queries, value determines tna, nonTna results
     """
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -43,11 +43,11 @@ def record_url(
             return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 
     if record:
-        if form_group == "archive":
+        if form_group in ("archive", "creator"):
             return record.non_reference_number_url
         if form_group == "nonTna":
             is_tna = False
-        elif form_group in ("tna", "digitised", "creator"):
+        elif form_group in ("tna", "digitised"):
             is_tna = True
         else:
             is_tna = record.is_tna

--- a/etna/records/tests/test_templatetags.py
+++ b/etna/records/tests/test_templatetags.py
@@ -55,7 +55,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "ADM",
                                 "type": "reference number",
                                 "value": "ADM",
@@ -85,7 +85,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "ADM 223",
                                 "type": "reference number",
                                 "value": "ADM 223",
@@ -149,7 +149,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "J",
                                 "type": "reference number",
                                 "value": "J",
@@ -171,7 +171,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "J 77",
                                 "type": "reference number",
                                 "value": "J 77",
@@ -193,7 +193,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "J 77/3417",
                                 "type": "reference number",
                                 "value": "J 77/3417",
@@ -208,7 +208,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "J 77/3417/4284",
                                 "type": "reference number",
                                 "value": "J 77/3417/4284",
@@ -247,7 +247,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-ADM-01 to LU-WIR-16; LU-AC-01",
                                 "type": "reference number",
                                 "value": "LU-ADM-01 to LU-WIR-16; LU-AC-01",
@@ -262,7 +262,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-ADM-01 to LU-WIR-16; LU-AC-01",
                                 "type": "reference number",
                                 "value": "LU-ADM-01 to LU-WIR-16; LU-AC-01",
@@ -277,7 +277,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-01 to LU-PEP-42; Blue Drawer 2B14 & 2B13; LU-WAR-30; LU-AC-01",
                                 "type": "reference number",
                                 "value": "LU-PEP-01 to LU-PEP-42; Blue Drawer 2B14 & 2B13; LU-WAR-30; LU-AC-01",
@@ -292,7 +292,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-02 to LU-PEP-42; Blue Drawer 2B14",
                                 "type": "reference number",
                                 "value": "LU-PEP-02 to LU-PEP-42; Blue Drawer 2B14",
@@ -307,7 +307,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-27; LU-PEP-30 to LU-PEP-42",
                                 "type": "reference number",
                                 "value": "LU-PEP-27; LU-PEP-30 to LU-PEP-42",
@@ -322,7 +322,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-27; LU-PEP-30 to LU-PEP-42; LU-AC-01",
                                 "type": "reference number",
                                 "value": "LU-PEP-27; LU-PEP-30 to LU-PEP-42; LU-AC-01",
@@ -337,7 +337,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-38",
                                 "type": "reference number",
                                 "value": "LU-PEP-38",
@@ -352,7 +352,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-41",
                                 "type": "reference number",
                                 "value": "LU-PEP-41",
@@ -367,7 +367,7 @@ class TestRecordURLTag(SimpleTestCase):
                         "@entity": "reference",
                         "identifier": [
                             {
-                                "primary": "true",
+                                "primary": True,
                                 "reference_number": "LU-PEP-41",
                                 "type": "reference number",
                                 "value": "LU-PEP-41",
@@ -542,7 +542,7 @@ class TestRecordURLTag(SimpleTestCase):
                 self.assertEqual(record_url(source, is_editorial=True), expected_result)
 
     @override_settings(FEATURE_RECORD_LINKS_GO_TO_DISCOVERY=True)
-    def test_discovery_links_when_is_editorial_is_true(self):
+    def test_discovery_links_when_is_editorial_is_True(self):
         for attribute_name, expected_result in (
             (
                 "record_instance",
@@ -624,82 +624,89 @@ class TestRecordURLTag(SimpleTestCase):
                     expected_result,
                 )
 
-    def test_level_or_archive_tna_levels(self):
+    def test_level_or_archive_tna_levels_without_hierarchy(self):
         self.record_lettercode = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C27",
                         "level": "Lettercode",
                         "referenceNumber": "BE",
                     }
-                }
+                },
             }
         )
         self.record_division = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C632",
                         "level": "Division",
                         "referenceNumber": "Division within FO",
                     }
-                }
+                },
             }
         )
         self.record_series = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C4144",
                         "level": "Series",
                         "referenceNumber": "CM 39",
                     }
-                }
+                },
             }
         )
         self.record_sub_series = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C88345",
                         "level": "Sub-series",
                         "referenceNumber": "Sub-series within PIN 18",
                     }
-                }
+                },
             }
         )
         self.record_sub_sub_series = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C149305",
                         "level": "Sub-sub-series",
                         "referenceNumber": "Sub-sub-series within FCO 63",
                     }
-                }
+                },
             }
         )
         self.record_piece = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C2519196",
                         "level": "Piece",
                         "referenceNumber": "FO 78/2294",
                     }
-                }
+                },
             }
         )
         self.record_item = Record(
             raw_data={
+                "@datatype": {"group": [{"value": "tna"}]},
                 "@template": {
                     "details": {
                         "iaid": "C7472714",
                         "level": "Item",
                         "referenceNumber": "C 1/498/26",
                     }
-                }
+                },
             }
         )
         for name, record, expected in (
@@ -718,6 +725,108 @@ class TestRecordURLTag(SimpleTestCase):
             with self.subTest(name):
                 self.assertEqual(
                     record_url(record, level_or_archive=record.level), expected
+                )
+
+    def test_level_or_archive_tna_levels_with_hierarchy(self):
+        self.record = self.tna_long_hierarchy_record_instance
+
+        self.hierarchy_level_1 = self.record.hierarchy[0]
+        self.hierarchy_level_3 = self.record.hierarchy[1]
+        self.hierarchy_level_6 = self.record.hierarchy[2]
+        self.hierarchy_level_7 = self.record.hierarchy[3]
+
+        for name, hierarchy_record, expected in (
+            ("hierarchy_level_1", self.hierarchy_level_1, "/catalogue/id/C162/"),
+            ("hierarchy_level_3", self.hierarchy_level_3, "/catalogue/ref/J/77/"),
+            ("hierarchy_level_6", self.hierarchy_level_6, "/catalogue/ref/J/77/3417/"),
+            (
+                "hierarchy_level_7",
+                self.hierarchy_level_7,
+                "/catalogue/ref/J/77/3417/4284/",
+            ),
+        ):
+            with self.subTest(name):
+                self.assertEqual(
+                    record_url(
+                        hierarchy_record,
+                        level_or_archive=level_name(
+                            hierarchy_record.level_code, self.record.is_tna
+                        ),
+                        base_record=self.record,
+                    ),
+                    expected,
+                )
+
+    def test_level_or_archive_non_tna_levels_with_hierarchy(self):
+        self.record = self.non_tna_long_hierarchy_record_instance
+
+        self.hierarchy_level_1 = self.record.hierarchy[0]
+        self.hierarchy_level_2 = self.record.hierarchy[1]
+        self.hierarchy_level_5 = self.record.hierarchy[2]
+        self.hierarchy_level_6 = self.record.hierarchy[3]
+        self.hierarchy_level_7 = self.record.hierarchy[4]
+        self.hierarchy_level_8 = self.record.hierarchy[5]
+        self.hierarchy_level_9 = self.record.hierarchy[6]
+        self.hierarchy_level_10 = self.record.hierarchy[7]
+        self.hierarchy_level_11 = self.record.hierarchy[8]
+
+        for name, hierarchy_record, expected in (
+            (
+                "hierarchy_level_1",
+                self.hierarchy_level_1,
+                "/catalogue/id/278e5baf-af95-4b8a-a246-7bbd4faebe92/",
+            ),
+            (
+                "hierarchy_level_2",
+                self.hierarchy_level_2,
+                "/catalogue/id/16131aa0-f1d9-42a5-8488-e9a236366b4b/",
+            ),
+            (
+                "hierarchy_level_5",
+                self.hierarchy_level_5,
+                "/catalogue/id/2dba8c17-0f69-4a53-b918-e6ddb06c41a7/",
+            ),
+            (
+                "hierarchy_level_6",
+                self.hierarchy_level_6,
+                "/catalogue/id/a6f76935-7e8d-451d-ac10-b5e6a0dd0efb/",
+            ),
+            (
+                "hierarchy_level_7",
+                self.hierarchy_level_7,
+                "/catalogue/id/fd77b34e-db7e-4b8f-93d2-2257e66e3d96/",
+            ),
+            (
+                "hierarchy_level_8",
+                self.hierarchy_level_8,
+                "/catalogue/id/fa5e6d5f-7838-4d4c-b168-2b983b70c0b3/",
+            ),
+            (
+                "hierarchy_level_9",
+                self.hierarchy_level_9,
+                "/catalogue/id/b5da3728-3977-485a-b4bf-c1949abe5c73/",
+            ),
+            (
+                "hierarchy_level_10",
+                self.hierarchy_level_10,
+                "/catalogue/id/dc02e42c-043b-4d49-bade-339c851a6019/",
+            ),
+            (
+                "hierarchy_level_11",
+                self.hierarchy_level_11,
+                "/catalogue/id/66787951-2237-4f8a-882f-0ac275fe2bff/",
+            ),
+        ):
+            with self.subTest(name):
+                self.assertEqual(
+                    record_url(
+                        hierarchy_record,
+                        level_or_archive=level_name(
+                            hierarchy_record.level_code, self.record.is_tna
+                        ),
+                        base_record=self.record,
+                    ),
+                    expected,
                 )
 
     def test_is_page_current_item_in_hierarchy(self):

--- a/etna/records/tests/test_templatetags.py
+++ b/etna/records/tests/test_templatetags.py
@@ -542,7 +542,7 @@ class TestRecordURLTag(SimpleTestCase):
                 self.assertEqual(record_url(source, is_editorial=True), expected_result)
 
     @override_settings(FEATURE_RECORD_LINKS_GO_TO_DISCOVERY=True)
-    def test_discovery_links_when_is_editorial_is_True(self):
+    def test_discovery_links_when_is_editorial_is_true(self):
         for attribute_name, expected_result in (
             (
                 "record_instance",
@@ -828,6 +828,250 @@ class TestRecordURLTag(SimpleTestCase):
                     ),
                     expected,
                 )
+
+    def test_tna_levels_for_search(self):
+        tna_search_record_department = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C427",
+                            "level": "Lettercode",
+                            "referenceNumber": "PHSO",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/C427/",
+        )
+
+        tna_search_record_division = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C632",
+                            "level": "Division",
+                            "referenceNumber": "Division within FO",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/C632/",
+        )
+
+        tna_search_record_series = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C14918854",
+                            "level": "Series",
+                            "referenceNumber": "FCO 158",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/ref/FCO/158/",
+        )
+
+        tna_search_record_sub_series = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C89162",
+                            "level": "Sub-series",
+                            "referenceNumber": "Sub-series within WO 400",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/C89162/",
+        )
+
+        tna_search_record_sub_sub_series = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C151221",
+                            "level": "Sub-sub-series",
+                            "referenceNumber": "Sub-sub-series within ADM 1",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/C151221/",
+        )
+
+        tna_search_record_item = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C8077549",
+                            "level": "Item",
+                            "referenceNumber": "J 77/3417/4284",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/ref/J/77/3417/4284/",
+        )
+
+        tna_search_record_piece = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C2519144",
+                            "level": "Piece",
+                            "referenceNumber": "FO 78/2242",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/ref/FO/78/2242/",
+        )
+
+        for name, search_record, expected in (
+            (
+                "tna_search_record_department",
+                *tna_search_record_department,
+            ),
+            (
+                "tna_search_record_division",
+                *tna_search_record_division,
+            ),
+            (
+                "tna_search_record_series",
+                *tna_search_record_series,
+            ),
+            (
+                "tna_search_record_sub_series",
+                *tna_search_record_sub_series,
+            ),
+            (
+                "tna_search_record_sub_sub_series",
+                *tna_search_record_sub_sub_series,
+            ),
+            (
+                "tna_search_record_item",
+                *tna_search_record_item,
+            ),
+            (
+                "tna_search_record_piece",
+                *tna_search_record_piece,
+            ),
+        ):
+            with self.subTest(name):
+                self.assertEqual(
+                    record_url(
+                        search_record,
+                        level_or_archive=search_record.level,
+                        form_group="tna",
+                    ),
+                    expected,
+                )
+
+    def test_non_tna_levels_for_search(self):
+        tna_search_record_item = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C10679336",
+                            "level": "Item",
+                            "referenceNumber": "ADM 359/32C/95",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/C10679336/",
+        )
+
+        tna_search_record_piece = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "C10996932",
+                            "level": "Piece",
+                            "referenceNumber": "DF 5/108",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/ref/DF/5/108/",
+        )
+        for name, search_record, expected in (
+            (
+                "tna_search_record_item",
+                *tna_search_record_item,
+            ),
+            (
+                "tna_search_record_piece",
+                *tna_search_record_piece,
+            ),
+        ):
+            with self.subTest(name):
+                self.assertEqual(
+                    record_url(
+                        search_record,
+                        level_or_archive=search_record.level,
+                        form_group="nonTna",
+                    ),
+                    expected,
+                )
+
+    def test_record_creators_for_search(self):
+        search_record, expected = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "primaryIdentifier": "F288770",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/F288770/",
+        )
+
+        self.assertEqual(
+            record_url(
+                search_record,
+                level_or_archive=search_record.level,
+                form_group="creator",
+            ),
+            expected,
+        )
+
+    def test_record_archive_for_search(self):
+        search_record, expected = (
+            Record(
+                raw_data={
+                    "@template": {
+                        "details": {
+                            "iaid": "A13531747",
+                            "referenceNumber": "262",
+                            "type": "archive",
+                        }
+                    },
+                }
+            ),
+            "/catalogue/id/A13531747/",
+        )
+
+        self.assertEqual(
+            record_url(
+                search_record,
+                level_or_archive=search_record.level,
+                form_group="creator",
+            ),
+            expected,
+        )
 
     def test_is_page_current_item_in_hierarchy(self):
         page = self.tna_long_hierarchy_record_instance

--- a/etna/records/tests/test_templatetags.py
+++ b/etna/records/tests/test_templatetags.py
@@ -608,7 +608,7 @@ class TestRecordURLTag(SimpleTestCase):
             with self.subTest(attribute_name):
                 source = getattr(self, attribute_name)
                 self.assertEqual(
-                    record_url(source, use_non_reference_number_url=True),
+                    record_url(source, level_or_archive="Archive"),
                     expected_result,
                 )
 
@@ -620,8 +620,104 @@ class TestRecordURLTag(SimpleTestCase):
             with self.subTest(attribute_name):
                 source = getattr(self, attribute_name)
                 self.assertEqual(
-                    record_url(source.repository, use_non_reference_number_url=True),
+                    record_url(source.repository, level_or_archive="Archive"),
                     expected_result,
+                )
+
+    def test_level_or_archive_tna_levels(self):
+        self.record_lettercode = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C27",
+                        "level": "Lettercode",
+                        "referenceNumber": "BE",
+                    }
+                }
+            }
+        )
+        self.record_division = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C632",
+                        "level": "Division",
+                        "referenceNumber": "Division within FO",
+                    }
+                }
+            }
+        )
+        self.record_series = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C4144",
+                        "level": "Series",
+                        "referenceNumber": "CM 39",
+                    }
+                }
+            }
+        )
+        self.record_sub_series = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C88345",
+                        "level": "Sub-series",
+                        "referenceNumber": "Sub-series within PIN 18",
+                    }
+                }
+            }
+        )
+        self.record_sub_sub_series = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C149305",
+                        "level": "Sub-sub-series",
+                        "referenceNumber": "Sub-sub-series within FCO 63",
+                    }
+                }
+            }
+        )
+        self.record_piece = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C2519196",
+                        "level": "Piece",
+                        "referenceNumber": "FO 78/2294",
+                    }
+                }
+            }
+        )
+        self.record_item = Record(
+            raw_data={
+                "@template": {
+                    "details": {
+                        "iaid": "C7472714",
+                        "level": "Item",
+                        "referenceNumber": "C 1/498/26",
+                    }
+                }
+            }
+        )
+        for name, record, expected in (
+            ("record_lettercode", self.record_lettercode, "/catalogue/id/C27/"),
+            ("record_division", self.record_division, "/catalogue/id/C632/"),
+            ("record_series", self.record_series, "/catalogue/ref/CM/39/"),
+            ("record_sub_series", self.record_sub_series, "/catalogue/id/C88345/"),
+            (
+                "record_sub_sub_series",
+                self.record_sub_sub_series,
+                "/catalogue/id/C149305/",
+            ),
+            ("record_piece", self.record_piece, "/catalogue/ref/FO/78/2294/"),
+            ("record_item", self.record_item, "/catalogue/ref/C/1/498/26/"),
+        ):
+            with self.subTest(name):
+                self.assertEqual(
+                    record_url(record, level_or_archive=record.level), expected
                 )
 
     def test_is_page_current_item_in_hierarchy(self):

--- a/templates/includes/records/hierarchy-full-item.html
+++ b/templates/includes/records/hierarchy-full-item.html
@@ -7,7 +7,7 @@
 <div class="hierarchy-full-panel__bar-container-outer">
     <div class="hierarchy-full-panel__bar-container-inner{% if is_current_item %} hierarchy-full-panel__bar-container-inner--active{% endif %}"></div>
     <div class="hierarchy-full-panel__text-container">
-        <p class="hierarchy-full-panel__text-level">{% if is_current_item %}You are currently looking at{% else %}Within{% endif %} the {% if hierarchy_level %}{{ hierarchy_level|lower }}{% else %}UNAVAILABLE{% endif %}: <a href="{% record_url item level_or_archive=hierarchy_level %}" data-link-type="Link" data-link="{{ item.reference_number }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{{ item.reference_number|truncatechars:47 }}</a></p>
+        <p class="hierarchy-full-panel__text-level">{% if is_current_item %}You are currently looking at{% else %}Within{% endif %} the {% if hierarchy_level %}{{ hierarchy_level|lower }}{% else %}UNAVAILABLE{% endif %}: <a href="{% record_url item level_or_archive=hierarchy_level base_record=record %}" data-link-type="Link" data-link="{{ item.reference_number }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{{ item.reference_number|truncatechars:47 }}</a></p>
         <p class="hierarchy-full-panel__text-title">{{item.summary_title}}</p>
     </div>
 </div>

--- a/templates/includes/records/hierarchy-full-item.html
+++ b/templates/includes/records/hierarchy-full-item.html
@@ -7,7 +7,7 @@
 <div class="hierarchy-full-panel__bar-container-outer">
     <div class="hierarchy-full-panel__bar-container-inner{% if is_current_item %} hierarchy-full-panel__bar-container-inner--active{% endif %}"></div>
     <div class="hierarchy-full-panel__text-container">
-        <p class="hierarchy-full-panel__text-level">{% if is_current_item %}You are currently looking at{% else %}Within{% endif %} the {% if hierarchy_level %}{{ hierarchy_level|lower }}{% else %}UNAVAILABLE{% endif %}: <a href="{% record_url item %}" data-link-type="Link" data-link="{{ item.reference_number }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{{ item.reference_number|truncatechars:47 }}</a></p>
+        <p class="hierarchy-full-panel__text-level">{% if is_current_item %}You are currently looking at{% else %}Within{% endif %} the {% if hierarchy_level %}{{ hierarchy_level|lower }}{% else %}UNAVAILABLE{% endif %}: <a href="{% record_url item level_or_archive=hierarchy_level %}" data-link-type="Link" data-link="{{ item.reference_number }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{{ item.reference_number|truncatechars:47 }}</a></p>
         <p class="hierarchy-full-panel__text-title">{{item.summary_title}}</p>
     </div>
 </div>

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -18,7 +18,7 @@
                     {% if breadcrumbs|length <= 2 %}
                         <li class="hierarchy-short-panel__list-item">
                             <span class="hierarchy-short-panel__level">
-                                <a href="{% record_url record.repository level_or_archive='Archive' %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
+                                <a href="{% record_url record.repository level_or_archive='Archive' base_record=record %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
                             </span>({{ record.template.heldBy|truncatechars:27 }})
                         </li>
                     {% endif %}
@@ -49,7 +49,7 @@
                 {% else %}
                     <li class="hierarchy-short-panel__list-item">
                         <span class="hierarchy-short-panel__level">
-                            <a href="{% record_url record.repository level_or_archive='Archive' %}">Archive</a>
+                            <a href="{% record_url record.repository level_or_archive='Archive' base_record=record %}">Archive</a>
                         </span>({{ record.template.heldBy|truncatechars:27 }})
                     </li>
                     {% if record.level_code %}
@@ -74,7 +74,7 @@
             <div class="hierarchy-full-panel__bar-container-outer">
                 <div class="hierarchy-full-panel__bar-container-inner"></div>
                 <div class="hierarchy-full-panel__text-container">
-                    <p class="hierarchy-full-panel__text-level">This record is held at: <a href="{% record_url record.repository level_or_archive='Archive' %}" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy|truncatechars:47}}</a></p>
+                    <p class="hierarchy-full-panel__text-level">This record is held at: <a href="{% record_url record.repository level_or_archive='Archive' base_record=record %}" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy|truncatechars:47}}</a></p>
                     <p class="hierarchy-full-panel__text-title">Located at DATA TO GO HERE</p> <!--TODO API data needs to contain the location of the archive as well-->
                 </div>
             </div>
@@ -91,7 +91,7 @@
                         {% if record.level_code %}
                             {% level_name record.level_code record.is_tna as hierarchy_level %}
                         {% endif %}
-                        <p class="hierarchy-full-panel__text-level">You are currently looking at the {{ hierarchy_level|lower }}: <a href="{% record_url record level_or_archive=hierarchy_level %}" data-link-type="Link" data-link="{{record.reference_number}}" data-catalogue-level="1" data-component-name="Hierarchy links">{{record.reference_number|truncatechars:22}}</a></p>
+                        <p class="hierarchy-full-panel__text-level">You are currently looking at the {{ hierarchy_level|lower }}: <a href="{% record_url record level_or_archive=hierarchy_level base_record=record %}" data-link-type="Link" data-link="{{record.reference_number}}" data-catalogue-level="1" data-component-name="Hierarchy links">{{record.reference_number|truncatechars:22}}</a></p>
                         <p class="hierarchy-full-panel__text-title">{{record.summary_title}}</p>
                     </div>
                 </div>

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -18,7 +18,7 @@
                     {% if breadcrumbs|length <= 2 %}
                         <li class="hierarchy-short-panel__list-item">
                             <span class="hierarchy-short-panel__level">
-                                <a href="{% record_url record.repository use_non_reference_number_url=True %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
+                                <a href="{% record_url record.repository level_or_archive='Archive' %}" data-link-type="Link" data-link="Archive" data-catalogue-level="0" data-component-name="Hierarchy links">Archive</a>
                             </span>({{ record.template.heldBy|truncatechars:27 }})
                         </li>
                     {% endif %}
@@ -49,7 +49,7 @@
                 {% else %}
                     <li class="hierarchy-short-panel__list-item">
                         <span class="hierarchy-short-panel__level">
-                            <a href="{% record_url record.repository use_non_reference_number_url=True %}">Archive</a>
+                            <a href="{% record_url record.repository level_or_archive='Archive' %}">Archive</a>
                         </span>({{ record.template.heldBy|truncatechars:27 }})
                     </li>
                     {% if record.level_code %}
@@ -74,7 +74,7 @@
             <div class="hierarchy-full-panel__bar-container-outer">
                 <div class="hierarchy-full-panel__bar-container-inner"></div>
                 <div class="hierarchy-full-panel__text-container">
-                    <p class="hierarchy-full-panel__text-level">This record is held at: <a href="{% record_url record.repository use_non_reference_number_url=True %}" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy|truncatechars:47}}</a></p>
+                    <p class="hierarchy-full-panel__text-level">This record is held at: <a href="{% record_url record.repository level_or_archive='Archive' %}" data-link-type="Link" data-link="{{record.template.heldBy}}" data-catalogue-level="0" data-component-name="Hierarchy links">{{record.template.heldBy|truncatechars:47}}</a></p>
                     <p class="hierarchy-full-panel__text-title">Located at DATA TO GO HERE</p> <!--TODO API data needs to contain the location of the archive as well-->
                 </div>
             </div>
@@ -91,7 +91,7 @@
                         {% if record.level_code %}
                             {% level_name record.level_code record.is_tna as hierarchy_level %}
                         {% endif %}
-                        <p class="hierarchy-full-panel__text-level">You are currently looking at the {{ hierarchy_level|lower }}: <a href="{% record_url record %}" data-link-type="Link" data-link="{{record.reference_number}}" data-catalogue-level="1" data-component-name="Hierarchy links">{{record.reference_number|truncatechars:22}}</a></p>
+                        <p class="hierarchy-full-panel__text-level">You are currently looking at the {{ hierarchy_level|lower }}: <a href="{% record_url record level_or_archive=hierarchy_level %}" data-link-type="Link" data-link="{{record.reference_number}}" data-catalogue-level="1" data-component-name="Hierarchy links">{{record.reference_number|truncatechars:22}}</a></p>
                         <p class="hierarchy-full-panel__text-title">{{record.summary_title}}</p>
                     </div>
                 </div>

--- a/templates/includes/records/hierarchy-short-item.html
+++ b/templates/includes/records/hierarchy-short-item.html
@@ -6,6 +6,6 @@
 
 <li class="hierarchy-short-panel__list-item {% if trail_off %}hierarchy-short-panel__list-item--more{% endif %}">
     <span class="hierarchy-short-panel__level">
-        <a href="{% record_url item%}" data-link-type="Link" data-link="{{ hierarchy_level }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{% if hierarchy_level %}{{ hierarchy_level }}{% else %}UNAVAILABLE{% endif %}</a>
+        <a href="{% record_url item level_or_archive=hierarchy_level %}" data-link-type="Link" data-link="{{ hierarchy_level }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{% if hierarchy_level %}{{ hierarchy_level }}{% else %}UNAVAILABLE{% endif %}</a>
     </span>({{ item.reference_number|truncatechars:27 }})
 </li>

--- a/templates/includes/records/hierarchy-short-item.html
+++ b/templates/includes/records/hierarchy-short-item.html
@@ -6,6 +6,6 @@
 
 <li class="hierarchy-short-panel__list-item {% if trail_off %}hierarchy-short-panel__list-item--more{% endif %}">
     <span class="hierarchy-short-panel__level">
-        <a href="{% record_url item level_or_archive=hierarchy_level %}" data-link-type="Link" data-link="{{ hierarchy_level }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{% if hierarchy_level %}{{ hierarchy_level }}{% else %}UNAVAILABLE{% endif %}</a>
+        <a href="{% record_url item level_or_archive=hierarchy_level base_record=record %}" data-link-type="Link" data-link="{{ hierarchy_level }}" data-catalogue-level="{{ item.level_code }}" data-component-name="Hierarchy links">{% if hierarchy_level %}{{ hierarchy_level }}{% else %}UNAVAILABLE{% endif %}</a>
     </span>({{ item.reference_number|truncatechars:27 }})
 </li>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -27,7 +27,7 @@
                     </picture>
                 </div>
             {% endif %}
-            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record use_non_reference_number_url=True %}{% else %}{% record_url record %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' %}{% else %}{% record_url record level_or_archive=record.level %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}<span class="sr-only">{{ record.reference_number }}</span>{% endif %}
                 {{ record.summary_title }}
             </a>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -27,7 +27,7 @@
                     </picture>
                 </div>
             {% endif %}
-            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' base_record=record %}{% else %}{% record_url record level_or_archive=record.level base_record=record %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' form_group=form.group.value %}{% else %}{% record_url record level_or_archive=record.level form_group=form.group.value %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}<span class="sr-only">{{ record.reference_number }}</span>{% endif %}
                 {{ record.summary_title }}
             </a>

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -27,7 +27,7 @@
                     </picture>
                 </div>
             {% endif %}
-            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' %}{% else %}{% record_url record level_or_archive=record.level %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' base_record=record %}{% else %}{% record_url record level_or_archive=record.level base_record=record %}{% endif %}" class="search-results__list-card-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}<span class="sr-only">{{ record.reference_number }}</span>{% endif %}
                 {{ record.summary_title }}
             </a>

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -13,7 +13,7 @@
 <li class="search-results__list-card" data-iaid="{{ record.iaid }}" data-score="{{ record.score }}">
     <div class="search-results__list-card-details">
         <h3 class="search-results__list-card-heading">
-            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' base_record=record %}{% else %}{% record_url record level_or_archive=record.level base_record=record %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' form_group=form.group.value %}{% else %}{% record_url record level_or_archive=record.level form_group=form.group.value %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}
                 <span class="sr-only">Reference number {{ record.reference_number }}: </span>
                 {% endif %}

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -13,7 +13,7 @@
 <li class="search-results__list-card" data-iaid="{{ record.iaid }}" data-score="{{ record.score }}">
     <div class="search-results__list-card-details">
         <h3 class="search-results__list-card-heading">
-            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record use_non_reference_number_url=True %}{% else %}{% record_url record %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' %}{% else %}{% record_url record level_or_archive=record.level %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}
                 <span class="sr-only">Reference number {{ record.reference_number }}: </span>
                 {% endif %}

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -13,7 +13,7 @@
 <li class="search-results__list-card" data-iaid="{{ record.iaid }}" data-score="{{ record.score }}">
     <div class="search-results__list-card-details">
         <h3 class="search-results__list-card-heading">
-            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' %}{% else %}{% record_url record level_or_archive=record.level %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
+            <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' base_record=record %}{% else %}{% record_url record level_or_archive=record.level base_record=record %}{% endif %}" class="search-results__list-card-heading-link" data-analytics-link="{{ record.reference_prefixed_summary_title }}">
                 {% if record.reference_number %}
                 <span class="sr-only">Reference number {{ record.reference_number }}: </span>
                 {% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-774

## About these changes

Changes to use id in Hierarchy and Search results for Department, Division, Sub-series, Sub-sub-series for tna records
Changes to use id in Hierarchy and Search results for Fonds, File, Item, Sub-item for nonTna

## How to check these changes

Navigate to results of search buckets
Filter level
Select the record for the above levels, it should not take you to the disambiguation page

Navigate through Hierarch links in record details
http://127.0.0.1:8000/catalogue/ref/WO/409/27/29/562/
http://127.0.0.1:8000/catalogue/ref/DF/106/7/
http://127.0.0.1:8000/catalogue/id/C162/
http://127.0.0.1:8000/catalogue/ref/ADM/159/
http://127.0.0.1:8000/catalogue/ref/DF/5/108/
http://127.0.0.1:8000/catalogue/id/66787951-2237-4f8a-882f-0ac275fe2bff/

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
