### PR TITLE
UN-612 - Multiple images with transcripts bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.3.0",
       "license": "ISC",
       "dependencies": {
-        "@nationalarchives/frontend": "^0.1.8-prerelease",
+        "@nationalarchives/frontend": "^0.1.10-prerelease",
         "jest": "~29.6",
         "jquery": "~3.7",
         "openseadragon": "~4.1"
@@ -2387,9 +2387,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@nationalarchives/frontend": {
-      "version": "0.1.8-prerelease",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/frontend/-/frontend-0.1.8-prerelease.tgz",
-      "integrity": "sha512-/7LqmZdGVKvhwVl9hjAqbRq6d6oGICp2cQQwPjxQttRjEpq3UIr4oV7K44kPBCkRDaLZXLwbB4kQXOK8tZp1Lw==",
+      "version": "0.1.10-prerelease",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/frontend/-/frontend-0.1.10-prerelease.tgz",
+      "integrity": "sha512-PlECeOvKOGNW6YfJ00h1IikUV9q9ZblG7s7bNe2ErwKk2PrufoliGjQCEhiOeOBYKdJdfa31cuNV39uOjeoNqw==",
       "engines": {
         "node": "18.x",
         "npm": "9.x"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "webpack-cli": "~5.1"
   },
   "dependencies": {
-    "@nationalarchives/frontend": "^0.1.8-prerelease",
+    "@nationalarchives/frontend": "^0.1.10-prerelease",
     "jest": "~29.6",
     "jquery": "~3.7",
     "openseadragon": "~4.1"

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -136,35 +136,8 @@ $largest-small-device: 992px;
 
 @import '@nationalarchives/frontend/nationalarchives/all';
 
-*:focus {
-    outline: none !important;
-}
-
-a,
-button,
-select,
-input[type="checkbox"],
-input[type="radio"],
-input[type="button"],
-input[type="submit"] {
-    &:focus {
-        outline: 0.3125rem solid #004c7e !important;
-        outline-offset: 0.125rem !important;
-    }
-
-    [class*="--dark"] & {
-        outline-color: #00b0ff !important;
-    }
-}
-
 .tna-hero {
     margin-bottom: 2rem;
-}
-
-.tna-hero__image {
-    @include media.on-mobile {
-        height: 320px;
-    }
 }
 
 .tna-hero__heading {

--- a/scripts/src/article.js
+++ b/scripts/src/article.js
@@ -53,8 +53,8 @@ window.addEventListener('load', () => {
     add_section_ids($sectionHeadings, $sectionContents);
 
     // Transcription tabs
-    const transcriptButton = document.querySelectorAll('[ data-js-transcript]');
-    const transcriptTabs = document.querySelectorAll('[ data-js-transcript-tablist]');
+    const transcriptButton = document.querySelectorAll('[data-js-transcript]');
+    const transcriptTabs = document.querySelectorAll('[data-js-transcript-tablist]');
 
     if(transcriptButton && transcriptTabs) {
 

--- a/scripts/src/modules/articles/accordion_functionality/accordion_functionality.js
+++ b/scripts/src/modules/articles/accordion_functionality/accordion_functionality.js
@@ -9,7 +9,9 @@ export default function accordion_functionality(currentHeading, sectionHeadings,
     sectionContents.each(function(index) {
         // If it matches, expand the section.
         if($(this).attr("data-controlled-by") === id) {
-            if(!$(this).is(':animated')) {
+            const imageBlock = $(this).closest('[data-module="data-imageblock"]')[0]
+            const imageBlockButton = $(currentHeading.closest('[data-module="data-imageblock"]'))[0]
+            if (imageBlock === imageBlockButton && !$(this).is(':animated')) {
                 slide_toggle($(this));
                 scroll_to_active_heading(headingPositions[index]);
                 toggle_aria_expanded($(sectionHeadings[index]));

--- a/templates/blocks/image-block-default.html
+++ b/templates/blocks/image-block-default.html
@@ -2,7 +2,7 @@
 {% image value.image width-600 as block_image %}
 
 {% if value.image %}
-    <figure class="image-block u-margin-l">
+    <figure class="image-block u-margin-l" data-module="data-imageblock">
         <picture>
             {% image value.image max-832x591 format-webp as desktop_img %}
             <source media="(min-width: 760px)" srcset="{{ desktop_img.url }}"/>
@@ -85,7 +85,7 @@
                                 role="tabpanel"
                                 tabindex="0"
                                 aria-labelledby="{{ heading_id }}-tab-1"
-                                class="transcription__tabpanel hidden">
+                                class="transcription__tabpanel">
                             {{ value.image.transcription|richtext }}
                         </div>
                     {% endif %}
@@ -94,7 +94,7 @@
                                 role="tabpanel"
                                 tabindex="0"
                                 aria-labelledby="{{ heading_id }}-tab-2"
-                                class="transcription__tabpanel hidden">
+                                class="transcription__tabpanel">
                             {{ value.image.translation|richtext }}
                         </div>
                     {% endif %}


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/UN-612

## About these changes

There was a bug where multiple images with transcripts in the same section wouldn't work.

This allows each transcript in a section to operate in isolation.

I also took the chance to update `@nationalarchives/frontend` to fix some bugs with the focus styles and remove some project-specific overrides.

## How to check these changes

Using staging data, there are two images with transcripts on `explore-the-collection/stories/richard-iii/`. They should now both be able to open and close independently of one another.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [ ] ~Added/updated tests and documentation where relevant.~
