### PR TITLE
DF-585:Fix uniqueness for sort_by id

### DIFF
--- a/etna/search/templatetags/search_tags.py
+++ b/etna/search/templatetags/search_tags.py
@@ -116,3 +116,20 @@ def extended_in_operator(lhs_operand, *rhs_operand_list) -> bool:
     Returns True when rhs_operand_list contains lhs_operand value, False otherwise
     """
     return (lhs_operand in rhs_operand_list) or False
+
+
+@register.simple_tag
+def render_sort_by_input(form, id_suffix) -> str:
+    """
+    returns sort_by field with name suffixed id.
+    """
+    bound_field = None
+    for field in form:
+        if field.name == "sort_by":
+            bound_field = field
+    html = ""
+    if bound_field:
+        html += bound_field.as_widget(
+            attrs={"id": f"id_{bound_field.name}_{id_suffix}"}
+        )
+    return mark_safe(html)

--- a/etna/search/tests/test_search_tags.py
+++ b/etna/search/tests/test_search_tags.py
@@ -11,6 +11,7 @@ from ..templatetags.search_tags import (
     query_string_exclude,
     query_string_include,
     render_fields_as_hidden,
+    render_sort_by_input,
 )
 
 
@@ -192,3 +193,20 @@ class RenderFieldsAsHiddenTest(SimpleTestCase):
                     f"as_hidden() should have been called for field: '{field.name}'"
                 ):
                     mocked_as_hidden.assert_any_call(field, attrs=mock.ANY)
+
+
+class RenderSortByTest(SimpleTestCase):
+    def setUp(self):
+        self.form = CatalogueSearchForm(
+            {
+                "group": "tna",
+                "sort_by": "relevance",
+                "sort_order": "asc",
+            }
+        )
+
+    def test_render_sort_by_input_input_id(self):
+        expected_html = '<select name="sort_by" class="search-sort-view__form-select" id="id_sort_by_somevalue">'
+        self.assertIn(
+            expected_html, render_sort_by_input(self.form, id_suffix="somevalue")
+        )

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -243,7 +243,8 @@ class EndToEndSearchTestCase(TestCase):
         '<ul class="search-buckets__list" data-id="search-buckets-list">'
     )
     search_within_option_html = '<label for="id_filter_keyword" class="search-filters__label--block">Search within results:</label>'
-    sort_order_options_html = '<label for="id_sort_by">Sort by</label>'
+    sort_by_desktop_options_html = '<label for="id_sort_by_desktop">Sort by</label>'
+    sort_by_mobile_options_html = '<label for="id_sort_by_mobile">Sort by</label>'
     filter_options_html = '<form method="GET" data-id="filters-form"'
 
     def patch_api_endpoint(self, url: str, fixture_path: str):
@@ -276,11 +277,13 @@ class EndToEndSearchTestCase(TestCase):
     def assertSearchWithinOptionNotRendered(self, response):
         self.assertNotIn(self.search_within_option_html, response)
 
-    def assertSortOrderOptionsRendered(self, response):
-        self.assertIn(self.sort_order_options_html, response)
+    def assertSortByOptionsRendered(self, response):
+        self.assertIn(self.sort_by_desktop_options_html, response)
+        self.assertIn(self.sort_by_mobile_options_html, response)
 
-    def assertSortOrderOptionsNotRendered(self, response):
-        self.assertNotIn(self.sort_order_options_html, response)
+    def assertSortByOptionsNotRendered(self, response):
+        self.assertNotIn(self.sort_by_desktop_options_html, response)
+        self.assertNotIn(self.sort_by_mobile_options_html, response)
 
     def assertFilterOptionsRendered(self, response):
         self.assertIn(self.filter_options_html, response)
@@ -324,7 +327,7 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         # SHOULD NOT see
         self.assertBucketLinksNotRendered(content)
         self.assertSearchWithinOptionNotRendered(content)
-        self.assertSortOrderOptionsNotRendered(content)
+        self.assertSortByOptionsNotRendered(content)
         self.assertFilterOptionsNotRendered(content)
         self.assertResultsNotRendered(content)
 
@@ -357,7 +360,7 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
 
         # SHOULD NOT see
         self.assertSearchWithinOptionNotRendered(content)
-        self.assertSortOrderOptionsNotRendered(content)
+        self.assertSortByOptionsNotRendered(content)
         self.assertFilterOptionsNotRendered(content)
         self.assertResultsNotRendered(content)
 
@@ -389,7 +392,7 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         # SHOULD see
         self.assertBucketLinksRendered(content)
         self.assertSearchWithinOptionRendered(content)
-        self.assertSortOrderOptionsRendered(content)
+        self.assertSortByOptionsRendered(content)
         self.assertNoResultsMessagingRendered(content)
         self.assertFilterOptionsRendered(content)
 
@@ -428,7 +431,7 @@ class CatalogueSearchEndToEndTest(EndToEndSearchTestCase):
         # SHOULD see
         self.assertBucketLinksRendered(content)
         self.assertSearchWithinOptionRendered(content)
-        self.assertSortOrderOptionsRendered(content)
+        self.assertSortByOptionsRendered(content)
         self.assertFilterOptionsRendered(content)
         self.assertResultsRendered(content)
 
@@ -543,7 +546,7 @@ class WebsiteSearchEndToEndTest(EndToEndSearchTestCase):
         # SHOULD NOT see
         self.assertBucketLinksNotRendered(content)
         self.assertSearchWithinOptionNotRendered(content)
-        self.assertSortOrderOptionsNotRendered(content)
+        self.assertSortByOptionsNotRendered(content)
         self.assertFilterOptionsNotRendered(content)
         self.assertResultsNotRendered(content)
 
@@ -573,7 +576,7 @@ class WebsiteSearchEndToEndTest(EndToEndSearchTestCase):
 
         # SHOULD NOT see
         self.assertSearchWithinOptionNotRendered(content)
-        self.assertSortOrderOptionsNotRendered(content)
+        self.assertSortByOptionsNotRendered(content)
         self.assertFilterOptionsNotRendered(content)
         self.assertResultsNotRendered(content)
 
@@ -605,7 +608,7 @@ class WebsiteSearchEndToEndTest(EndToEndSearchTestCase):
         # SHOULD see
         self.assertBucketLinksRendered(content)
         self.assertSearchWithinOptionRendered(content)
-        self.assertSortOrderOptionsRendered(content)
+        self.assertSortByOptionsRendered(content)
         self.assertFilterOptionsRendered(content)
         self.assertNoResultsMessagingRendered(content)
 
@@ -643,7 +646,7 @@ class WebsiteSearchEndToEndTest(EndToEndSearchTestCase):
         # SHOULD see
         self.assertBucketLinksRendered(content)
         self.assertSearchWithinOptionRendered(content)
-        self.assertSortOrderOptionsRendered(content)
+        self.assertSortByOptionsRendered(content)
         self.assertFilterOptionsRendered(content)
         self.assertResultsRendered(content)
 

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -3,10 +3,10 @@
 <div class="search-sort-view">
     <form method="GET" class="search-sort-view__form search-sort-view__mobile" data-id="sort-form" id="catalogue-sort-form-mobile" data-search-type="{{ view.search_tab }}" data-search-bucket="{{ buckets.current.label }}" data-search-filter-name="Sort results" data-search-filter-value="">
         <h2 class="search-sort-view__heading">
-            <label for="{{form.sort_by.id_for_label}}">Sort by</label>
+            <label for="id_sort_by_mobile">Sort by</label>
         </h2>
         {{ form.sort_by.errors }}
-        {{ form.sort_by }}
+        {% render_sort_by_input form=form id_suffix="mobile" %}
 
         {# render hidden inputs for fields controlled by other forms #}
         {% render_fields_as_hidden form exclude='sort_by' %}

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -5,11 +5,11 @@
     <form method="GET" class="search-sort-view__form search-sort-view__desktop" data-id="sort-form" id="catalogue-sort-form-desktop" data-search-type="{{ view.search_tab }}" data-search-bucket="{{ buckets.current.label }}" data-search-filter-name="Sort results" data-search-filter-value="">
 
         <h2 class="search-sort-view__heading">
-           <label for="{{form.sort_by.id_for_label}}">Sort by</label>
+           <label for="id_sort_by_desktop">Sort by</label>
         </h2>
 
         {{ form.sort_by.errors }}
-        {{ form.sort_by }}
+        {% render_sort_by_input form=form id_suffix="desktop" %}
 
         {% render_fields_as_hidden form exclude='sort_by' %}
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-585

## About these changes

Sort by field is used for desktop and mobile. This PR make rendering of the fields with unique ids. 

## How to check these changes

- Navigate to Catalogue search bucket ex. tna
- Select sort by options
- View page source - for id_sort_by_desktop, id_sort_by_mobile uniqueness

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
