### PR TITLE
CHORE: Fix record revealed promo

### DIFF
--- a/templates/includes/record-revealed.html
+++ b/templates/includes/record-revealed.html
@@ -22,9 +22,9 @@
             {% endif %}
             <div class="featured-record-article__container">
                 {% if link_page.has_custom_type_label %}
-                    <p class="featured-record-article__meta u-margin-xxs">{{ link_page.has_custom_type_label }}</p>
+                    <p class="featured-record-article__meta u-margin-xxs">{{ link_page.type_label }}</p>
                 {% endif %}
-                <a href="{% pageurl page %}" class="featured-record-article__link" data-component-name="Featured record article" data-link-type="Banner title" data-link="{{ link_page.title }}">
+                <a href="{% pageurl link_page %}" class="featured-record-article__link" data-component-name="Featured record article" data-link-type="Banner title" data-link="{{ link_page.title }}">
                     <h3 class="featured-record-article__title u-margin-xs">{{ link_page.title }}</h3>
                 </a>
                 {% if link_page.date_text %}


### PR DESCRIPTION
## About these changes

Lizzy spotted a broken page label:
![image](https://github.com/nationalarchives/ds-wagtail/assets/62654785/48998908-4a97-47a7-8f0d-02fa2e07d677)

And I also realised it was linking incorrectly.

This fixes the link issue, and the label issue.

## How to check these changes

Edit an Article Page and add a "Featured Record Revealed" to the page. The element should then display correctly.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
