### PR TITLE
Fix/DF-778 fixes to website results formatting

### DIFF
--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -254,7 +254,7 @@
 
 .search-results__list-card-image {
     margin-left: 20px;
-    flex: 0 0 200px;
+    flex: 0 0 300px;
 }
 
 .search-results__list-card-image-anchor {

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -254,7 +254,7 @@
 
 .search-results__list-card-image {
     margin-left: 20px;
-    flex: 0 0 300px;
+    flex: 0 0 348px;
     margin-bottom:1em;
 }
 

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -255,6 +255,7 @@
 .search-results__list-card-image {
     margin-left: 20px;
     flex: 0 0 300px;
+    margin-bottom:1em;
 }
 
 .search-results__list-card-image-anchor {

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -99,6 +99,7 @@
   &-metadata-item {
     font-weight:100;
     //line-height:2em;
+
   }
 
   &-metadata-item-held-by-icon {
@@ -254,7 +255,7 @@
 
 .search-results__list-card-image {
     margin-left: 20px;
-    flex: 0 0 348px;
+    flex: 0 0 200px;
     margin-bottom:1em;
 }
 
@@ -321,5 +322,16 @@ dd {
     margin-bottom:1em;
 }
 
+.format {
+    width:0;
+}
+
+.inline-fix {
+    margin-left:48px;
+}
+
+.image-web-results {
+   flex: 0 0 348px;
+}
 
 

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -332,6 +332,7 @@ dd {
 
 .image-web-results {
    flex: 0 0 348px;
+    max-width:348px;
 }
 
 

--- a/templates/search/blocks/native_website_result.html
+++ b/templates/search/blocks/native_website_result.html
@@ -12,10 +12,10 @@
         </p>
 
         <dl class="search-results__list-card-metadata">
-            <dt class="search-results__list-card-metadata-item">
+            <dt class="search-results__list-card-metadata-item format">
                 Format:
             </dt>
-            <dd>{{ result.type_label }}</dd>
+            <dd class="inline-fix">{{ result.type_label }}</dd>
             {% if result.show_publish_date_in_search_results and result.first_published_at %}
                 <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
                     Published:
@@ -27,7 +27,7 @@
     </div>
 
     {% if result.teaser_image %}
-        <div class="search-results__list-card-image">
+        <div class="search-results__list-card-image image-web-results">
             {% image result.teaser_image fill-288x172 as teaser_image_small %}
             {% image result.teaser_image fill-328x196 as teaser_image_medium %}
             {% image result.teaser_image fill-348x208 as teaser_image_large %}

--- a/templates/search/blocks/native_website_result.html
+++ b/templates/search/blocks/native_website_result.html
@@ -1,6 +1,27 @@
 {% load static records_tags search_tags wagtailcore_tags wagtailimages_tags %}
+
+
 <li class="search-results__list-card" data-score="{{ result.score }}">
-    <div class="search-results__list-card-details">
+    {% if result.teaser_image %}
+    <div class="search-results__list-card-image image-web-results order-md-2">
+        {% image result.teaser_image fill-288x172 as teaser_image_small %}
+        {% image result.teaser_image fill-328x196 as teaser_image_medium %}
+        {% image result.teaser_image fill-348x208 as teaser_image_large %}
+        {% image result.teaser_image fill-508x304 as teaser_image_extra_large %}
+        <picture>
+            <source media="(max-width: 480px)" srcset="{{ teaser_image_small }}">
+            <source media="(max-width: 640px)" srcset="{{ teaser_image_medium }}">
+            <source media="(max-width: 768px)" srcset="{{ teaser_image_medium }}">
+            <source media="(max-width: 991px)" srcset="{{ teaser_image_large }}">
+            <source media="(max-width: 1200px)" srcset="{{ teaser_image_large }}">
+            <img src="{{ teaser_image_large.url }}" alt="" />
+        </picture>
+
+    </div>
+    {% endif %}
+
+
+    <div class="search-results__list-card-details order-md-1">
         <h3 class="search-results__list-card-heading">
             <a href="{% pageurl result %}" class="search-results__list-card-heading-link" data-analytics-link="{{ result.title }}">
                 {{ result.title }}
@@ -26,21 +47,6 @@
 
     </div>
 
-    {% if result.teaser_image %}
-        <div class="search-results__list-card-image image-web-results">
-            {% image result.teaser_image fill-288x172 as teaser_image_small %}
-            {% image result.teaser_image fill-328x196 as teaser_image_medium %}
-            {% image result.teaser_image fill-348x208 as teaser_image_large %}
-            {% image result.teaser_image fill-508x304 as teaser_image_extra_large %}
-            <picture>
-                <source media="(max-width: 480px)" srcset="{{ teaser_image_small }}">
-                <source media="(max-width: 640px)" srcset="{{ teaser_image_medium }}">
-                <source media="(max-width: 768px)" srcset="{{ teaser_image_medium }}">
-                <source media="(max-width: 991px)" srcset="{{ teaser_image_large }}">
-                <source media="(max-width: 1200px)" srcset="{{ teaser_image_large }}">
-                <img src="{{ teaser_image_large.url }}" alt="" />
-            </picture>
 
-        </div>
-    {% endif %}
 </li>
+


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-778

## About these changes

reordered the images on mobile and other formatting fixes (see ticket)

## How to check these changes

Perform a search, select the 'Website Results' tab, check the layout across viewports  

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
