### PR TITLE
Layout fix on close button for record revealed

### DIFF
--- a/sass/includes/_generic-intro.scss
+++ b/sass/includes/_generic-intro.scss
@@ -12,6 +12,7 @@
     margin-bottom: 0;
     font-size: 4rem;
     font-family: $font__supria-sans;
+      //background: green;
 
     @media (max-width: $screen__md) {
       font-size: 2.5rem;

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -132,8 +132,10 @@
 
   &__icon {
     width: 2rem;
-    height: 2rem;
+    height: 1.7rem;
     padding-left: 0.3rem;
+      float: left;
+      padding-right: 1em;
   }
 
   &__image {


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-785

## About these changes

Small layout change to close button on record revealed

## How to check these changes

Go to a record revealed page, open the 'View image and transcript' button, check the layout of the 'Close Images and Transcripts' button

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
