### PR TITLE
Add padding for transcript paragraphs and lists

### DIFF
--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -220,9 +220,16 @@
             outline-offset: 0.125rem;
         }
 
-        > p {
+        > p,
+        > ul,
+        > ol {
             // Normalise the rich-text output
-            margin: 0;
+            margin-top: 0;
+            margin-bottom: 1rem;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
         }
     }
 


### PR DESCRIPTION
Before:
<img width="475" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/2356642/3160a6ee-85d5-446d-9066-78a1717ed965">

After:
<img width="469" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/2356642/d3125547-7cb1-4918-a0c0-db97945b0b35">