### PR TITLE
Create two Docker instances to update dependencies

### DIFF
--- a/.docker/update-npm/Dockerfile
+++ b/.docker/update-npm/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:18.16
+WORKDIR /home
+COPY package.json package-lock.json ./
+CMD ["npm", "update"]

--- a/.docker/update-poetry/Dockerfile
+++ b/.docker/update-poetry/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11
+ENV \
+  # python:
+  PYTHONFAULTHANDLER=1 \
+  PYTHONUNBUFFERED=1 \
+  PYTHONHASHSEED=random \
+  PYTHONDONTWRITEBYTECODE=1 \
+  # pip:
+  PIP_NO_CACHE_DIR=off \
+  PIP_DISABLE_PIP_VERSION_CHECK=on \
+  PIP_DEFAULT_TIMEOUT=100 \
+  # poetry:
+  POETRY_HOME=/home/app/poetry \
+  POETRY_VERSION=1.5.1 \
+  POETRY_NO_INTERACTION=1 \
+  POETRY_VIRTUALENVS_CREATE=true
+RUN useradd --system --create-home app
+WORKDIR /app
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -sSL "https://install.python-poetry.org" | python -
+ENV PATH="$POETRY_HOME/bin:$PATH"
+COPY pyproject.toml poetry.lock ./
+CMD ["poetry", "update"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,25 @@ services:
     ports:
       - 8001:8000
 
+  poetry_update:
+    container_name: update-poetry
+    build:
+      context: .
+      dockerfile: .docker/update-poetry/Dockerfile
+    volumes:
+      - .:/app
+    profiles:
+      - update
+
+  npm_update:
+    container_name: update-npm
+    build:
+      context: .
+      dockerfile: .docker/update-npm/Dockerfile
+    volumes:
+      - .:/home
+    profiles:
+      - update
+
 volumes:
   media:

--- a/docs/developer-guide/dependency-management.md
+++ b/docs/developer-guide/dependency-management.md
@@ -2,7 +2,7 @@
 
 ## Updating all dependencies
 
-From the host machine, run:
+To update dependencies, change the version in either `package.json` or `pyproject.toml` and from the host machine, run:
 
 ```sh
 fab update-deps
@@ -10,7 +10,7 @@ fab update-deps
 
 This will start two Docker machines, one to update npm and the other to update Poetry.
 
-The `package.json`, `package-lock.json`, `pyproject.toml` and `poetry.lock` files should then be updated and ready to commit.
+The `package.json`, `package-lock.json`, `pyproject.toml` and/or `poetry.lock` files should then be updated and ready to commit.
 
 ## For the backend
 

--- a/docs/developer-guide/dependency-management.md
+++ b/docs/developer-guide/dependency-management.md
@@ -1,5 +1,17 @@
 # Dependency management
 
+## Updating all dependencies
+
+From the host machine, run:
+
+```sh
+fab update-deps
+```
+
+This will start two Docker machines, one to update NPM and the other to update Poetry.
+
+The `package.json`, `package-lock.json`, `pyproject.toml` and `poetry.lock` files should then be updated and ready to commit.
+
 ## For the backend
 
 The Etna project uses [Poetry](https://python-poetry.org/docs/) to manage Python dependencies, which uses lock-file to help ensure environment consistency.
@@ -12,12 +24,10 @@ $ fab sh
 
 You can then run Poetry commands exactly [as they are documented here](https://python-poetry.org/docs/cli/).
 
-Here are the ones you'll use regularly:
-
 ### Updating local dependencies to reflect changes
 
 ```console
-poetry install --remove-untracked --no-root"
+poetry install --remove-untracked --no-root
 ```
 
 ### Adding a dependency

--- a/docs/developer-guide/dependency-management.md
+++ b/docs/developer-guide/dependency-management.md
@@ -8,7 +8,7 @@ From the host machine, run:
 fab update-deps
 ```
 
-This will start two Docker machines, one to update NPM and the other to update Poetry.
+This will start two Docker machines, one to update npm and the other to update Poetry.
 
 The `package.json`, `package-lock.json`, `pyproject.toml` and `poetry.lock` files should then be updated and ready to commit.
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -100,6 +100,14 @@ def stop(c, container_name=None):
 
 
 @task
+def update_deps(c):
+    """
+    Update npm and poetry dependencies through Docker containers
+    """
+    local("docker-compose --profile update up -d")
+
+
+@task
 def restart(c):
     """
     Restart the local development environment.


### PR DESCRIPTION
This allows us to run `fab update-deps` to update all dependencies for npm and Poetry.

Two Docker instances are created and the updates happens inside them. This ensures a consistent environment for updating (identical versions of Python, Node etc.)

Behind the scenes, `fab update-deps` runs `docker-compose --profile update up -d` which starts up the two Docker instances defined in `docker-compose.yml`. Their volumes are mapped to the current working directory so they can write changes back and then they shut down after updating.

These two images are not affected by `fab build` or `fab start`.

In the future we can look to remove duplicated version definitions, possibly use nvm and maybe pyenv.