### PR TITLE
UN-781: Focused Article "You may be interested in" and "More stories"

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -271,11 +271,11 @@ class ArticlePage(
 
         # Identify other live pages with tags in common
         related_tags = (
-            Page.objects.live()
+            Page.objects.filter(tagged_items__tag_id__in=tag_ids)
+            .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
+            .live()
             .public()
             .not_page(self)
-            .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
-            .filter(tagged_items__tag_id__in=tag_ids)
         )
 
         return tuple(
@@ -419,11 +419,11 @@ class FocusedArticlePage(
 
         # Identify other live pages with tags in common
         related_tags = (
-            Page.objects.live()
+            Page.objects.filter(tagged_items__tag_id__in=tag_ids)
+            .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
+            .live()
             .public()
             .not_page(self)
-            .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
-            .filter(tagged_items__tag_id__in=tag_ids)
         )
 
         return tuple(

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -398,7 +398,7 @@ class FocusedArticlePage(
             customDimension7="; ".join(obj.title for obj in self.time_periods),
         )
         return data
-    
+
     @cached_property
     def similar_items(
         self,
@@ -429,7 +429,7 @@ class FocusedArticlePage(
         return tuple(
             Page.objects.filter(id__in=related_tags).order_by("-first_published_at")[:3]
         )
-    
+
     @cached_property
     def latest_items(
         self,

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -398,6 +398,62 @@ class FocusedArticlePage(
             customDimension7="; ".join(obj.title for obj in self.time_periods),
         )
         return data
+    
+    @cached_property
+    def similar_items(
+        self,
+    ) -> Tuple[Union["ArticlePage", "FocusedArticlePage", "RecordArticlePage"], ...]:
+        """
+        Returns a maximum of three ArticlePages that are tagged with at least
+        one of the same ArticleTags. Items should be ordered by the number
+        of tags they have in common.
+        """
+        if not self.article_tag_names:
+            # Avoid unncecssary lookups
+            return ()
+
+        tag_ids = self.tagged_items.values_list("tag_id", flat=True)
+        if not tag_ids:
+            # Avoid unncecssary lookups
+            return ()
+
+        # Identify other live pages with tags in common
+        related_tags = (
+            Page.objects.live()
+            .public()
+            .not_page(self)
+            .exact_type(ArticlePage, FocusedArticlePage, RecordArticlePage)
+            .filter(tagged_items__tag_id__in=tag_ids)
+        )
+
+        return tuple(
+            Page.objects.filter(id__in=related_tags).order_by("-first_published_at")[:3]
+        )
+    
+    @cached_property
+    def latest_items(
+        self,
+    ) -> List[Union["ArticlePage", "FocusedArticlePage", "RecordArticlePage"]]:
+        """
+        Return the three most recently published ArticlePages,
+        excluding this object.
+        """
+
+        latest_query_set = []
+
+        for page_type in [ArticlePage, FocusedArticlePage, RecordArticlePage]:
+            latest_query_set.extend(
+                page_type.objects.live()
+                .public()
+                .exclude(id__in=[page.id for page in self.similar_items])
+                .not_page(self)
+                .select_related("teaser_image")
+                .prefetch_related("teaser_image__renditions")
+            )
+
+        return sorted(
+            latest_query_set, key=lambda x: x.first_published_at, reverse=True
+        )[:3]
 
 
 class RecordArticlePage(

--- a/etna/articles/tests/test_similar_items.py
+++ b/etna/articles/tests/test_similar_items.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from wagtail.models import Site
 
-from ..models import ArticlePage, ArticleTag, TaggedArticle
+from ..models import ArticlePage, ArticleTag, TaggedArticle, FocusedArticlePage
 
 
 class TestArticlePageSimilarItems(TestCase):
@@ -98,5 +98,102 @@ class TestArticlePageSimilarItems(TestCase):
 
     def test_search_prevented_if_no_tag_matches_identified(self):
         test_page = ArticlePage.objects.get(id=self.different_tags_page.id)
+        with self.assertNumQueries(4):
+            self.assertFalse(test_page.similar_items)
+
+
+class TestFocusedArticlePageSimilarItems(TestCase):
+    def setUp(self):
+        root = Site.objects.get().root_page
+
+        # Add pages
+        self.original_page = FocusedArticlePage(
+            title="Original", intro="test", teaser_text="test"
+        )
+        root.add_child(instance=self.original_page)
+        self.untagged_page = FocusedArticlePage(
+            title="Untagged", intro="test", teaser_text="test"
+        )
+        root.add_child(instance=self.untagged_page)
+        self.single_match_page = FocusedArticlePage(
+            title="Single", intro="test", teaser_text="test"
+        )
+        root.add_child(instance=self.single_match_page)
+        self.two_matches_page = FocusedArticlePage(
+            title="Two", intro="test", teaser_text="test"
+        )
+        root.add_child(instance=self.two_matches_page)
+        self.three_matches_page = FocusedArticlePage(
+            title="Three", intro="test", teaser_text="test"
+        )
+        root.add_child(instance=self.three_matches_page)
+        self.draft_page = FocusedArticlePage(
+            title="Draft", intro="test", teaser_text="test", live=False
+        )
+        root.add_child(instance=self.draft_page)
+        self.different_tags_page = FocusedArticlePage(
+            title="Different", intro="test", teaser_text="test"
+        )
+        root.add_child(instance=self.different_tags_page)
+
+        # Set tag values for above pages
+        for page in (
+            self.original_page,
+            self.three_matches_page,
+            self.draft_page,
+        ):
+            page.tagged_items = [
+                TaggedArticle(tag=t)
+                for t in ArticleTag.objects.filter(
+                    slug__in=["americas", "army", "asia"]
+                )
+            ]
+            page.save()
+
+        self.two_matches_page.tagged_items = [
+            TaggedArticle(tag=t)
+            for t in ArticleTag.objects.filter(slug__in=["americas", "army"])
+        ]
+        self.two_matches_page.save()
+
+        self.single_match_page.tagged_items = [
+            TaggedArticle(tag=t) for t in ArticleTag.objects.filter(slug="americas")
+        ]
+        self.single_match_page.save()
+
+        self.different_tags_page.tagged_items = [
+            TaggedArticle(tag=t)
+            for t in ArticleTag.objects.filter(slug__in=["ufos", "witchcraft"])
+        ]
+        self.different_tags_page.save()
+
+    def test_similar_items_ranking(self):
+        # Items should be in 'most recent' order
+        # No draft items should be included
+        test_page = FocusedArticlePage.objects.get(id=self.original_page.id)
+        with self.assertNumQueries(3):
+            self.assertEqual(
+                list(page.id for page in test_page.similar_items),
+                [
+                    self.three_matches_page.id,
+                    self.two_matches_page.id,
+                    self.single_match_page.id,
+                ],
+            )
+
+    def test_all_queries_prevented_when_article_tag_names_is_blank(self):
+        test_page = FocusedArticlePage.objects.get(id=self.original_page.id)
+        test_page.article_tag_names = ""
+        with self.assertNumQueries(0):
+            self.assertFalse(test_page.similar_items)
+
+    def test_further_queries_prevented_when_no_tags_available(self):
+        test_page = FocusedArticlePage.objects.get(id=self.untagged_page.id)
+        test_page.article_tag_names = "foobar"
+        with self.assertNumQueries(1):
+            self.assertFalse(test_page.similar_items)
+
+    def test_search_prevented_if_no_tag_matches_identified(self):
+        test_page = FocusedArticlePage.objects.get(id=self.different_tags_page.id)
         with self.assertNumQueries(4):
             self.assertFalse(test_page.similar_items)

--- a/etna/articles/tests/test_similar_items.py
+++ b/etna/articles/tests/test_similar_items.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from wagtail.models import Site
 
-from ..models import ArticlePage, ArticleTag, TaggedArticle, FocusedArticlePage
+from ..models import ArticlePage, ArticleTag, FocusedArticlePage, TaggedArticle
 
 
 class TestArticlePageSimilarItems(TestCase):

--- a/etna/articles/tests/test_similar_items.py
+++ b/etna/articles/tests/test_similar_items.py
@@ -195,5 +195,5 @@ class TestFocusedArticlePageSimilarItems(TestCase):
 
     def test_search_prevented_if_no_tag_matches_identified(self):
         test_page = FocusedArticlePage.objects.get(id=self.different_tags_page.id)
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             self.assertFalse(test_page.similar_items)

--- a/templates/articles/focused_article_page.html
+++ b/templates/articles/focused_article_page.html
@@ -45,13 +45,35 @@
         </div>
     </div>
 
-    {% if page.primary_topic or page.primary_time_period %}
-        <div class="related-content related-content--borderless">
-            <div class="container">
+    <div class="related-content related-content--borderless">
+        <div class="container">
+            {% if page.similar_items %}
+                <h2 class="related-content__heading">You may also be interested in</h2>
+
+                <ul class="card-group--list-style-none">
+                    {% for item in page.similar_items %}
+                        {% include 'includes/card-group-secondary-nav.html' with link_page=item.specific heading="You may also be interested in" card_type="Featured" show_type_label=True %}
+                    {% endfor %}
+                </ul>
+            {% endif %}
+
+
+            {% if page.primary_topic or page.primary_time_period %}
                 {% include "includes/related_topic_timeline_cards.html" with topic=page.primary_topic time_period=page.primary_time_period title="Discover highlights from the collection" %}
-            </div>
+            {% endif %}
+
+
+            {% if page.latest_items %}
+                <h2 class="related-content__heading">More stories</h2>
+
+                <ul class="card-group--list-style-none">
+                    {% for item in page.latest_items %}
+                        {% include 'includes/card-group-secondary-nav.html' with link_page=item heading="More stories" card_type="Featured" show_type_label=True %}
+                    {% endfor %}
+                </ul>
+            {% endif %}
         </div>
-    {% endif %}
+    </div>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Ticket URL: [UN-781]

## About these changes

- Added `similar_items` property to `FocusedArticlePage` to retrieve pages (`FocusedArticle`, `RecordArticle`, `Article`) with similar tags to the current page.
- Added `latest_items` property to `FocusedArticlePage` to retrieve the latest published pages (`FocusedArticle`, `RecordArticle`, `Article`).
- Added these to the HTML to display the pages.
- Created tests for the property.

## How to check these changes

Open a Focused Article page, scroll to the bottom and see that there is a section for similar items, and latest items.

The FA page must be tagged in the "article tags" section on the promote admin panel - similar items will only work if there are other pages tagged with the same tag.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-781]: https://national-archives.atlassian.net/browse/UN-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ