### PR TITLE
DF-715-Applying anchor for 'Skip to search results'

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -83,9 +83,9 @@
         <a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable" data-link="Skip to main content">Skip to main content</a>
         {% wagtailuserbar %}
 
-        {% if search_query %}
+
             <a href="#search-results-title" class="skip-to-content-link sr-only sr-only-focusable">Skip to search results</a>
-        {% endif %}
+
 
         {% if cookies_permitted %}
             {% include 'includes/gtm-no-script.html' %}

--- a/templates/search/featured_search.html
+++ b/templates/search/featured_search.html
@@ -17,7 +17,7 @@
 
     {% if buckets.tna.result_count > 0 or buckets.nonTna.result_count > 0 or buckets.creator.result_count > 0 %}
     <p class="search-results__explainer">Results for everything that matches your search term.</p>
-    <div class="featured-search__results">
+    <div id ="search-results-title" class="featured-search__results">
         {% if buckets.tna.result_count > 0 %}
             {% include './blocks/featured-search__results-block.html' with bucket=buckets.tna %}
         {% endif %}


### PR DESCRIPTION
… no search term.

Ticket URL: https://national-archives.atlassian.net/browse/DF-715

## About these changes

Adding in a 'Skip o search results' anchor, for both search term and no search term

## How to check these changes

Perform a search, check source code for sr-only : Skip to search results, click link to check that the anchor link works. Try with a search term and without. Check mobile view also.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
