### PR TITLE
Allow no-interaction create-superuser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,9 @@ services:
       - DATABASE_HOST=db
       - DATABASE_NAME=postgres
       - DATABASE_USER=postgres
-      - DJANGO_SUPERUSER_PASSWORD=app
-      - DJANGO_SUPERUSER_USERNAME=app
-      - DJANGO_SUPERUSER_EMAIL=app@app.com
+      - DJANGO_SUPERUSER_PASSWORD=wagtail
+      - DJANGO_SUPERUSER_USERNAME=wagtail
+      - DJANGO_SUPERUSER_EMAIL=wagtail@tna-development
 
   cli:
     container_name: cli

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - DATABASE_HOST=db
       - DATABASE_NAME=postgres
       - DATABASE_USER=postgres
+      - DJANGO_SUPERUSER_PASSWORD=app
+      - DJANGO_SUPERUSER_USERNAME=app
+      - DJANGO_SUPERUSER_EMAIL=app@app.com
 
   cli:
     container_name: cli

--- a/fabfile.py
+++ b/fabfile.py
@@ -176,6 +176,7 @@ def create_superuser(c):
             "python",
             "manage.py",
             "createsuperuser",
+            "--noinput"
         ]
     )
 


### PR DESCRIPTION
Rather than running `python manage.py createsuperuser` and entering some values for development, the command `fab create-superuser` now takes values from the environment variables `DJANGO_SUPERUSER_PASSWORD`, `DJANGO_SUPERUSER_USERNAME` and `DJANGO_SUPERUSER_EMAIL` to avoid entering them manually.

The default login is:

- Username: `wagtail`
- Password: `wagtail`