### PR TITLE
DF-316-moving the cancel link outside of the <form> element

### DIFF
--- a/templates/search/long_filter_options.html
+++ b/templates/search/long_filter_options.html
@@ -10,12 +10,13 @@
 
     <div class="long-filters">
         <h1 class="long-filters__heading">Select filters to apply to your results</h1>
+        <div class="long-filters__options">
+            <input type="submit" value="Apply filters" class="search-filters__submit">
+            <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>
+        </div>
         <form method="get" action="{% url url_name %}" data-id="long-filter-form" id="analytics-long-filter-form" data-long-filters>
 
-            <div class="long-filters__options">
-                <input type="submit" value="Apply filters" class="search-filters__submit">
-                <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>
-            </div>
+
 
             <div class="long-filters__filters" data-id="long-filters-container">
                 <fieldset data-id="long-filters-fieldset">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-316

## About these changes
Moved the 'Cancel and return to results' link outside the <form> element

## How to check these changes

Perform a search, chose 'more filters', check that the 'Cancel and return to results' link  displays correctly and functions corectly across viewports. Check with screen reader software - I used https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
