### PR TITLE
Fix/DF-317 screen reader see more link

### DIFF
--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -85,7 +85,7 @@
             {% endif %}
 
 
-            {% include "search/includes/filter.html" with field=form.collection %} //collections filter
+            {% include "search/includes/filter.html" with field=form.collection %} <!--collections filter-->
 
 
 

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -84,7 +84,10 @@
                 </div>
             {% endif %}
 
-            {% include "search/includes/filter.html" with field=form.collection %}
+
+            {% include "search/includes/filter.html" with field=form.collection %} //collections filter
+
+
 
             {% include "search/includes/filter.html" with field=form.time_period %}
 
@@ -97,6 +100,8 @@
             {% endif %}
 
             {% include "search/includes/filter.html" with field=form.closure %}
+
+
 
             {% if form.group.value == 'tna' or form.group.value == 'digitised' %}
                 <div class="search-filters__accordion-section">
@@ -136,6 +141,7 @@
                         <input type="submit" value="Update" class="search-filters__submit">
                     </fieldset>
                 </div>
+
             {% endif %}
 
             {% if form.group.value == bucketkeys.NONTNA.value %}
@@ -157,5 +163,6 @@
         {% render_fields_as_hidden form include='q group sort_by sort_order' %}
 
     </form>
+
     {% comment %} {% include './search_export_and_share.html' %} {% endcomment %}
 </div>

--- a/templates/search/includes/filter.html
+++ b/templates/search/includes/filter.html
@@ -8,9 +8,9 @@
             </div>
             {% if field.more_filter_options_available %}
                 {% if search_tab == searchtabs.CATALOGUE.value %}
-                    <a href="{% url 'search-catalogue-long-filter-chooser' field_name=field.name %}?{{ request.GET.urlencode }}">See more</a>
+                    <a href="{% url 'search-catalogue-long-filter-chooser' field_name=field.name %}?{{ request.GET.urlencode }}"  aria-label='See more'>See more</a>
                 {% elif search_tab == searchtabs.WEBSITE.value %}
-                    <a href="{% url 'search-website-long-filter-chooser' field_name=field.name %}?{{ request.GET.urlencode }}">See more</a>
+                    <a href="{% url 'search-website-long-filter-chooser' field_name=field.name %}?{{ request.GET.urlencode }}"  aria-label='See more'>See more</a>
                 {% endif %}
             {% endif %}
             <input type="submit" value="Update" class="search-filters__submit">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/projects/DF/issues/DF-317

## About these changes

Adding an aria-label attribute for the 'See more' link (Long filters)

## How to check these changes

Check search results page : Catalogue / Website, check that 'See more' link is read by screen reader in form mode

# Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
