### PR TITLE
Fix typography and spacing

### DIFF
--- a/dev/bin/dev-js
+++ b/dev/bin/dev-js
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-tna-node dev:css
+tna-node dev:js

--- a/etna/feedback/templates/feedback/includes/prompt.html
+++ b/etna/feedback/templates/feedback/includes/prompt.html
@@ -30,7 +30,7 @@
                 </form>
 
                 <div class="feedback__form feedback__success" id="feedback-success">
-                    <h3 class="feedback__success-heading">
+                    <h3 class="tna-heading feedback__success-heading">
                         {{ prompt.thank_you_heading }}
                     </h3>
 

--- a/etna/feedback/templates/feedback/success.html
+++ b/etna/feedback/templates/feedback/success.html
@@ -10,7 +10,7 @@
 <div class="container">
     <div class="row">
         <div class="col-12 text-center">
-            <h1>{{ prompt.thank_you_heading }}</h1>
+            <h1 class="tna-heading">{{ prompt.thank_you_heading }}</h1>
 
             {% if prompt.thank_you_message %}
                 {{ prompt.thank_you_message|richtext }}

--- a/etna/feedback/tests/test_tags.py
+++ b/etna/feedback/tests/test_tags.py
@@ -58,7 +58,7 @@ class TestRenderFeedbackPromptTag(TestCase):
             '<input type="hidden" name="page_revision" id="id_page_revision">', result
         )
         self.assertInHTML(
-            f'<h3 class="feedback__success-heading">{self.default_prompt.thank_you_heading}</h3>',
+            f'<h3 class="tna-heading feedback__success-heading">{self.default_prompt.thank_you_heading}</h3>',
             result,
         )
 
@@ -83,7 +83,7 @@ class TestRenderFeedbackPromptTag(TestCase):
             result,
         )
         self.assertInHTML(
-            f'<h3 class="feedback__success-heading">{self.default_prompt.thank_you_heading}</h3>',
+            f'<h3 class="tna-heading feedback__success-heading">{self.default_prompt.thank_you_heading}</h3>',
             result,
         )
 

--- a/etna/media/templates/wagtailmedia/chooser/chooser.html
+++ b/etna/media/templates/wagtailmedia/chooser/chooser.html
@@ -17,7 +17,7 @@
                 {% endif %}
                 {% if popular_tags %}
                     <li class="taglist">
-                        <h3>{% trans 'Popular tags' %}</h3>
+                        <h3 class="tna-heading">{% trans 'Popular tags' %}</h3>
                         {% for tag in popular_tags %}
                             <a class="suggested-tag tag" href="{% url 'wagtailmedia:index' %}?tag={{ tag.name|urlencode }}">{{ tag.name }}</a>
                         {% endfor %}

--- a/etna/search/tests/test_native_website_search.py
+++ b/etna/search/tests/test_native_website_search.py
@@ -451,7 +451,7 @@ class NativeWebsiteSearchTestCase(TestCase):
         self.assertEqual(response.context_data["paginator"].count, 0)
         self.assertContains(
             response,
-            '<h2 class="featured-search__heading">We did not find any results for your search</h2>',
+            '<h2 class="tna-heading featured-search__heading">We did not find any results for your search</h2>',
             html=True,
         )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.7.1",
       "license": "ISC",
       "dependencies": {
-        "@nationalarchives/frontend": "^0.1.14-prerelease",
+        "@nationalarchives/frontend": "^0.1.16-prerelease",
         "jest": "~29.6",
         "jquery": "~3.7",
         "openseadragon": "~4.1"
@@ -2361,9 +2361,9 @@
       }
     },
     "node_modules/@nationalarchives/frontend": {
-      "version": "0.1.14-prerelease",
-      "resolved": "https://registry.npmjs.org/@nationalarchives/frontend/-/frontend-0.1.14-prerelease.tgz",
-      "integrity": "sha512-x5LuJt6RaYz/bmiYyNxmf4oN69//4wrPm83tua1DnyUo4NVChgKvruSWgaOuN5O3D58jBOgs+7FQgZRscFMI7g==",
+      "version": "0.1.16-prerelease",
+      "resolved": "https://registry.npmjs.org/@nationalarchives/frontend/-/frontend-0.1.16-prerelease.tgz",
+      "integrity": "sha512-KJueufDUqbj3xvh0hfzBf4ez2nva1HXXCwR5WiiM9u8nYWG5TcmclWDQAJOAugKAGnwAdwsZjvZbPqTrETgSog==",
       "engines": {
         "node": "18.x",
         "npm": "9.x"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "~5.1"
   },
   "dependencies": {
-    "@nationalarchives/frontend": "^0.1.14-prerelease",
+    "@nationalarchives/frontend": "^0.1.16-prerelease",
     "jest": "~29.6",
     "jquery": "~3.7",
     "openseadragon": "~4.1"

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -176,6 +176,10 @@ $largest-small-device: 992px;
     margin-bottom: 3rem;
 }
 
+.tna-skip-link {
+    transition: none !important;
+}
+
 .template-focused-article {
     .tna-breadcrumbs__wrapper {
         // ELEMENT SPECIFIC TO THIS SITE

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -136,10 +136,11 @@ $largest-small-device: 992px;
 @import "@nationalarchives/frontend/nationalarchives/all";
 
 .tna-breadcrumbs {
-    margin-bottom: 2rem;
+    padding-bottom: 0;
 }
 
 .tna-hero {
+    margin-top: 1rem;
     margin-bottom: 2rem;
 }
 
@@ -214,9 +215,20 @@ $largest-small-device: 992px;
     }
 }
 
+.highlight-gallery {
+    color: #fff;
+    .tna-heading {
+        color: inherit;
+    }
+}
+
 .card-group-secondary-nav,
 .generic-intro__paragraph {
-    margin-bottom: 2rem;
+    margin-bottom: 4rem;
+}
+
+.section-separator__heading {
+    padding-top: 2rem;
 }
 
 .container + .container {

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -178,6 +178,18 @@ $largest-small-device: 992px;
 .tna-message {
     margin-top: 2rem;
     margin-bottom: 3rem;
+
+    &__icon {
+        flex: 1 0 2.5rem;
+
+        @include media.on-mobile {
+            flex: 1 0 1.5rem;
+        }
+    }
+
+    &__message {
+        flex: 1;
+    }
 }
 
 .tna-skip-link {
@@ -232,7 +244,7 @@ $largest-small-device: 992px;
 
 .card-group-secondary-nav,
 .generic-intro__paragraph {
-    margin-bottom: 4rem;
+    margin-bottom: 3rem;
 }
 
 .section-separator__heading {

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -135,6 +135,10 @@ $largest-small-device: 992px;
 
 @import "@nationalarchives/frontend/nationalarchives/all";
 
+.tna-template {
+    overflow: initial !important;
+}
+
 .tna-breadcrumbs {
     padding-bottom: 0;
 }

--- a/sass/includes/_generic-intro.scss
+++ b/sass/includes/_generic-intro.scss
@@ -1,5 +1,5 @@
 .generic-intro {
-    padding-top: 1rem;
+    // padding-top: 1rem;
     background-color: $color__white;
     color: $color__black;
 

--- a/sass/includes/_jumplinks.scss
+++ b/sass/includes/_jumplinks.scss
@@ -26,7 +26,9 @@
     &__list-item {
         padding: 0.3rem 0;
 
-        a {
+        a,
+        a:link,
+        a:visited {
             color: $color__link;
             position: relative;
             bottom: 3px;
@@ -38,11 +40,9 @@
     }
 
     &__list-item.active {
-        color: $color__yellow;
-
         a {
-            outline: 0.1875rem solid $color__yellow;
-            outline-offset: 0.25rem;
+            outline: 0.3125rem solid $color__yellow;
+            outline-offset: 0.125rem;
             text-decoration: none;
 
             &:focus {

--- a/templates/404.html
+++ b/templates/404.html
@@ -41,7 +41,7 @@
         {% if cookies_permitted %}
             {% include 'includes/gtm-no-script.html' %}
         {% endif %}
-        <a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable" data-link="Skip to main content">Skip to main content</a>
+        <a href="#maincontent" class="tna-skip-link" data-link="Skip to main content">Skip to main content</a>
         {% include 'includes/header.html' %}
 
         <main id="maincontent">

--- a/templates/404.html
+++ b/templates/404.html
@@ -49,7 +49,7 @@
                 <div class="container">
                     <div class="row">
                         <div class="col-12">
-                            <h1 class="generic-intro__title">
+                            <h1 class="tna-heading generic-intro__title">
                                 Page not found
                             </h1>
                         </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -40,9 +40,9 @@
             {% include 'includes/gtm-no-script.html' %}
         {% endif %}
 
-        <h1>Internal server error</h1>
+        <h1 class="tna-heading">Internal server error</h1>
 
-        <h2>Sorry, there seems to be an error. Please try again soon.</h2>
+        <h2 class="tna-heading">Sorry, there seems to be an error. Please try again soon.</h2>
 
         {% if show_cookie_notice %}
             <script src="{% static 'scripts/cookie_consent.js' %}"></script>

--- a/templates/503.html
+++ b/templates/503.html
@@ -48,7 +48,7 @@
         </div>
         <main id="maincontent">
             <div class="maintenance">
-                <h1 class="maintenance__heading">Sorry, The National Archives Beta website is temporarily down for maintenance.</h1>
+                <h1 class="tna-heading maintenance__heading">Sorry, The National Archives Beta website is temporarily down for maintenance.</h1>
                 <p class="maintenance__text">Please try again in a few minutes</p>
 <!--                <p class="maintenance__text maintenance__text&#45;&#45;small">-->
 <!--                    Follow us on <a href="https://twitter.com/UkNatArchives" rel="noopener noreferrer">Twitter</a> for updates-->

--- a/templates/account/account_inactive.html
+++ b/templates/account/account_inactive.html
@@ -10,7 +10,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-12">
-                    <h1 class="generic-intro__title">
+                    <h1 class="tna-heading generic-intro__title">
                         {% trans "Private Beta is now closed" %}
                     </h1>
                 </div>

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -12,7 +12,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-12">
-                    <h1 class="generic-intro__title">
+                    <h1 class="tna-heading generic-intro__title">
                         {% trans "Sign in" %}
                     </h1>
                 </div>
@@ -29,7 +29,7 @@
 
                     {% if form.non_field_errors or form.errors %}
                         <div class="tna-form__error-summary" role="alert" id="analytics-error-message">
-                            <h2>There is a problem</h2>
+                            <h2 class="tna-heading">There is a problem</h2>
                             <ul>
                                 {% if form.non_field_errors %}
                                     {% for error in form.non_field_errors %}

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -10,7 +10,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-12">
-                    <h1 class="generic-intro__title">
+                    <h1 class="tna-heading generic-intro__title">
                         {% trans "Sign out" %}
                     </h1>
                 </div>

--- a/templates/account/signup_closed.html
+++ b/templates/account/signup_closed.html
@@ -10,7 +10,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-12">
-                    <h1 class="generic-intro__title">
+                    <h1 class="tna-heading generic-intro__title">
                         {% trans "Signup closed" %}
                     </h1>
                 </div>

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -11,7 +11,7 @@
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     <div class="container">
-        <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
+        <h2 class="tna-heading sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>
 
     {% if page.featured_article.live %}
@@ -23,7 +23,7 @@
     </div>
 
     <div class="container mt-4" data-container-name="{{ page.title }}">
-        <h2>Discover all stories</h2>
+        <h2 class="tna-heading">Discover all stories</h2>
         <p>Browse and explore the human stories behind The National Archives’ collection.</p>
         <ul class="card-group--list-style-none">
 

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -11,7 +11,7 @@
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     <div class="container">
-        <h2 class="tna-heading sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
+        <h2 class="sr-only">{% trans "Each collection insight takes an in-depth look into a group of the records we hold." %}</h2>
     </div>
 
     {% if page.featured_article.live %}

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -30,7 +30,7 @@
     <div class="related-content related-content--borderless">
         <div class="container">
             {% if page.similar_items %}
-                <h2 class="related-content__heading">You may also be interested in</h2>
+                <h2 class="tna-heading related-content__heading">You may also be interested in</h2>
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.similar_items %}
@@ -46,7 +46,7 @@
 
 
             {% if page.latest_items %}
-                <h2 class="related-content__heading">More stories</h2>
+                <h2 class="tna-heading related-content__heading">More stories</h2>
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.latest_items %}

--- a/templates/articles/blocks/featured_collection.html
+++ b/templates/articles/blocks/featured_collection.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 
 <div class="featured-collection">
-    <h2>{{ value.heading }}</h2>
+    <h2 class="tna-heading">{{ value.heading }}</h2>
     <p>{{ value.description }}</p>
 
     <ul class="card-group--list-style-none">

--- a/templates/articles/blocks/featured_link.html
+++ b/templates/articles/blocks/featured_link.html
@@ -32,7 +32,7 @@
             {% endwith %}
         </div>
         <div class="featured-link__content">
-            <{{ heading_level }} class="featured-link__heading u-margin-xs">
+            <{{ heading_level }} class="tna-heading featured-link__heading u-margin-xs">
                 {% if value.target_blank %}
                     <a class="featured-link__heading-link" href="{{ value.url }}" data-component-name="{{ value.block.meta.label }}: {{ value.category }}" data-link-type="Banner title" data-link="{{ value.title }}" data-category="{{ value.category }}" target="_blank">
                         {{ value.title }}

--- a/templates/articles/blocks/promoted_list_block.html
+++ b/templates/articles/blocks/promoted_list_block.html
@@ -14,7 +14,7 @@
         <ul class="related-resources__list">
             {% for item in value.promoted_items %}
             <li class="related-resources__list-item">
-                <h3 class="related-resources__link-heading">
+                <h3 class="tna-heading related-resources__link-heading">
                     <a class="related-resources__link" href="{{ item.url }}" data-component-name="{{value.block.meta.label}}: {{ value.heading }}" data-link-type="{{value.block.meta.label}}" data-link="{{ item.title }}" data-position="{{ forloop.counter0 }}">
                         {{ item.title }}
                     </a>

--- a/templates/articles/blocks/promoted_pages.html
+++ b/templates/articles/blocks/promoted_pages.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags i18n %}
 <section class="promoted-pages body-container body-container--short{% if bg %} promoted-pages--bg{% endif %}">
     <div class="container">
-        <h2 class="promoted-pages__heading">{% trans value.heading %}</h2>
+        <h2 class="tna-heading promoted-pages__heading">{% trans value.heading %}</h2>
         <ul class="card-grid card-grid__trio card-grid--list promoted-pages__cards"
             data-container-name="promoted-pages"
             id="analytics-promoted-pages">
@@ -26,7 +26,7 @@
                                 alt="{% if promoted_item.teaser_image.alt_text %}{{ promoted_item.teaser_image.alt_text }}{% endif %}"/>
                         </picture>
                     </a>
-                    <h3 class="promoted-pages__title">
+                    <h3 class="tna-heading promoted-pages__title">
                         <a data-component-name="Featured card: {% trans value.heading %}" data-link-type="Card text" data-card-position="{{ forloop.counter0 }}" data-card-title="{{ promoted_item.title }}" class="promoted-pages__title-link" href="{{ promoted_item.url }}">
                             {{ promoted_item.title }}
                         </a>

--- a/templates/articles/blocks/related_item.html
+++ b/templates/articles/blocks/related_item.html
@@ -25,7 +25,7 @@
             </div>
         </a>
             <div class="card-group-secondary-nav__body">
-                <{{ heading_level }} class="card-group-secondary-nav__heading">
+                <{{ heading_level }} class="tna-heading card-group-secondary-nav__heading">
                     <a href="{{ value.url }}" 
                     class="card-group-secondary-nav__title-link" 
                     data-card-title="{{ value.title }}" 

--- a/templates/articles/blocks/related_items.html
+++ b/templates/articles/blocks/related_items.html
@@ -2,7 +2,7 @@
 
 <div class="container">
     <div class="col-12">
-        <{{ heading_level }} class="related-content__heading">{{ value.heading }}</{{ heading_level }}>
+        <{{ heading_level }} class="tna-heading related-content__heading">{{ value.heading }}</{{ heading_level }}>
         <p>{{ value.description }}</p>
     </div>
     <ul class="card-group--list-style-none" data-container-name="related-items" id="analytics-related-items">

--- a/templates/articles/blocks/section.html
+++ b/templates/articles/blocks/section.html
@@ -3,7 +3,7 @@
 <div class="section-wrapper" data-section-level="{{ content_level }}">
     <div{% if content_level == 1 %} class="section-separator"{% endif %}>
         <div class="container">
-            <{{ heading_level }} id="{{ heading_id }}" class="section-separator__heading">
+            <{{ heading_level }} id="{{ heading_id }}" class="tna-heading section-separator__heading">
                 <span class="section-separator__heading-text">
                     {{ value.heading }}
                 </span>

--- a/templates/articles/blocks/sub_heading.html
+++ b/templates/articles/blocks/sub_heading.html
@@ -1,3 +1,3 @@
 <div class="container">
-    <{{ heading_level }} id="{{ heading_id }}">{{ value.heading }}</{{ heading_level }}>
+    <{{ heading_level }} id="{{ heading_id }}" class="tna-heading">{{ value.heading }}</{{ heading_level }}>
 </div>

--- a/templates/articles/focused_article_page.html
+++ b/templates/articles/focused_article_page.html
@@ -48,7 +48,7 @@
     <div class="related-content related-content--borderless">
         <div class="container">
             {% if page.similar_items %}
-                <h2 class="related-content__heading">You may also be interested in</h2>
+                <h2 class="tna-heading related-content__heading">You may also be interested in</h2>
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.similar_items %}
@@ -64,7 +64,7 @@
 
 
             {% if page.latest_items %}
-                <h2 class="related-content__heading">More stories</h2>
+                <h2 class="tna-heading related-content__heading">More stories</h2>
 
                 <ul class="card-group--list-style-none">
                     {% for item in page.latest_items %}

--- a/templates/authors/blocks/author.html
+++ b/templates/authors/blocks/author.html
@@ -9,7 +9,7 @@
                 </div>
             {% endif %}
             <div class="col-md-8">
-                <h2 class="author-name no-margin-bottom">Authored by {{ value.author.name }}</h2>
+                <h2 class="tna-heading author-name no-margin-bottom">Authored by {{ value.author.name }}</h2>
                 {% if value.author.role %}
                     <p class="author-occupation">{{ value.author.role }}</p>
                 {% endif %}

--- a/templates/base-images.html
+++ b/templates/base-images.html
@@ -45,7 +45,7 @@
 </head>
 
 <body class="{% block body_class %}{% endblock %}">
-<a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable" data-link="Skip to main content">Skip to main content</a>
+<a href="#maincontent" class="tna-skip-link" data-link="Skip to main content">Skip to main content</a>
 
 {% include 'includes/gtm-no-script.html' %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,11 +80,11 @@
         {% if show_cookie_notice %}
             {% include 'includes/cookie-consent.html' %}
         {% endif %}
-        <a href="#maincontent" class="skip-to-content-link sr-only sr-only-focusable" data-link="Skip to main content">Skip to main content</a>
+        <a href="#maincontent" class="tna-skip-link" data-link="Skip to main content">Skip to main content</a>
         {% wagtailuserbar %}
 
 
-            <a href="#search-results-title" class="skip-to-content-link sr-only sr-only-focusable">Skip to search results</a>
+            <a href="#search-results-title" class="tna-skip-link">Skip to search results</a>
 
 
         {% if cookies_permitted %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -117,9 +117,6 @@
             {# Override this in templates to add extra javascript #}
         {% endblock %}
         <script src="{% static 'scripts/all.js' %}"></script>
-        <script>
-            window.TNAFrontend.initAll()
-        </script>
         <script src="{% static 'scripts/global_search.js' %}"></script>
         <script src="{% static 'scripts/hamburger_menu.js' %}"></script>
         <script src="{% static 'scripts/feedback_tracking.js' %}"></script>

--- a/templates/blocks/image-block-default.html
+++ b/templates/blocks/image-block-default.html
@@ -38,11 +38,11 @@
             {% if value.image.transcription or value.image.translation %}
                 <div class="transcription__text">
                     {% if value.image.transcription %}
-                        <h2>{{ value.image.get_transcription_heading_display }}</h2>
+                        <h2 class="tna-heading">{{ value.image.get_transcription_heading_display }}</h2>
                         {{ value.image.transcription|richtext }}
                     {% endif %}
                     {% if value.image.translation %}
-                        <h2>{{ value.image.get_translation_heading_display }}</h2>
+                        <h2 class="tna-heading">{{ value.image.get_translation_heading_display }}</h2>
                         {{ value.image.translation|richtext }}
                     {% endif %}
                 </div>

--- a/templates/blocks/large_links_block.html
+++ b/templates/blocks/large_links_block.html
@@ -6,7 +6,7 @@
 <div class="related-highlight-cards">
     <div class="container">
         {% if value.heading %}
-            <h2 class="card-grid__title">
+            <h2 class="tna-heading card-grid__title">
                 {{ value.heading }}
             </h2>
         {% endif %}

--- a/templates/blocks/paragraph-with-heading.html
+++ b/templates/blocks/paragraph-with-heading.html
@@ -2,7 +2,7 @@
 
 <div class="content-block">
     <div class="container">
-        <h2 class="content-block__heading">
+        <h2 class="tna-heading content-block__heading">
             {{ value.heading }}
         </h2>
         <div class="content-block__text">

--- a/templates/blocks/section_heading.html
+++ b/templates/blocks/section_heading.html
@@ -1,6 +1,6 @@
 <div id="{{ value.heading|slugify }}" class="section-separator">
     <div class="container">
-        <h2 class="section-separator__heading">
+        <h2 class="tna-heading section-separator__heading">
             {{ value.heading }}
         </h2>
     </div>

--- a/templates/collections/blocks/promoted_pages.html
+++ b/templates/collections/blocks/promoted_pages.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 
-<h2>{{ value.heading }}</h2>
+<h2 class="tna-heading">{{ value.heading }}</h2>
 <p>{{ value.sub_heading }}</p>
 <div class="row">
     <ul class="card-group--list-style-none" data-container-name="promoted-pages" id="analytics-promoted-pages">
@@ -40,7 +40,7 @@
                     </div>
                 </a>
                 <div class="card-group-secondary-nav__body">
-                    <h3 class="card-group-secondary-nav__heading">
+                    <h3 class="tna-heading card-group-secondary-nav__heading">
                         <a href="{{ promoted_item.url }}" 
                         class="card-group-secondary-nav__title-link" 
                         data-card-type="card-group-secondary-nav" 

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -16,7 +16,7 @@
     </div>
     
     <div class="container">
-        <h2>{{ page.articles_title }}</h2>
+        <h2 class="tna-heading">{{ page.articles_title }}</h2>
 
         <p>{{ page.articles_introduction }}</p>
     </div>

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -9,7 +9,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h2 class="tna-heading sr-only">Select a time period</h2>
+            <h2 class="sr-only">Select a time period</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-time-period" id="analytics-select-a-time-period">
                 {% for child in page.time_period_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with link_page=child.specific card_type="Navigation" %}

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -9,7 +9,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h2 class="sr-only">Select a time period</h2>
+            <h2 class="tna-heading sr-only">Select a time period</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-time-period" id="analytics-select-a-time-period">
                 {% for child in page.time_period_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with link_page=child.specific card_type="Navigation" %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -9,7 +9,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h2 class="sr-only">Select a topic</h2>
+            <h2 class="tna-heading sr-only">Select a topic</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-topic" id="analytics-select-a-topic">
                 {% for child in page.topic_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with link_page=child.specific card_type="Navigation" %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -9,7 +9,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h2 class="tna-heading sr-only">Select a topic</h2>
+            <h2 class="sr-only">Select a topic</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-topic" id="analytics-select-a-topic">
                 {% for child in page.topic_explorer_pages %}
                     {% include 'includes/card-group-secondary-nav.html' with link_page=child.specific card_type="Navigation" %}

--- a/templates/home/blocks/featured_external_page.html
+++ b/templates/home/blocks/featured_external_page.html
@@ -34,7 +34,7 @@ from a block for containing external page data or Wagtail page via its URL
             </div>
         </a>
         <div class="card-group-secondary-nav__body">
-            <h3 class="card-group-secondary-nav__heading">
+            <h3 class="tna-heading card-group-secondary-nav__heading">
                 <a href='{{ value.url }}'
                 id="card-group-secondary-nav__desc{{ value.id }}{% if instance_id %}-{{ instance_id }}{% endif %}" 
                 class="card-group-secondary-nav__title-link" 

--- a/templates/home/blocks/featured_items.html
+++ b/templates/home/blocks/featured_items.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 
-<h2 class="tna-heading sr-only">Featured items</h2>
+<h2 class="sr-only">Featured items</h2>
 <ul class="card-group--list-style-none" data-container-name="featured-items" id="analytics-featured-items">
     {% for block in value.0 %}
         {% include_block block %}

--- a/templates/home/blocks/featured_items.html
+++ b/templates/home/blocks/featured_items.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 
-<h2 class="sr-only">Featured items</h2>
+<h2 class="tna-heading sr-only">Featured items</h2>
 <ul class="card-group--list-style-none" data-container-name="featured-items" id="analytics-featured-items">
     {% for block in value.0 %}
         {% include_block block %}

--- a/templates/home/blocks/featured_page.html
+++ b/templates/home/blocks/featured_page.html
@@ -33,7 +33,7 @@ containging a page with fields to optionally override some fields.
             </div>
         </a>
         <div class="card-group-secondary-nav__body">
-            <h3 class="card-group-secondary-nav__heading">
+            <h3 class="tna-heading card-group-secondary-nav__heading">
                 <a href='{{ value.page.url }}'
                 id="card-group-secondary-nav__desc{{ value.id | default:value.page.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"
                 class="card-group-secondary-nav__title-link"

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -2,7 +2,7 @@
 
 <div class="container">
     {% if title %}
-        <h2 class="extra-padding">{% translate title %}</h2>
+        <h2 class="tna-heading extra-padding">{% translate title %}</h2>
     {% endif %}
     <div class="featured-article u-margin-m">
         {% if page.teaser_image %}
@@ -26,7 +26,7 @@
         {% endif %}
 
         <div class="featured-article__description">
-            <h2 class="featured-article__heading">
+            <h2 class="tna-heading featured-article__heading">
                 {% if page.has_custom_type_label %}
                     <small>{{ page.type_label }}</small>
                 {% endif %}

--- a/templates/includes/breadcrumb.html
+++ b/templates/includes/breadcrumb.html
@@ -1,7 +1,7 @@
 {% if self.get_ancestors|length > 1 %}
-<div class="tna-breadcrumbs__wrapper">
-    <div class="tna-breadcrumbs tna-container">
-        <nav class="tna-column tna-column--full" aria-label="Breadcrumb">
+<div class="tna-breadcrumbs" data-module="tna-breadcrumbs">
+    <div class="tna-container">
+        <nav class="tna-breadcrumbs__wrapper tna-column tna-column--full" aria-label="Breadcrumb">
             <ol class="tna-breadcrumbs__list">
                 <li class="tna-breadcrumbs__item">
                     <a href="/" class="tna-breadcrumbs__link" data-component-name="Breadcrumb" data-link-type="Breadcrumb link" data-link="Home">

--- a/templates/includes/card-group-promo--green.html
+++ b/templates/includes/card-group-promo--green.html
@@ -6,7 +6,7 @@
 {% image page.teaser_image fill-626x383 as teaser_image_extra_large %}
 
 <li class="card-group-promo--green">
-    <h2 class="card-group-promo__heading">{{ heading }}</h2>
+    <h2 class="tna-heading card-group-promo__heading">{{ heading }}</h2>
 
     <div class="card-group-promo__card">
         <div class="row">
@@ -23,7 +23,7 @@
                 </picture>
             </div>
             <div class="col-md-12 col-lg-5 col-xl-6">
-                <h3 class="card-group-promo__card-heading"><a href="{{ page.url }}" data-card-type="card-group-promo" data-card-title="{{ page.title }}">{{ page.title }}</a></h3>
+                <h3 class="tna-heading card-group-promo__card-heading"><a href="{{ page.url }}" data-card-type="card-group-promo" data-card-title="{{ page.title }}">{{ page.title }}</a></h3>
                 <p class="card-group-promo__card-paragraph">{{ page.introduction }}</p>
             </div>
         </div>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -37,7 +37,7 @@
             {% if show_type_label and link_page.type_label %}
                 <p class="card-group-secondary-nav__title-label">{{ link_page.type_label }}</p>
             {% endif %}
-            <h3 class="card-group-secondary-nav__heading">
+            <h3 class="tna-heading card-group-secondary-nav__heading">
                 <a
                     href="{{ link_page.url }}"
                     class="card-group-secondary-nav__title-link"

--- a/templates/includes/content-block.html
+++ b/templates/includes/content-block.html
@@ -1,6 +1,6 @@
 <div class="content-block">
     <div class="container">
-        <h3 class="content-block__heading">
+        <h3 class="tna-heading content-block__heading">
             Shakespeare's career
         </h3>
         <div class="content-block__text">

--- a/templates/includes/generic-intro.html
+++ b/templates/includes/generic-intro.html
@@ -5,7 +5,7 @@
 <div class="generic-intro{% if classes %} {{ classes }}{% endif %}">
     <div class="tna-container">
         <div class="tna-column tna-column--full">
-            <h1 class="tna-heading tna-heading--xl tna-!--margin-top-xl">
+            <h1 class="tna-heading tna-heading--xl tna-!--margin-top-l">
                 {{ title }}
             </h1>
             {% if intro %}

--- a/templates/includes/generic-intro.html
+++ b/templates/includes/generic-intro.html
@@ -5,7 +5,7 @@
 <div class="generic-intro{% if classes %} {{ classes }}{% endif %}">
     <div class="tna-container">
         <div class="tna-column tna-column--full">
-            <h1 class="tna-heading tna-heading--xl">
+            <h1 class="tna-heading tna-heading--xl tna-!--margin-top-xl">
                 {{ title }}
             </h1>
             {% if intro %}

--- a/templates/includes/highlight-intro.html
+++ b/templates/includes/highlight-intro.html
@@ -29,7 +29,7 @@
     <div class="container">
         <div class="highlight-intro__standout-container">
             <div class="highlight-intro__standout">
-                <h1 class="highlight-intro__title">{{ title }}</h1>
+                <h1 class="tna-heading highlight-intro__title">{{ title }}</h1>
                 <div class="highlight-intro__intro">{{ intro|richtext }}</div>
             </div>
         </div>

--- a/templates/includes/highlight_gallery_teaser.html
+++ b/templates/includes/highlight_gallery_teaser.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags wagtailcore_tags i18n %}
 <section class="highlight-gallery-teaser">
     <div class="container">
-        <h2 class="highlight-gallery-teaser__title">
+        <h2 class="tna-heading highlight-gallery-teaser__title">
             {% trans "Explore records about" %} <a class="highlight-gallery-teaser__title-link"
         href="{% pageurl page %}" 
         data-component-name="Featured card: {% trans "Explore records about" %} {% trans title %}"
@@ -33,7 +33,7 @@
                             alt="{{ card.alt_text }}"/>
                     </a>
                     <div class="highlight-gallery-teaser__content">
-                        <h3 class="highlight-gallery-teaser__text">
+                        <h3 class="tna-heading highlight-gallery-teaser__text">
                             <a class="highlight-gallery-teaser__link"
                             href="{% pageurl card.page %}#highlight{{ forloop.counter0 }}"
                             data-card-position="{{ forloop.counter0 }}"

--- a/templates/includes/highlights-gallery.html
+++ b/templates/includes/highlights-gallery.html
@@ -7,7 +7,7 @@
                 <div class="highlight-gallery__wrapper u-margin-m">
                     <div class="highlight-gallery__item">
                         <div class="highlight-gallery__content">
-                            <h2 class="highlight-gallery__heading">{{ highlight.image.title }}</h2>
+                            <h2 class="tna-heading highlight-gallery__heading">{{ highlight.image.title }}</h2>
                             <div class="highlight-gallery__intro">
                                 {% if highlight.image.record_dates %}<p>Date: {{ highlight.image.record_dates }}</p>{% endif %}
                                 {% if highlight.image.record %}

--- a/templates/includes/image_gallery.html
+++ b/templates/includes/image_gallery.html
@@ -1,7 +1,7 @@
 {% load static wagtailimages_tags wagtailcore_tags records_tags %}
 <div class="transcription u-margin-xs" data-image-gallery>
     {% if page.gallery_heading %}
-        <h2 class="transcription__gallery-heading">{{ page.gallery_heading }}</h2>
+        <h2 class="tna-heading transcription__gallery-heading">{{ page.gallery_heading }}</h2>
     {% endif %}
     <div class="transcription__preview hidden">
         <div class="transcription__container">
@@ -70,11 +70,11 @@
                 {% if item.image.transcription or item.image.translation %}
                     <div class="transcription__text">
                         {% if item.image.transcription %}
-                            <h2>{{ item.image.get_transcription_heading_display }}</h2>
+                            <h2 class="tna-heading">{{ item.image.get_transcription_heading_display }}</h2>
                             {{ item.image.transcription|richtext }}
                         {% endif %}
                         {% if item.image.translation %}
-                            <h2>{{ item.image.get_translation_heading_display }}</h2>
+                            <h2 class="tna-heading">{{ item.image.get_translation_heading_display }}</h2>
                             {{ item.image.translation|richtext }}
                         {% endif %}
                     </div>

--- a/templates/includes/jumplinks.html
+++ b/templates/includes/jumplinks.html
@@ -1,6 +1,6 @@
 {% if sections %}
     <nav class="jumplinks">
-        <h2 class="jumplinks__heading u-margin-s">On this page</h2>
+        <h2 class="tna-heading jumplinks__heading u-margin-s">On this page</h2>
         <ol class="jumplinks__list">
             {% for section in sections %}
                 <li class="jumplinks__list-item">

--- a/templates/includes/record-embed--no-image.html
+++ b/templates/includes/record-embed--no-image.html
@@ -8,7 +8,7 @@
         <p class="record-embed-no-image__icon-label" role="presentation" aria-hidden="true">
             Discover our records
         </p>
-        <h3 class="record-embed-no-image__heading">
+        <h3 class="tna-heading record-embed-no-image__heading">
             <span class="sr-only">Discover our records.</span>
             Shakespeare and James I
         </h3>

--- a/templates/includes/record-matters.html
+++ b/templates/includes/record-matters.html
@@ -3,7 +3,7 @@
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-10 col-sm-12">
-                <h2 class="story-title">{% trans title %}</h2>
+                <h2 class="tna-heading story-title">{% trans title %}</h2>
                 {% if page.date_text or record.reference_number %}
                     <div class="record-matters__content">
                         {% if page.date_text %}

--- a/templates/includes/record-revealed-intro.html
+++ b/templates/includes/record-revealed-intro.html
@@ -4,7 +4,7 @@
         <div class="row">
             <div class="col-lg-8 col-sm-12">
                 <p class="explore-intro__title explore-intro__title--meta u-margin-s">Record revealed</p>
-                <h1 class="explore-intro__title u-margin-s">{{ page.title }}</h1>
+                <h1 class="tna-heading explore-intro__title u-margin-s">{{ page.title }}</h1>
                 <div class="explore-intro__paragraph{% if display_content_warning %} explore-intro__paragraph--short{% endif %} u-margin-l">{{ page.intro|richtext }}</div>
                 {% if display_content_warning %}    
                     {% include "includes/content-warning.html" with custom_warning_text=custom_warning_text %} 

--- a/templates/includes/record-revealed.html
+++ b/templates/includes/record-revealed.html
@@ -25,7 +25,7 @@
                     <p class="featured-record-article__meta u-margin-xxs">{{ link_page.type_label }}</p>
                 {% endif %}
                 <a href="{% pageurl link_page %}" class="featured-record-article__link" data-component-name="Featured record article" data-link-type="Banner title" data-link="{{ link_page.title }}">
-                    <h3 class="featured-record-article__title u-margin-xs">{{ link_page.title }}</h3>
+                    <h3 class="tna-heading featured-record-article__title u-margin-xs">{{ link_page.title }}</h3>
                 </a>
                 {% if link_page.date_text %}
                     <p class="featured-record-article__date u-margin-xs">{{ link_page.date_text }}</p>

--- a/templates/includes/records/archive-additional-resources.html
+++ b/templates/includes/records/archive-additional-resources.html
@@ -1,6 +1,6 @@
 {% if record.archive_accessions.accession_years %}
     <div class="archive-additional-resources">
-        <h2>Accessions</h2>
+        <h2 class="tna-heading">Accessions</h2>
         <p>These are selected lists of new or additional collections that were acquired by this archive during a specific year. If a date is not displayed there are no accessions for that year.</p>
 
         <form action="" id="archive" method="GET">
@@ -18,7 +18,7 @@
 
 {% if record.archive_repository_url %}
     <div class="archive-additional-resources">
-        <h2>Other finding aids</h2>
+        <h2 class="tna-heading">Other finding aids</h2>
         <ul>
             <li><a href="{{ record.archive_repository_url }}">Repository's catalogue</a></li>
             <li><a href="{{ discovery_browse }}/{{ record.iaid }}">Browse records in Discovery</a></li>

--- a/templates/includes/records/archive-collections.html
+++ b/templates/includes/records/archive-collections.html
@@ -1,9 +1,9 @@
 {% if record.archive_collections.collection_info_list %}
     <div class="archive-collections">
-        <h2>Collections information</h2>
+        <h2 class="tna-heading">Collections information</h2>
             {% for collection in record.archive_collections.collection_info_list %}
                 {% if collection.count > 0 %}
-                    <h3  id="heading-{{collection.name}}">{{ collection.long_display_name }} ({{ collection.count }})</h3>                    
+                    <h3 class="tna-heading" id="heading-{{collection.name}}">{{ collection.long_display_name }} ({{ collection.count }})</h3>                    
                     <div class="archive-collections__container">
                         <ul class="archive-collections__list">
                             {% for info in collection.info_list %}

--- a/templates/includes/records/archive-description.html
+++ b/templates/includes/records/archive-description.html
@@ -1,7 +1,7 @@
 <div class="archive-description">
-    <h1>{{ record.title }}</h1>
+    <h1 class="tna-heading">{{ record.title }}</h1>
     <div class="archive-description__contact">
-        <h2>Contact information</h2>
+        <h2 class="tna-heading">Contact information</h2>
         
         <p><b>Address:</b> {{ record.archive_contact_info.address_line1 }}, {{ record.archive_contact_info.address_town }}, {{ record.archive_contact_info.address_country }}. {{ record.archive_contact_info.postcode }}</p>
         
@@ -49,13 +49,13 @@
     <div class="archive-description__container">
         <div class="row">
             <div class="col-lg-8">
-                <h2>Key information</h2>
+                <h2 class="tna-heading">Key information</h2>
                 ARCHON code: {{ record.reference_number }}</br>
                 {{ record.archive_further_info.comments }}
             </div>
             {% if record.archive_collections.collection_info_list %}
                 <div class="col-lg-4">
-                    <h2>Summary of collections</h2>                    
+                    <h2 class="tna-heading">Summary of collections</h2>                    
                     <ul>
                         {% for collection in record.archive_collections.collection_info_list %}
                             {% if collection.count > 0 %}

--- a/templates/includes/records/hierarchy-global.html
+++ b/templates/includes/records/hierarchy-global.html
@@ -7,7 +7,7 @@
 
         <!-- SHORT HIERARCHY VIEW -->
         <nav class="hierarchy-short-panel" role="navigation" aria-labelledby="short-hierarchy-title">
-            <h2 class="hierarchy-short-panel__heading sr-only" id="short-hierarchy-title">Catalogue location at a glance</h2>
+            <h2 class="tna-heading hierarchy-short-panel__heading sr-only" id="short-hierarchy-title">Catalogue location at a glance</h2>
             <p class="hierarchy-short-panel__label">You are here:</p>
 
             <ul class="hierarchy-short-panel__list">
@@ -68,7 +68,7 @@
 
         <!-- DETAILED HIERARCHY VIEW -->
         <nav class="hierarchy-full-panel" role="navigation" data-id="hierarchy-detailed-view" aria-labelledby="detailed-hierarchy-title">
-            <h2 class="hierarchy-full-panel__heading" id="detailed-hierarchy-title">Detailed catalogue location:</h2>
+            <h2 class="tna-heading hierarchy-full-panel__heading" id="detailed-hierarchy-title">Detailed catalogue location:</h2>
 
             <!-- Level 1 -->
             <div class="hierarchy-full-panel__bar-container-outer">

--- a/templates/includes/records/record-access-options.html
+++ b/templates/includes/records/record-access-options.html
@@ -14,7 +14,7 @@ this template
 <div class="record-access" data-container-name="record-access" id="analytics-record-access">
     {% if page.availability_delivery_condition == 'TooLargeToCopyOriginal' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>This record has not been digitised and cannot be downloaded.</p>
         <details>
             <summary data-link="Further information">Further information</summary>
@@ -28,7 +28,7 @@ this template
 
     {% elif page.availability_delivery_condition == 'OrderOriginal' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>This record has not been digitised and cannot be downloaded.</p>
         <details>
             <summary data-link="Further information">Further information</summary>
@@ -41,7 +41,7 @@ this template
 
     {% elif page.availability_delivery_condition == 'InvigilationSafeRoom' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>This record can only be seen under supervision at The National Archives</p>
         <p>Request a quotation for a copy to be digitised or printed and sent to you.  </p>
 
@@ -51,7 +51,7 @@ this template
 
     {% elif page.availability_delivery_condition == 'Surrogate' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>This record has not been digitised and cannot be downloaded.</p>
         <p>Request a quotation for a copy to be digitised and sent to you.</p>
 
@@ -61,7 +61,7 @@ this template
 
     {% elif page.availability_delivery_condition == 'DigitizedDiscovery' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>Free</p>
         <p>Download format PDF</p>
         <p>Approximate size 16 MB</p>
@@ -71,11 +71,11 @@ this template
 
     {% elif page.availability_delivery_condition == 'UnAvailable' %}
 
-        <h3>This record is not available to order. More information may be available in the catalogue description.</h3>
+        <h3 class="tna-heading">This record is not available to order. More information may be available in the catalogue description.</h3>
 
     {% elif page.availability_delivery_condition == 'Offsite' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>This record has not been digitised and cannot be downloaded.</p>
 
         <details>
@@ -90,7 +90,7 @@ this template
 
     {% elif page.availability_delivery_condition == 'DigitizedAvailableButNotDownloadableAtPieceLevel' %}
 
-        <h3>Ordering and viewing options</h3>
+        <h3 class="tna-heading">Ordering and viewing options</h3>
         <p>This record has been digitised as part of multiple records</p>
         <p>You can browse for these records.</p>
         <ul class="record-access__list">
@@ -99,13 +99,13 @@ this template
 
     {% elif page.availability_delivery_condition == 'CollectionCare' %}
 
-        <h3>This record requires supervised handling in Collection Care</h3>
+        <h3 class="tna-heading">This record requires supervised handling in Collection Care</h3>
         <p>The National Archives is closed until further notice due to the Covid-19 pandemic. For updated information <a href="https://www.nationalarchives.gov.uk/about/news/coronavirus-update/">read our news story</a>.</p>
         <p>Please expect further delays once normal operations have resumed.</p>
 
     {% else %}
 
-        <h3> Ordering and viewing options currently unavailable</h3>
+        <h3 class="tna-heading"> Ordering and viewing options currently unavailable</h3>
 
     {% endif %}
 </div>

--- a/templates/includes/records/record-crosslink-panel.html
+++ b/templates/includes/records/record-crosslink-panel.html
@@ -1,7 +1,7 @@
 {% load records_tags %}
 
 <div class="crosslink-panel">
-    <h2>How to order/download this record</h2>
+    <h2 class="tna-heading">How to order/download this record</h2>
     <ol>
         <li>View this record page in Discovery – our catalogue</li>
         <li>Check viewing options</li>

--- a/templates/includes/records/record-series-panel.html
+++ b/templates/includes/records/record-series-panel.html
@@ -3,7 +3,7 @@
 <div class="series-panel">
     {% include "includes/icon.html" with name="diagram-folder" classname="series-panel__icon" %}
     <div class="series-panel__container">
-        <h3 class="series-panel__heading"><span class="series-panel__reference">{{record.hierarchy.1.reference_number}}</span>{{record.hierarchy.1.summary_title}}</h3>
+        <h3 class="tna-heading series-panel__heading"><span class="series-panel__reference">{{record.hierarchy.1.reference_number}}</span>{{record.hierarchy.1.summary_title}}</h3>
         <p>See the series level description for more information about this record.</p>
         <a class="series-panel__link" href="{% record_url record.hierarchy.1 %}" data-link-type="Link" data-link="View series description" data-component-name="Series link">View series description</a>
     </div>

--- a/templates/includes/records/record-title.html
+++ b/templates/includes/records/record-title.html
@@ -3,6 +3,6 @@
 <div class="record-title">
     <p class="record-title__description">You are viewing the catalogue description of the following item:</p>
     {% if record.summary_title %}
-        <h1 class="record-title__heading">{{ record.summary_title }}</h1>
+        <h1 class="tna-heading record-title__heading">{{ record.summary_title }}</h1>
     {% endif %}
 </div>

--- a/templates/includes/records/record_creator_collections.html
+++ b/templates/includes/records/record_creator_collections.html
@@ -1,5 +1,5 @@
 <div class="record-creator-collections">
-    <h2>Summary of collections</h2>
+    <h2 class="tna-heading">Summary of collections</h2>
     <div class="record-creator-collections__table-container">
         <table class="record-creator-collections__table">
             <thead>

--- a/templates/includes/records/record_creator_description.html
+++ b/templates/includes/records/record_creator_description.html
@@ -1,8 +1,8 @@
 <div class="record-creator-description">
-    <h1>{{ record.summary_title }}</h1>
+    <h1 class="tna-heading">{{ record.summary_title }}</h1>
     
     <div class="record-creator-description__container">
-        <h2>Details of this record creator</h2>
+        <h2 class="tna-heading">Details of this record creator</h2>
         <table class="record-creator-description__table">
             <tbody>                
                 {% if record.alternative_names %}

--- a/templates/includes/related-articles-highlight-cards.html
+++ b/templates/includes/related-articles-highlight-cards.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 <div class="highlight-cards">
     <div class="container">
-        <h2 class="highlight-cards__title">{{ title }}</h2>
+        <h2 class="tna-heading highlight-cards__title">{{ title }}</h2>
         <div class="card-grid card-grid__quad">
             {% if featured_article %}
                 <div class="highlight-cards__card highlight-cards__card--highlight highlight-cards__link">
@@ -24,7 +24,7 @@
                             alt=""/>
                     </a>
                     <div class="highlight-cards__content">
-                        <h3 class="highlight-cards__card_title">
+                        <h3 class="tna-heading highlight-cards__card_title">
                             <a href="{% pageurl featured_article %}"
                             id="highlight-cards__card-desc{{ featured_article.id }}"
                             class="highlight-cards__card-title-link"
@@ -67,7 +67,7 @@
                             alt=""/>
                     </a>
                     <div class="highlight-cards__card__content">
-                        <h3 class="highlight-cards__card_title">
+                        <h3 class="tna-heading highlight-cards__card_title">
                             <a href="{% pageurl article %}"
                             id="highlight-cards__card-desc{{ article.id }}"
                             class="highlight-cards__card-title-link"

--- a/templates/includes/related-highlight-cards.html
+++ b/templates/includes/related-highlight-cards.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 <section class="related-highlight-cards">
     <div class="container">
-        <h2 class="related-highlight-cards__title">{{ title }} highlights in pictures</h2>
+        <h2 class="tna-heading related-highlight-cards__title">{{ title }} highlights in pictures</h2>
         <div class="card-grid card-grid__trio">
             {% for card in cards %}
                 <div class="related-highlight-cards__card">
@@ -30,7 +30,7 @@
                         </picture>
                     </a>
                     <div class="related-highlight-cards__content">
-                        <h3 class="related-highlight-cards__card-title" id="related-highlight-card-title-{{ forloop.counter }}">
+                        <h3 class="tna-heading related-highlight-cards__card-title" id="related-highlight-card-title-{{ forloop.counter }}">
                             <a href="{{ card.url }}"
                                 id="related-highlight-cards__card-desc{{ card.id }}{% if instance_id %}-{{ instance_id }}{% endif %}"                                class="related-highlight-cards__card-title-link"
                                 data-component-name="Featured card: {{ title }} highlights in pictures"

--- a/templates/includes/related_topic_timeline_cards.html
+++ b/templates/includes/related_topic_timeline_cards.html
@@ -1,7 +1,7 @@
 {% load static wagtailimages_tags wagtailcore_tags %}
 <div class="related-highlight-cards">
     <div class="container">
-        <h2 class="card-grid__title">{{ title|default:"You may be interested in" }}</h2>
+        <h2 class="tna-heading card-grid__title">{{ title|default:"You may be interested in" }}</h2>
         <div class="card-grid card-grid__duo">
             {% if topic %}
                 <div class="related-highlight-cards__card">

--- a/templates/includes/research-resources.html
+++ b/templates/includes/research-resources.html
@@ -7,7 +7,7 @@
             Research
         </p>
 
-        <h3 class="research-resources__heading">
+        <h3 class="tna-heading research-resources__heading">
             Research resources
             <span class="sr-only">Research</span>
         </h3>
@@ -19,7 +19,7 @@
         <dl class="research-resources__list">
             <div class="research-resources__list-item">
                 <dt>
-                    <h4 class="research-resources__link-heading">
+                    <h4 class="tna-heading research-resources__link-heading">
                         <a class="research-resources__link" href="https://www.nationalarchives.gov.uk/education/resources/tudor-entertainment/" data-link="0: Tudor Entertainment">
                             Tudor Entertainment
                         </a>
@@ -31,7 +31,7 @@
             </div>
             <div class="research-resources__list-item">
                 <dt>
-                    <h4 class="research-resources__link-heading">
+                    <h4 class="tna-heading research-resources__link-heading">
                         <a class="research-resources__link" href="https://www.nationalarchives.gov.uk/education/resources/james-i/" data-link="1: James I">
                             James I
                         </a>

--- a/templates/media/blocks/media-block--embed.html
+++ b/templates/media/blocks/media-block--embed.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load wagtailcore_tags %}
 
-<h3 class="media-embed__heading u-margin-xs">
+<h3 class="tna-heading media-embed__heading u-margin-xs">
     <span class="sr-only">{% if media.type == "video" %}Video.{% elif media.type == "audio" %}Listen.{% endif %}</span>
     {{ value.title }}
 </h3>
@@ -30,7 +30,7 @@
 <div class="media-embed__transcript">
     <details class="media-embed__details">
         <summary class="media-embed__summary">
-            <h4 class="media-embed__transcript-heading">Transcript</h4>
+            <h4 class="tna-heading media-embed__transcript-heading">Transcript</h4>
         </summary>
         <div class="media-embed__transcript-text">
             {{ media.transcript|richtext }}

--- a/templates/password_pages/password_required.html
+++ b/templates/password_pages/password_required.html
@@ -13,7 +13,7 @@
     <div class="container">
         <div class="row">
             <div class="col-12">
-                <h1>Password required</h1>
+                <h1 class="tna-heading">Password required</h1>
                 <p>
                     You need a password to access this page.
                 </p>

--- a/templates/records/blocks/record_links_block.html
+++ b/templates/records/blocks/record_links_block.html
@@ -11,7 +11,7 @@
                     {% endif %}
                     <div class="record-links__item__text">
                         <p class="record-links__item__reference"><span class="sr-only">Link to record </span>IN THE CATALOGUE: {{ item.record.reference_number }}</p>
-                        <h2 class="record-links__item__title">
+                        <h2 class="tna-heading record-links__item__title">
                             <a data-component-name="{{ value.block.label }}" data-link-type="Link list" data-position="{{ forloop.counter0 }}" data-link="{{ item.descriptive_title }}" href="{% record_url item.record is_editorial=True %}">{{ item.descriptive_title }}</a>
                         </h2>
                         <p class="record-links__item__dates">{{ item.record_dates }}</p>

--- a/templates/records/image-browse.html
+++ b/templates/records/image-browse.html
@@ -17,7 +17,7 @@
     <div class="image-browse">
         <div class="image-browse__header">
             <div class="image-browse__reference_and_count">
-                <h1><strong>{{ page.reference_number }}</strong>
+                <h1 class="tna-heading"><strong>{{ page.reference_number }}</strong>
                     <span>- {{ images_count }} images</span>
                 </h1>
             </div>

--- a/templates/records/image-viewer.html
+++ b/templates/records/image-viewer.html
@@ -10,7 +10,7 @@
         <div class="image-viewer" data-container-name="image-viewer" id="analytics-image-viewer">
             <div class="image-viewer__header">
                 <div class="image-viewer__reference">
-                    <h1>{{ images.has_other_pages }}<strong>{{ page.reference_number }}</strong> <span>- Image {{ index|add:'1' }} of {{ images_count }}</span></h1>
+                    <h1 class="tna-heading">{{ images.has_other_pages }}<strong>{{ page.reference_number }}</strong> <span>- Image {{ index|add:'1' }} of {{ images_count }}</span></h1>
                 </div>
                 <nav class="image-viewer__navigation" aria-label="Explore this record">
 

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -19,14 +19,14 @@
         {% include "includes/records/record-title.html" %}
         {% include "includes/records/hierarchy-global.html" %}
 
-        <h2 id="record-details-heading">Description and record details</h2>
+        <h2 id="record-details-heading" class="tna-heading">Description and record details</h2>
 
         {% include "includes/records/record-details.html" %}
         {% include "includes/records/record-crosslink-panel.html" %}
 
         {% if record.hierarchy %}
             {% if record.hierarchy|length > 2 %}
-                <h2>This record is in the series</h2>
+                <h2 class="tna-heading">This record is in the series</h2>
 
                 {% include "includes/records/record-series-panel.html" %}
             {% endif %}

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -19,7 +19,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h2 class="tna-heading sr-only">Associated records</h2>
+            <h2 class="sr-only">Associated records</h2>
 
             <ul class="card-group--list-style-none" data-container-name="associated-records"
                 id="analytics-associated-records">

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -8,7 +8,7 @@
 
     <div class="disambiguation-explanation">
         <div class="container">
-            <h2 class="disambiguation-explanation__subheading">Several records share the
+            <h2 class="tna-heading disambiguation-explanation__subheading">Several records share the
                 reference {{ queried_reference_number }}. </h2>
             <p>Very occasionally (less than 1% of the time) a record shares its catalogue reference with other records
                 in the catalogue, usually with its own sub-records. This is the case with
@@ -19,7 +19,7 @@
 
     <div class="container mt-4">
         <div class="row">
-            <h2 class="sr-only">Associated records</h2>
+            <h2 class="tna-heading sr-only">Associated records</h2>
 
             <ul class="card-group--list-style-none" data-container-name="associated-records"
                 id="analytics-associated-records">

--- a/templates/search/blocks/catalogue_search_buckets.html
+++ b/templates/search/blocks/catalogue_search_buckets.html
@@ -5,7 +5,7 @@
    <form method="GET" class="search-sort-view__form" data-id="search-bucket-mobile" id="search-bucket-mobile">
    
     
-        <h2 class="search-sort-view__heading">
+        <h2 class="tna-heading search-sort-view__heading">
             <label for="id-for-this-dropdown">Show results from:</label>
         </h2>
         <select name="group" id="id-for-this-dropdown" class="search-sort-view__form-select">

--- a/templates/search/blocks/featured-search__interpretive-card.html
+++ b/templates/search/blocks/featured-search__interpretive-card.html
@@ -2,7 +2,7 @@
 {% load search_tags %}
 <!--
 <div class="featured-search__interpretive-results-section">
-    <h2 class="featured-search__heading">{{ bucket.label }}</h2>
+    <h2 class="tna-heading featured-search__heading">{{ bucket.label }}</h2>
     {% for record in bucket.results|slice:":1" %}
         <div>
             <a href={% record_url record %} aria-hidden="true" tabindex="-1" class="featured-search__interpretive-card-link">
@@ -18,7 +18,7 @@
             </a>
                 <div>
                     <a href={% record_url record %} class="featured-search__results-link">
-                        <h3 class="featured-search__heading">
+                        <h3 class="tna-heading featured-search__heading">
                             {{ record.summary_title }}
                         </h3>
                     </a>

--- a/templates/search/blocks/featured-search__record-creator.html
+++ b/templates/search/blocks/featured-search__record-creator.html
@@ -1,7 +1,7 @@
 {% load records_tags %}
 {% load search_tags %}
 <div class="featured-search__results-block">
-    <h2 class="featured-search__heading">{{ bucket.label }}</h2>
+    <h2 class="tna-heading featured-search__heading">{{ bucket.label }}</h2>
 
     {% for record in bucket.results|slice:":3" %}
         <div class="featured-search__record-creator">
@@ -14,7 +14,7 @@
                     -->
                 </a>
             </div>
-            <h3 class="featured-search__results-heading"><a href="{% record_url record %}" class="featured-search__results-link">{{ record.summary_title }}</a></h3>
+            <h3 class="tna-heading featured-search__results-heading"><a href="{% record_url record %}" class="featured-search__results-link">{{ record.summary_title }}</a></h3>
         </div>
     {% endfor %}
 

--- a/templates/search/blocks/featured-search__results-block.html
+++ b/templates/search/blocks/featured-search__results-block.html
@@ -1,12 +1,12 @@
 {% load records_tags %}
 {% load search_tags %}
 <div class="featured-search__results-block">
-    <h2 class="featured-search__heading">{{ bucket.label }}</h2>
+    <h2 class="tna-heading featured-search__heading">{{ bucket.label }}</h2>
     <ul class="featured-search__results-list">
         {% for record in bucket.results %}
             <li class="featured-search__results-list-item">
                 <a href="{% record_url record %}" class="featured-search__results-link">
-                    <h3 class="featured-search__results-heading">
+                    <h3 class="tna-heading featured-search__results-heading">
                         {{ record.summary_title }}
                     </h3>
                 </a>

--- a/templates/search/blocks/native_website_result.html
+++ b/templates/search/blocks/native_website_result.html
@@ -23,7 +23,7 @@
 
     <div class="search-results__list-card-details order-md-1">
 
-        <h3 class="search-results__list-card-heading">
+        <h3 class="tna-heading search-results__list-card-heading">
             <a href="{% pageurl result %}" class="search-results__list-card-heading-link" data-link="{{ result.title }}" data-link-type="Search results list" search-bucket="Website results">
                 {{ result.title }}
             </a>

--- a/templates/search/blocks/no_results.html
+++ b/templates/search/blocks/no_results.html
@@ -7,7 +7,7 @@
 </style>
 
 <div class="no-results">
-    <h2 class="featured-search__heading">We did not find any results for your search</h2>
+    <h2 class="tna-heading featured-search__heading">We did not find any results for your search</h2>
     <p class="search-results__explainer">Some record descriptions are much less detailed than others, so you may not find what you are looking for using a simple keyword search.</p> 
 
     <ul>

--- a/templates/search/blocks/no_results_catalogue_website.html
+++ b/templates/search/blocks/no_results_catalogue_website.html
@@ -2,7 +2,7 @@
 <!-- need to add in logic to check the number of results, if 0 then display the message-->
 
 <div class="no-results">
-    <h2 class="featured-search__heading">We did not find any results for your search</h2>
+    <h2 class="tna-heading featured-search__heading">We did not find any results for your search</h2>
     <p class="search-results__explainer">Some record descriptions are much less detailed than others, so you may not find what you are looking for using a simple keyword search.</p> 
 
     <ul>

--- a/templates/search/blocks/no_results_website.html
+++ b/templates/search/blocks/no_results_website.html
@@ -3,6 +3,6 @@
 </style>
 
 <div class="no-results">
-    <h2 class="featured-search__heading">We did not find any results for your search</h2>
+    <h2 class="tna-heading featured-search__heading">We did not find any results for your search</h2>
     <p class="search-results__explainer">Try again with different spellings or search terms or <a href="/search/website/">view all</a> website results.</p>
 </div>

--- a/templates/search/blocks/search_export_and_share.html
+++ b/templates/search/blocks/search_export_and_share.html
@@ -1,6 +1,6 @@
 {% load static %}
 <div>
-    <h2 class="sr-only">Export and share</h2>
+    <h2 class="tna-heading sr-only">Export and share</h2>
     <div class="search-results__export-container" href="#">
         <a href="#" class="search-results__export-link" >Export results</a> <img class="search-results__share-icon" src="{% static 'images/icons/download.svg' %}" alt=""/>
     </div>

--- a/templates/search/blocks/search_export_and_share.html
+++ b/templates/search/blocks/search_export_and_share.html
@@ -1,6 +1,6 @@
 {% load static %}
 <div>
-    <h2 class="tna-heading sr-only">Export and share</h2>
+    <h2 class="sr-only">Export and share</h2>
     <div class="search-results__export-container" href="#">
         <a href="#" class="search-results__export-link" >Export results</a> <img class="search-results__share-icon" src="{% static 'images/icons/download.svg' %}" alt=""/>
     </div>

--- a/templates/search/blocks/search_filters.html
+++ b/templates/search/blocks/search_filters.html
@@ -2,7 +2,7 @@
 
 <div class="search-sort-view">
     <form method="GET" class="search-sort-view__form search-sort-view__mobile" data-id="sort-form" id="catalogue-sort-form-mobile" data-search-type="{{ view.search_tab }}" data-search-bucket="{{ buckets.current.label }}" data-search-filter-name="Sort results" data-search-filter-value="">
-        <h2 class="search-sort-view__heading">
+        <h2 class="tna-heading search-sort-view__heading">
             <label for="id_sort_by_mobile">Sort by</label>
         </h2>
         {{ form.sort_by.errors }}
@@ -17,7 +17,7 @@
 
 <div class="search-filters" data-search-filters>
     {% comment %} Hidden on archive & creator as they currently have no filters  {% endcomment %}
-    <h2 class="search-filters__heading">Refine results</h2>
+    <h2 class="tna-heading search-filters__heading">Refine results</h2>
 
     <form method="GET" data-id="filters-form"  id="catalogue-filters-form">
         {% comment %}
@@ -41,13 +41,13 @@
         {% endif %}
 
         <div class="search-filters__form-block">
-            <h3 class="sr-only">Edit filters</h3>
+            <h3 class="tna-heading sr-only">Edit filters</h3>
 
             {% if form.group.value == 'tna' or form.group.value == 'digitised' or form.group.value == 'nonTna' %}
                 <div class="search-filters__accordion-section">
                     <fieldset>
                         <legend>
-                            <h4 class="search-filters__accordion-section-heading" id="record_covering_date">Dates</h4>
+                            <h4 class="tna-heading search-filters__accordion-section-heading" id="record_covering_date">Dates</h4>
                         </legend>
 
                         <span class="example-text">For example, 27 3 2007</span>
@@ -107,7 +107,7 @@
                 <div class="search-filters__accordion-section">
                     <fieldset>
                         <legend>
-                            <h4 class="search-filters__accordion-section-heading" id="record_opening_date">Record opening date</h4>
+                            <h4 class="tna-heading search-filters__accordion-section-heading" id="record_opening_date">Record opening date</h4>
                         </legend>
 
                         <div class="search-filters__opening-date-section">

--- a/templates/search/blocks/search_landing_hero.html
+++ b/templates/search/blocks/search_landing_hero.html
@@ -3,7 +3,7 @@
         <div class="tna-container">
             <div class="tna-column tna-column--full">
                 <div class="search-landing-hero__container">
-                    <h1 class="search-landing-hero__heading">Search</h1>
+                    <h1 class="tna-heading search-landing-hero__heading">Search</h1>
                     <div class="search-landing-hero__form">
                         <label for="id_q" class="search-landing-hero__label">
                             <span class="sr-only">Enter search term.</span> For example, naturalisation or medal cards

--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -30,7 +30,7 @@
     </div>
 
     {% if page.object_list %}
-        <h2 class="sr-only">Results</h2>
+        <h2 class="tna-heading sr-only">Results</h2>
 
         {% if form.cleaned_data.display == "grid" %}
             <ul class="search-results__list--grid" id="analytics-results-list">

--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -30,7 +30,7 @@
     </div>
 
     {% if page.object_list %}
-        <h2 class="tna-heading sr-only">Results</h2>
+        <h2 class="sr-only">Results</h2>
 
         {% if form.cleaned_data.display == "grid" %}
             <ul class="search-results__list--grid" id="analytics-results-list">

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -15,7 +15,7 @@
 
     <div class="search-results__list-card-content">
 
-        <h4 class="search-results__list-card-heading">
+        <h4 class="tna-heading search-results__list-card-heading">
             {% if apply_teaser_image %}
                 <div class="search-results__list-card-full-width-image">
                     <picture>

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -12,7 +12,7 @@
 
 <li class="search-results__list-card" data-iaid="{{ record.iaid }}" data-score="{{ record.score }}">
     <div class="search-results__list-card-details">
-        <h3 class="search-results__list-card-heading">
+        <h3 class="tna-heading search-results__list-card-heading">
             <a href="{% if form.group.value == bucketkeys.ARCHIVE.value %}{% record_url record level_or_archive='Archive' form_group=form.group.value %}{% else %}{% record_url record level_or_archive=record.level form_group=form.group.value %}{% endif %}" class="search-results__list-card-heading-link" data-link="{{ record.reference_prefixed_summary_title }}" data-link-type="Search results list" search-bucket="{{ buckets.current.label }}">
                 {% if record.reference_number %}
                 <span class="sr-only">Reference number {{ record.reference_number }}: </span>

--- a/templates/search/blocks/search_results__selected-filters.html
+++ b/templates/search/blocks/search_results__selected-filters.html
@@ -1,7 +1,7 @@
 {% load search_tags %}
 
 {% if selected_filters %}
-    <h2 class="tna-heading sr-only">Selected filters</h2>
+    <h2 class="sr-only">Selected filters</h2>
 
     <ul class="search-results__selected-filters" data-search-bucket="{{ buckets.current.label }}">
         {% for field_name, selected_options in selected_filters.items %}

--- a/templates/search/blocks/search_results__selected-filters.html
+++ b/templates/search/blocks/search_results__selected-filters.html
@@ -1,7 +1,7 @@
 {% load search_tags %}
 
 {% if selected_filters %}
-    <h2 class="sr-only">Selected filters</h2>
+    <h2 class="tna-heading sr-only">Selected filters</h2>
 
     <ul class="search-results__selected-filters" data-search-bucket="{{ buckets.current.label }}">
         {% for field_name, selected_options in selected_filters.items %}

--- a/templates/search/blocks/search_results_hero.html
+++ b/templates/search/blocks/search_results_hero.html
@@ -1,7 +1,7 @@
 {% load search_tags %}
 
 <div class="search-results-hero">
-    <h1 class="search-results-hero__heading">{{search_tab|search_title}}</h1>
+    <h1 class="tna-heading search-results-hero__heading">{{search_tab|search_title}}</h1>
     <form method="GET" class="search-results-hero__form" data-id="search-form" id="catalogue-search-form">
 
         <label for="{{form.q.id_for_label}}" class="sr-only">Search term</label>

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -4,7 +4,7 @@
 <div class="search-sort-view">
     <form method="GET" class="search-sort-view__form search-sort-view__desktop" data-id="sort-form" id="catalogue-sort-form-desktop" data-search-type="{{ view.search_tab }}" data-search-bucket="{{ buckets.current.label }}" data-search-filter-name="Sort results" data-search-filter-value="">
 
-        <h2 class="search-sort-view__heading">
+        <h2 class="tna-heading search-sort-view__heading">
            <label for="id_sort_by_desktop">Sort by</label>
         </h2>
 
@@ -16,7 +16,7 @@
         <input type="submit" value="Update" class="search-sort-view__form-submit">
     </form>
 
-    <h2 class="search-sort-view__heading"><span class="sr-only">Display as:</span></h2>
+    <h2 class="tna-heading search-sort-view__heading"><span class="sr-only">Display as:</span></h2>
     <ul class="search-sort-view__list">
 
         <li class="search-sort-view__list-item">

--- a/templates/search/blocks/survey.html
+++ b/templates/search/blocks/survey.html
@@ -7,7 +7,7 @@
 
             <div class="col-sm-12 col-lg-12">
                 <div class="survey-outline">
-                    <h3>What did you think of this page?</h3>
+                    <h3 class="tna-heading">What did you think of this page?</h3>
 
                     <span id ="replacer-easy">
                     <a class="tna-button--dark response-btn" href="#" id="easy" rel="noopener noreferrer" tabindex="1" data-component-name="Feedback" data-link="Easy to use"><span><img class="thumb-image" src="{% static 'images/thumb-up.png' %}" alt=""> Easy to use</span></a>
@@ -28,7 +28,7 @@
 <noscript>
     <div class="cta-banner-survey cta-banner-survey--border cta-banner-survey--no-js">
     <div class="container py-3">
-        <h3>What did you think of this page?</h3>
+        <h3 class="tna-heading">What did you think of this page?</h3>
         <div class="rowr">
           <a href="https://www.smartsurvey.co.uk/s/SY13JD/" target="_blank">Take our short survey</a>
         </div>

--- a/templates/search/featured_search.html
+++ b/templates/search/featured_search.html
@@ -36,7 +36,7 @@
         <div class="container-fluid">
         <section class="featured-search__website-results">
             <header class="featured-search__website-results__head">
-                <h2 class="featured-search__website-results__heading">Results from the website</h2>
+                <h2 class="tna-heading featured-search__website-results__heading">Results from the website</h2>
                 <a href="/search/website?q={{ search_query|iriencode }}" class="featured-search__website_results-link">
                         See all{% if search_query %} relevant{% endif %} website results ({{ website_result_count }})
                 </a>

--- a/templates/search/includes/filter.html
+++ b/templates/search/includes/filter.html
@@ -1,7 +1,7 @@
 {% if field.field.choices and field.field.choices_updated %}
     <div class="search-filters__accordion-section">
         <fieldset>
-            <legend><h4 class="search-filters__accordion-section-heading">{{ field.label }}</h4></legend>
+            <legend><h4 class="tna-heading search-filters__accordion-section-heading">{{ field.label }}</h4></legend>
             <div>
                 {{ field.errors }}
                 {{ field }}

--- a/templates/search/long_filter_options.html
+++ b/templates/search/long_filter_options.html
@@ -9,7 +9,7 @@
 {% block content %}
 
     <div class="long-filters">
-        <h1 class="long-filters__heading">Select filters to apply to your results</h1>
+        <h1 class="tna-heading long-filters__heading">Select filters to apply to your results</h1>
         <div class="long-filters__options">
             <input type="submit" value="Apply filters" class="search-filters__submit">
             <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>

--- a/templates/search/native_website_search.html
+++ b/templates/search/native_website_search.html
@@ -65,7 +65,7 @@
                         </div>
 
                         {% if page.object_list %}
-                            <h2 class="tna-heading sr-only">Results</h2>
+                            <h2 class="sr-only">Results</h2>
 
                             <ul class="search-results__list{% if form.cleaned_data.display == "grid" %}--grid{% endif %}" id="analytics-results-list">
                                 {% for obj in page %}

--- a/templates/search/native_website_search.html
+++ b/templates/search/native_website_search.html
@@ -65,7 +65,7 @@
                         </div>
 
                         {% if page.object_list %}
-                            <h2 class="sr-only">Results</h2>
+                            <h2 class="tna-heading sr-only">Results</h2>
 
                             <ul class="search-results__list{% if form.cleaned_data.display == "grid" %}--grid{% endif %}" id="analytics-results-list">
                                 {% for obj in page %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -17,7 +17,7 @@
     <div class="search-landing-buckets">
         <div class="tna-container">
             <div class="tna-column tna-column--full">
-                <h2 class="search-landing-buckets__heading">
+                <h2 class="tna-heading search-landing-buckets__heading">
                     See all records from the catalogue
                 </h2>  
             </div>


### PR DESCRIPTION
- Update frontend to [v0.1.16-prerelease](https://github.com/nationalarchives/tna-frontend/releases/tag/v0.1.16-prerelease) - also includes [v0.1.15-prerelease](https://github.com/nationalarchives/tna-frontend/releases/tag/v0.1.15-prerelease)
- Expandable breadcrumbs for pages more than two layers deep
- Full width skip link (see https://nationalarchives.github.io/tna-frontend/?path=/story/components-skip-link--standard)
- Slightly heavier weight body font (Open Sans 400 -> Open Sans 500)
- Fixed spacing around elements towards the top of the page
- Fixed icon size in warning messages
- Fixed sticky sidebar in article pages

Before
![Screenshot 2023-08-29 at 17 56 36](https://github.com/nationalarchives/ds-wagtail/assets/2356642/e9b061f8-ddb5-4f19-a605-3e76db61da1f)

After
![Screenshot 2023-08-29 at 17 56 33](https://github.com/nationalarchives/ds-wagtail/assets/2356642/77928570-aab0-46ab-abb3-291bc1492805)

---

Before
![Screenshot 2023-08-29 at 17 56 43](https://github.com/nationalarchives/ds-wagtail/assets/2356642/c7aca6c5-de38-41e1-838e-fa26f93df46d)

After
![Screenshot 2023-08-29 at 17 56 41](https://github.com/nationalarchives/ds-wagtail/assets/2356642/6d428acd-04b0-4552-a22c-6be3a4b7d71e)

---

Before
![Screenshot 2023-08-29 at 17 57 04](https://github.com/nationalarchives/ds-wagtail/assets/2356642/598d08c5-0ae5-4c49-91a0-28d81b640e62)

After
![Screenshot 2023-08-29 at 17 57 02](https://github.com/nationalarchives/ds-wagtail/assets/2356642/41ba9b64-db82-4167-907c-91c7c24b7701)

---

Before
![Screenshot 2023-08-29 at 17 59 42](https://github.com/nationalarchives/ds-wagtail/assets/2356642/960d5902-e82e-4ef6-b9b7-19387a1f495a)

After
![Screenshot 2023-08-29 at 17 59 44](https://github.com/nationalarchives/ds-wagtail/assets/2356642/a0ae186e-50f1-4c9f-8a9d-2b28b536593b)