### PR TITLE
CSS bugs

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -163,6 +163,7 @@ $largest-small-device: 992px;
 }
 
 .tna-hero__body {
+    color: #fff;
     font-size: 1.25rem;
 
     @include media.on-mobile {

--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -163,10 +163,10 @@ $largest-small-device: 992px;
 }
 
 .tna-hero__body {
-    color: #fff;
     font-size: 1.25rem;
 
     @include media.on-mobile {
+        color: #fff;
         font-size: 1rem;
         line-height: 1.5;
     }
@@ -243,9 +243,18 @@ $largest-small-device: 992px;
     }
 }
 
-.card-group-secondary-nav,
+.card-group-secondary-nav {
+    margin-bottom: 2rem;
+}
+
 .generic-intro__paragraph {
     margin-bottom: 3rem;
+}
+
+.related-highlight-cards {
+    .related-highlight-cards__card {
+        margin-top: 2rem;
+    }
 }
 
 .section-separator__heading {

--- a/sass/includes/_card-groups.scss
+++ b/sass/includes/_card-groups.scss
@@ -33,7 +33,7 @@
             text-transform: uppercase;
             font-size: 0.875rem;
 
-            @media only screen and (min-width: $screen__md) {
+            @media only screen and (min-width: #{$screen__md + 1px}) {
                 font-size: 0.9rem;
             }
         }
@@ -46,7 +46,7 @@
             color: $color__black;
             text-decoration-thickness: 1px;
 
-            @media only screen and (min-width: $screen__md) {
+            @media only screen and (min-width: #{$screen__md + 1px}) {
                 font-size: 1.25rem;
             }
 
@@ -99,7 +99,7 @@
             display: block;
         }
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: block;
         }
     }

--- a/sass/includes/_content-block.scss
+++ b/sass/includes/_content-block.scss
@@ -1,7 +1,7 @@
 .content-block {
     padding: 0.5rem 0;
 
-    @media (min-width: $screen__lg) {
+    @media (min-width: #{$screen__lg + 1px}) {
         .template-focused-article & {
             padding-left: 10%;
             padding-right: 10%;

--- a/sass/includes/_content-warning.scss
+++ b/sass/includes/_content-warning.scss
@@ -3,13 +3,13 @@
     border-left: 4px solid #ffcc00;
     padding: 1.5rem 1.75rem;
 
-    @media screen and (min-width: $screen__sm) {
+    @media screen and (min-width: #{$screen__sm + 1px}) {
         display: flex;
         padding: 1.25rem 2rem;
         margin-top: 2rem;
     }
 
-    @media screen and (min-width: $screen__md) {
+    @media screen and (min-width: #{$screen__md + 1px}) {
         margin-bottom: 3rem;
     }
 
@@ -27,7 +27,7 @@
     }
 
     &--short {
-        @media screen and (min-width: $screen__md) {
+        @media screen and (min-width: #{$screen__md + 1px}) {
             margin-bottom: 1.25rem;
         }
     }
@@ -49,7 +49,7 @@
         min-width: 34px;
         margin-right: 18px;
 
-        @media (min-width: $screen__sm) {
+        @media (min-width: #{$screen__sm + 1px}) {
             display: block;
         }
     }

--- a/sass/includes/_explore-intro.scss
+++ b/sass/includes/_explore-intro.scss
@@ -40,7 +40,7 @@
         @include font-size(m);
         line-height: 1.5;
 
-        @media (min-width: $screen__md) {
+        @media (min-width: #{$screen__md + 1px}) {
             @include font-size(xl);
         }
 

--- a/sass/includes/_featured-article.scss
+++ b/sass/includes/_featured-article.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
 
-    @media only screen and (min-width: $screen__md) {
+    @media only screen and (min-width: #{$screen__md + 1px}) {
         flex-direction: row;
     }
 
@@ -55,7 +55,7 @@
             margin-bottom: 0.5rem;
             text-transform: uppercase;
 
-            @media only screen and (min-width: $screen__md) {
+            @media only screen and (min-width: #{$screen__md + 1px}) {
                 font-size: 0.9rem;
             }
         }

--- a/sass/includes/_featured-link.scss
+++ b/sass/includes/_featured-link.scss
@@ -4,7 +4,7 @@
     margin: 3rem 0;
 
     &__container {
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: flex;
         }
     }
@@ -15,7 +15,7 @@
         font-family: $font__body;
         font-weight: $font-weight-bold;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             @include font-size(xl);
         }
     }
@@ -39,7 +39,7 @@
     }
 
     &__image {
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             flex: 0 0 33.33%;
         }
     }
@@ -65,7 +65,7 @@
         color: $color__grey-700;
         margin-bottom: 0.75rem;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: inline-flex;
             margin: 0;
 

--- a/sass/includes/_featured-record.scss
+++ b/sass/includes/_featured-record.scss
@@ -13,7 +13,7 @@
         border-top: 1px solid $color__grey-400;
         padding-bottom: 1rem;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: flex;
             flex-direction: row;
             align-items: center;
@@ -23,7 +23,7 @@
     }
 
     &__image-text {
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: flex;
             flex-direction: row;
         }
@@ -33,7 +33,7 @@
         display: block;
         margin-bottom: 0.5rem;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             flex-basis: 40%;
             max-width: 40%;
             margin-right: 1.5rem;
@@ -57,7 +57,7 @@
             margin-right: 15px;
         }
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: block;
             padding: 2rem 1rem 2rem 0;
         }
@@ -72,7 +72,7 @@
 
     &__metadata {
         margin-bottom: 1rem;
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: flex;
             justify-content: space-evenly;
             margin-bottom: 0;
@@ -90,7 +90,7 @@
         display: block;
         text-align: center;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: inline-block;
         }
     }

--- a/sass/includes/_generic-intro.scss
+++ b/sass/includes/_generic-intro.scss
@@ -53,7 +53,7 @@
         font-size: 1.125rem; // one off font size (18px)
         margin-bottom: 0.5rem;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             font-size: 1.313rem; // one off font size (21px)
         }
 
@@ -61,7 +61,7 @@
             margin-top: 2.875rem;
             font-size: $font-size-base;
 
-            @media (min-width: $screen__md) {
+            @media (min-width: #{$screen__md + 1px}) {
                 margin-top: 4.625rem;
                 font-size: 1.313rem;
             }

--- a/sass/includes/_hero-image.scss
+++ b/sass/includes/_hero-image.scss
@@ -18,7 +18,7 @@
         }
     }
 
-    @media (min-width: $screen__md) {
+    @media (min-width: #{$screen__md + 1px}) {
         .template-focused-article & {
             &__container {
                 background: linear-gradient(

--- a/sass/includes/_hierarchy-global-nav.scss
+++ b/sass/includes/_hierarchy-global-nav.scss
@@ -6,7 +6,7 @@
     background-color: $color__yellow;
     padding: 0;
 
-    @media screen and (min-width: $screen__lg) {
+    @media screen and (min-width: #{$screen__lg + 1px}) {
         padding: 0 0 0 3.5rem;
     }
 
@@ -18,7 +18,7 @@
         top: 10px;
         left: 10px;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: block;
         }
     }
@@ -83,7 +83,7 @@
             min-width: 5rem;
         }
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             position: absolute;
             top: 0;
             right: 25px;
@@ -96,7 +96,7 @@
         padding: 0;
         margin: 1rem 0;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             margin: 1rem 0 0.25rem;
         }
     }
@@ -119,13 +119,13 @@
                 center;
             padding-left: 1.8rem;
 
-            @media screen and (min-width: $screen__lg) {
+            @media screen and (min-width: #{$screen__lg + 1px}) {
                 background: transparent;
                 padding-left: 0;
             }
         }
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: inline-block;
             margin: 0 0.75rem 0 0;
         }
@@ -133,7 +133,7 @@
             content: "...";
             display: none;
 
-            @media screen and (min-width: $screen__lg) {
+            @media screen and (min-width: #{$screen__lg + 1px}) {
                 display: inline-block;
                 margin: 0 0.75rem 0 0;
             }
@@ -153,7 +153,7 @@
         font-family: $font__supria-sans;
         font-size: 1.3rem;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             margin: 2.75rem 0 1rem 1rem;
         }
     }
@@ -164,7 +164,7 @@
         border-top: 2px solid $color__yellow;
         background: $color__yellow-dark;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             border-top: 0;
             padding: 0.25rem 0;
             background: transparent;
@@ -174,7 +174,7 @@
             border-bottom: 2px solid $color__yellow;
             background: $color__yellow;
 
-            @media screen and (min-width: $screen__lg) {
+            @media screen and (min-width: #{$screen__lg + 1px}) {
                 border-bottom: 0;
                 background: transparent;
             }
@@ -187,7 +187,7 @@
         vertical-align: top;
         color: $color__black;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             background-color: $color__yellow-dark;
             padding: 0.5rem 0.75rem;
             display: inline-block;
@@ -206,12 +206,12 @@
             margin-top: 0.25rem;
             line-height: 1.2rem;
 
-            @media screen and (min-width: $screen__sm) {
+            @media screen and (min-width: #{$screen__sm + 1px}) {
                 display: block;
                 float: right;
             }
 
-            @media screen and (min-width: $screen__lg) {
+            @media screen and (min-width: #{$screen__lg + 1px}) {
                 display: block;
                 text-align: left;
                 background: transparent;
@@ -219,7 +219,7 @@
             }
         }
         &--active {
-            @media screen and (min-width: $screen__lg) {
+            @media screen and (min-width: #{$screen__lg + 1px}) {
                 background: $color__yellow;
                 border-left: 0;
             }
@@ -229,7 +229,7 @@
                 border-bottom: 2px solid $color__grey-800;
                 font-weight: bold;
 
-                @media screen and (min-width: $screen__lg) {
+                @media screen and (min-width: #{$screen__lg + 1px}) {
                     border: 0;
                 }
             }
@@ -243,7 +243,7 @@
         color: $color__grey-700;
         letter-spacing: -0.4px;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: inline-block;
             font-size: 1.1rem;
             width: 100%;
@@ -255,7 +255,7 @@
         display: inline-block;
         text-align: right;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: inline-block;
             font-size: 0.8rem;
         }
@@ -267,10 +267,10 @@
         line-height: 1.8rem;
         width: auto;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             width: 70%;
         }
-        @media screen and (min-width: $screen__xl) {
+        @media screen and (min-width: #{$screen__xl + 1px}) {
             width: auto;
         }
 
@@ -282,7 +282,7 @@
                 color: $color__link-blue;
             }
 
-            @media screen and (min-width: $screen__lg) {
+            @media screen and (min-width: #{$screen__lg + 1px}) {
                 display: inline-block;
                 line-height: 1.4rem;
             }
@@ -295,7 +295,7 @@
         font-size: 1.15rem;
         display: inline-block;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             margin: 0.7rem 0 0;
         }
     }
@@ -341,19 +341,19 @@
         color: $color__link-blue;
     }
 
-    @media screen and (min-width: $screen__md) {
+    @media screen and (min-width: #{$screen__md + 1px}) {
         margin: 2rem 0 0.5rem;
     }
 
     &__container {
-        @media screen and (min-width: $screen__md) {
+        @media screen and (min-width: #{$screen__md + 1px}) {
             display: inline-block;
             text-align: center;
             min-width: 19%;
         }
 
         &--previous {
-            @media screen and (min-width: $screen__md) {
+            @media screen and (min-width: #{$screen__md + 1px}) {
                 margin: 0 2rem;
                 padding-right: 2rem;
                 text-align: right;
@@ -361,7 +361,7 @@
         }
 
         &--next {
-            @media screen and (min-width: $screen__md) {
+            @media screen and (min-width: #{$screen__md + 1px}) {
                 margin: 0 2rem;
                 padding-left: 2rem;
                 text-align: left;
@@ -375,7 +375,7 @@
         margin-bottom: 0.75rem;
 
         &--left {
-            @media screen and (min-width: $screen__xl) {
+            @media screen and (min-width: #{$screen__xl + 1px}) {
                 background: url($fa_chevron_left) no-repeat left 7px;
                 background-size: 8px;
                 padding: 0 1.5rem 0 0;
@@ -383,7 +383,7 @@
         }
 
         &--right {
-            @media screen and (min-width: $screen__xl) {
+            @media screen and (min-width: #{$screen__xl + 1px}) {
                 background: url($fa_chevron_right) no-repeat 75% 7px;
                 background-size: 8px;
                 padding: 0 1.5rem 0 0;

--- a/sass/includes/_hierarchy-local-nav.scss
+++ b/sass/includes/_hierarchy-local-nav.scss
@@ -37,7 +37,7 @@
     &__nav-label {
         display: none;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: inline;
         }
     }

--- a/sass/includes/_highlight-intro.scss
+++ b/sass/includes/_highlight-intro.scss
@@ -15,7 +15,7 @@
         position: relative;
 
         // mimics left & right padding of body-container to match page content
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             padding: 0 9%;
         }
     }
@@ -29,7 +29,7 @@
         padding: 28px 0 36px;
 
         // tablet and up
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             width: 46rem;
             position: absolute;
             bottom: 3.25rem;
@@ -48,7 +48,7 @@
         padding-bottom: 0.75rem;
         margin: 0;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             line-height: 1.22;
         }
     }
@@ -60,7 +60,7 @@
         padding: 0;
         margin: 0;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             @include font-size(xl);
             line-height: 1.71;
         }

--- a/sass/includes/_image-browse.scss
+++ b/sass/includes/_image-browse.scss
@@ -46,17 +46,17 @@
         grid-column-gap: 1vw;
         grid-row-gap: 1vw;
 
-        @media screen and (min-width: $screen__sm) {
+        @media screen and (min-width: #{$screen__sm + 1px}) {
             grid-template-columns: repeat(3, 1fr);
             grid-auto-rows: 33vw;
         }
 
-        @media screen and (min-width: $screen__md) {
+        @media screen and (min-width: #{$screen__md + 1px}) {
             grid-template-columns: repeat(4, 1fr);
             grid-auto-rows: 25vw;
         }
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             grid-template-columns: repeat(5, 1fr);
             grid-auto-rows: 20vw;
         }

--- a/sass/includes/_key-facts.scss
+++ b/sass/includes/_key-facts.scss
@@ -8,14 +8,14 @@
         li {
             margin-bottom: 1rem;
 
-            @media only screen and (min-width: $screen__lg) {
+            @media only screen and (min-width: #{$screen__lg + 1px}) {
                 margin-bottom: 0.3rem;
             }
 
             span {
                 display: block;
 
-                @media only screen and (min-width: $screen__lg) {
+                @media only screen and (min-width: #{$screen__lg + 1px}) {
                     display: inline-block;
                     width: 10rem;
                 }

--- a/sass/includes/_mixins.scss
+++ b/sass/includes/_mixins.scss
@@ -46,11 +46,11 @@
     } @else {
         @include rem-font-size($small-size);
 
-        @media (min-width: $screen__md) {
+        @media (min-width: #{$screen__md + 1px}) {
             @include rem-font-size($medium-size);
         }
 
-        @media (min-width: $screen__lg) {
+        @media (min-width: #{$screen__lg + 1px}) {
             @include rem-font-size($large-size);
         }
     }

--- a/sass/includes/_pagination.scss
+++ b/sass/includes/_pagination.scss
@@ -186,7 +186,7 @@
     &-link-current {
         margin-top: 0;
 
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             width: 2.5rem;
             height: 1.875rem;
             margin-top: 0.5rem;

--- a/sass/includes/_promoted-pages.scss
+++ b/sass/includes/_promoted-pages.scss
@@ -21,7 +21,7 @@
         margin-bottom: 1.5rem;
         margin-top: 3rem;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             margin-bottom: 3rem;
             margin-top: 3.75rem;
         }
@@ -36,7 +36,7 @@
         margin-bottom: 0;
         text-decoration: none;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             margin-bottom: 4.5rem;
         }
     }

--- a/sass/includes/_quote.scss
+++ b/sass/includes/_quote.scss
@@ -3,7 +3,7 @@
     margin-right: calc((2rem + 15px) * -1);
     width: calc((4rem + 30px) + 100%);
 
-    @media only screen and (min-width: $screen__md) {
+    @media only screen and (min-width: #{$screen__md + 1px}) {
         margin-left: 0;
         margin-right: 0;
         width: 100%;
@@ -17,7 +17,7 @@
         border-bottom: $default__border;
         text-align: center;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             padding: 3rem;
             margin-top: 2rem; // ideally this would be managed on the element preceeding, but not for now
         }

--- a/sass/includes/_record-cta-panel.scss
+++ b/sass/includes/_record-cta-panel.scss
@@ -6,7 +6,7 @@
     padding: 0 0.5rem;
     margin: 0.75rem 0 0;
 
-    @media screen and (min-width: $screen__sm) {
+    @media screen and (min-width: #{$screen__sm + 1px}) {
         margin: 0.5rem 0 1.5rem;
     }
 
@@ -23,7 +23,7 @@
             color: $color__link-blue;
         }
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             margin: 0 0.5rem 0.5rem 0;
         }
     }

--- a/sass/includes/_record-links.scss
+++ b/sass/includes/_record-links.scss
@@ -5,7 +5,7 @@
         flex-direction: column;
         margin-bottom: 2rem;
 
-        @media (min-width: $screen__lg) {
+        @media (min-width: #{$screen__lg + 1px}) {
             padding-left: 10%;
             padding-right: 10%;
         }
@@ -28,7 +28,7 @@
         padding-bottom: 2rem;
         width: 100%;
 
-        @media (min-width: $screen__lg) {
+        @media (min-width: #{$screen__lg + 1px}) {
             display: flex;
         }
 
@@ -39,7 +39,7 @@
             margin-left: 2rem;
             margin-bottom: 1rem;
 
-            @media (min-width: $screen__lg) {
+            @media (min-width: #{$screen__lg + 1px}) {
                 margin-bottom: 0;
             }
         }

--- a/sass/includes/_record-series-panel.scss
+++ b/sass/includes/_record-series-panel.scss
@@ -5,7 +5,7 @@
     background: $color__yellow;
     padding: 0;
 
-    @media screen and (min-width: $screen__lg) {
+    @media screen and (min-width: #{$screen__lg + 1px}) {
         padding: 0 0 0 3.5rem;
     }
 
@@ -17,7 +17,7 @@
         top: 11px;
         left: 12px;
 
-        @media screen and (min-width: $screen__lg) {
+        @media screen and (min-width: #{$screen__lg + 1px}) {
             display: block;
         }
     }

--- a/sass/includes/_record-title.scss
+++ b/sass/includes/_record-title.scss
@@ -1,7 +1,7 @@
 .record-title {
     padding: 1.5rem 0 2rem;
 
-    @media (min-width: $screen__lg) {
+    @media (min-width: #{$screen__lg + 1px}) {
         padding: 2rem 0;
     }
 

--- a/sass/includes/_related-highlight-cards.scss
+++ b/sass/includes/_related-highlight-cards.scss
@@ -69,7 +69,7 @@
     }
 
     &__content {
-        margin: 1.75rem;
+        padding: 1.75rem;
         color: $color__grey-500;
     }
 

--- a/sass/includes/_related-highlight-cards.scss
+++ b/sass/includes/_related-highlight-cards.scss
@@ -20,7 +20,7 @@
         font-size: 1.25rem;
         margin: 0 0 0.5rem 0;
 
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             font-size: 1.3rem;
         }
 

--- a/sass/includes/_related-resources.scss
+++ b/sass/includes/_related-resources.scss
@@ -2,7 +2,7 @@
     margin: 2rem 0;
     padding-bottom: 1rem;
 
-    @media (min-width: $screen__lg) {
+    @media (min-width: #{$screen__lg + 1px}) {
         .template-focused-article & {
             padding-left: 10%;
             padding-right: 10%;

--- a/sass/includes/_section-separator.scss
+++ b/sass/includes/_section-separator.scss
@@ -6,7 +6,7 @@
         color: $color__grey-700;
         background: transparent;
 
-        @media (min-width: $screen__lg) {
+        @media (min-width: #{$screen__lg + 1px}) {
             .template-focused-article & {
                 padding-left: 10%;
                 padding-right: 10%;

--- a/sass/includes/_specifics.scss
+++ b/sass/includes/_specifics.scss
@@ -17,7 +17,7 @@ When adding a style, ensure it is within the pre-pended with 'specific' class to
     Used on: Details page - */
 
     &-border-left-lg {
-        @media only screen and (min-width: $screen__xl) {
+        @media only screen and (min-width: #{$screen__xl + 1px}) {
             border-left: 2px solid $color__grey-500;
         }
     }
@@ -28,7 +28,7 @@ When adding a style, ensure it is within the pre-pended with 'specific' class to
     Used on: Details page - */
 
     &-border-top-lg {
-        @media only screen and (min-width: $screen__xl) {
+        @media only screen and (min-width: #{$screen__xl + 1px}) {
             border-top: 2px solid $color__grey-500;
         }
     }
@@ -39,7 +39,7 @@ When adding a style, ensure it is within the pre-pended with 'specific' class to
     Used on: Details page - */
 
     &-border-bottom-lg {
-        @media only screen and (min-width: $screen__xl) {
+        @media only screen and (min-width: #{$screen__xl + 1px}) {
             border-bottom: 2px solid $color__grey-500;
         }
     }
@@ -62,7 +62,7 @@ When adding a style, ensure it is within the pre-pended with 'specific' class to
     &-margin-top-sm-to-lg {
         margin: 2rem 0 0;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             margin: 0;
         }
     }

--- a/sass/includes/_transcription.scss
+++ b/sass/includes/_transcription.scss
@@ -59,7 +59,7 @@
         max-height: 100%;
         display: block;
 
-        @media screen and (min-width: $screen__sm) {
+        @media screen and (min-width: #{$screen__sm + 1px}) {
             max-width: 80%;
             margin: 0 auto;
         }

--- a/sass/includes/_utilities.scss
+++ b/sass/includes/_utilities.scss
@@ -22,7 +22,7 @@
         &-l {
             margin-bottom: 3rem; // 48px
 
-            @media only screen and (min-width: $screen__md) {
+            @media only screen and (min-width: #{$screen__md + 1px}) {
                 margin-bottom: 4.563rem; // 72px
             }
         }
@@ -30,7 +30,7 @@
         &-xl {
             margin-bottom: 3rem; // 48px
 
-            @media only screen and (min-width: $screen__md) {
+            @media only screen and (min-width: #{$screen__md + 1px}) {
                 margin-bottom: 4.563rem; // 96px
             }
         }

--- a/sass/includes/_variables.scss
+++ b/sass/includes/_variables.scss
@@ -1,8 +1,8 @@
 // Screen sizes
-$screen__sm: 30rem;
-$screen__md: 48rem;
-$screen__lg: 62rem;
-$screen__xl: 75rem;
+$screen__sm: 480px;
+$screen__md: 768px;
+$screen__lg: 992px;
+$screen__xl: 1200px;
 
 // Fonts
 $font__open-sans: "Open Sans", sans-serif;

--- a/sass/includes/search/_featured-search.scss
+++ b/sass/includes/search/_featured-search.scss
@@ -2,7 +2,7 @@
     &__results {
         margin-left: 1rem;
         margin-right: 1rem;
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             margin-left: 2rem;
             display: -ms-grid;
             display: grid;
@@ -77,7 +77,7 @@
         padding-top: 2rem;
         border-top: 3px dotted $color__grey-500;
 
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             display: grid;
             display: -ms-grid;
             -ms-grid-columns: 1fr 1fr 1fr;
@@ -123,13 +123,13 @@
     .featured-search__heading {
         padding: 1rem 1rem;
 
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             padding: 1rem 2rem;
         }
     }
 
     ul {
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             margin-left: 1rem;
         }
     }

--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -2,7 +2,7 @@
     margin-left: 1rem;
     margin-right: 1rem;
 
-    @media only screen and (min-width: $screen__md) {
+    @media only screen and (min-width: #{$screen__md + 1px}) {
         margin-left: 2rem;
         margin-right: 2rem;
     }
@@ -13,12 +13,12 @@
 
     &__options {
         padding-bottom: 2rem;
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             margin-bottom: 2rem;
         }
         border-bottom: 0.1875rem dotted $color__grey-500;
 
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             display: flex;
             justify-content: space-between;
             align-items: baseline;
@@ -26,7 +26,7 @@
     }
 
     &__filters {
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             display: flex;
         }
 
@@ -38,7 +38,7 @@
             padding-left: 0;
             margin-bottom: 0;
 
-            @media only screen and (min-width: $screen__md) {
+            @media only screen and (min-width: #{$screen__md + 1px}) {
                 column-count: 3;
                 column-gap: 1rem;
             }
@@ -74,7 +74,7 @@
         margin-right: 1rem;
         margin-bottom: 1rem;
 
-        @media only screen and (min-width: $screen__lg) {
+        @media only screen and (min-width: #{$screen__lg + 1px}) {
             max-width: 20rem;
         }
 
@@ -90,7 +90,7 @@
         }
         &-box {
             width: 100%;
-            @media only screen and (min-width: $screen__lg) {
+            @media only screen and (min-width: #{$screen__lg + 1px}) {
                 max-width: 17.5rem;
             }
             margin-bottom: 0.5rem;

--- a/sass/includes/search/_search-buckets.scss
+++ b/sass/includes/search/_search-buckets.scss
@@ -11,14 +11,15 @@
         margin-left: auto;
         margin-right: auto;
         margin-bottom: 0;
-        padding-left: 2rem;
-        padding-right: 2rem;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
         order: -1;
         &-item {
             display: inline-block;
             list-style: none;
             width: 18%;
-            margin-right: 1rem;
+            margin-right: 0.5rem;
+            margin-left: 0.5rem;
             min-height: 100px;
             margin-bottom: 1rem;
             font-family: $font__supria-sans;

--- a/sass/includes/search/_search-button.scss
+++ b/sass/includes/search/_search-button.scss
@@ -21,7 +21,7 @@
     }
 
     &:focus {
-        @include focus-default;
+        // @include focus-default;
     }
 
     &--primary {

--- a/sass/includes/search/_search-results-hero.scss
+++ b/sass/includes/search/_search-results-hero.scss
@@ -37,7 +37,7 @@
             margin-right: 0.2rem;
             margin-bottom: 1rem;
             &:focus {
-                outline: 5px solid $color__focus-outline-light-bg;
+                // outline: 5px solid $color__focus-outline-light-bg;
             }
         }
     }

--- a/sass/includes/search/_search-results.scss
+++ b/sass/includes/search/_search-results.scss
@@ -160,7 +160,7 @@
         margin-right: 1rem;
         margin-bottom: 1rem;
         display: none; //hiding on mobile
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             margin-left: 2rem;
             margin-right: 2rem;
             display: block;

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -286,7 +286,7 @@ dd {
 /*---additional styles for All results--*/
 
 .featured-search__website-results__head {
-    @media only screen and (min-width: $screen__md) {
+    @media only screen and (min-width: #{$screen__md + 1px}) {
         padding-left: 1em;
         padding-bottom: 2em;
     }
@@ -326,7 +326,7 @@ dd {
     max-width: 100%;
     margin-left: 1em;
     margin-right: 1em;
-    @media only screen and (min-width: $screen__sm) {
+    @media only screen and (min-width: #{$screen__sm + 1px}) {
         margin-left: 0;
     }
 }

--- a/sass/includes/search/_search-results__list-card.scss
+++ b/sass/includes/search/_search-results__list-card.scss
@@ -150,7 +150,7 @@
             //width:183px;
             margin-bottom: 0;
             //margin-top: 0.2rem;
-            padding: 1em 2em;
+            padding: 1em 0em;
             background: black;
             text-align: center;
         }

--- a/sass/includes/search/_search-sort-view.scss
+++ b/sass/includes/search/_search-sort-view.scss
@@ -1,6 +1,7 @@
 .search-sort-view {
     $root: &;
     display: flex;
+    align-items: flex-start;
 
     @media only screen and (max-width: $screen__md) {
         margin-left: 1rem;

--- a/sass/includes/search/_search-sort-view.scss
+++ b/sass/includes/search/_search-sort-view.scss
@@ -45,7 +45,7 @@
 
     &__mobile {
         padding-bottom: 1em;
-        @media only screen and (min-width: $screen__md) {
+        @media only screen and (min-width: #{$screen__md + 1px}) {
             display: none;
         }
     }
@@ -133,7 +133,7 @@
 
 .search-others {
     margin-bottom: 1rem;
-    @media only screen and (min-width: $screen__md) {
+    @media only screen and (min-width: #{$screen__md + 1px}) {
         display: none;
     }
 

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -18,13 +18,15 @@
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
     {% endif %}
 
-    <div class="container">
+    <div class="tna-container">
         {% include_block page.featured_pages %}
     </div>
 
-    <div class="container mt-4" data-container-name="{{ page.title }}">
+    <div class="tna-container mt-4" data-container-name="{{ page.title }}">
+        <div class="tna-column tna-column--full">
         <h2 class="tna-heading">Discover all stories</h2>
-        <p>Browse and explore the human stories behind The National Archives’ collection.</p>
+        <p class="mb-4">Browse and explore the human stories behind The National Archives’ collection.</p>
+    </div>
         <ul class="card-group--list-style-none">
 
             {% for article_page in article_pages %}

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -15,7 +15,11 @@
     </div>
 
     {% if page.featured_article.live %}
+    <div class="tna-container">
+    <div class="tna-column tna-column--full">
         {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
+        </div>
+        </div>
     {% endif %}
 
     <div class="tna-container">

--- a/templates/articles/blocks/featured_collection.html
+++ b/templates/articles/blocks/featured_collection.html
@@ -2,12 +2,14 @@
 {% load wagtailcore_tags %}
 
 <div class="featured-collection">
-    <h2 class="tna-heading">{{ value.heading }}</h2>
-    <p>{{ value.description }}</p>
+    <div class="tna-column tna-column--full">
+        <h2 class="tna-heading">{{ value.heading }}</h2>
+        <p class="mb-4">{{ value.description }}</p>
+    </div>
+    </div>
 
     <ul class="card-group--list-style-none">
         {% for item in value.items %}
             {% include 'includes/card-group-secondary-nav.html' with heading=value.heading link_page=item.specific card_type="Featured" show_type_label=True %}
         {% endfor %}
     </ul>
-</div>

--- a/templates/articles/blocks/related_items.html
+++ b/templates/articles/blocks/related_items.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 
-<div class="container">
-    <div class="col-12">
+<div class="tna-container">
+    <div class="tna-column tna-column--full">
         <{{ heading_level }} class="tna-heading related-content__heading">{{ value.heading }}</{{ heading_level }}>
         <p>{{ value.description }}</p>
     </div>

--- a/templates/blocks/large_links_block.html
+++ b/templates/blocks/large_links_block.html
@@ -4,14 +4,16 @@
     used below because they are used in explorer.js for tracking purposes.
 {% endcomment %}
 <div class="related-highlight-cards">
-    <div class="container">
+    <div class="tna-container">
         {% if value.heading %}
-            <h2 class="tna-heading card-grid__title">
-                {{ value.heading }}
-            </h2>
+            <div class="tna-column tna-column--full">
+                <h2 class="tna-heading card-grid__title">
+                    {{ value.heading }}
+                </h2>
+            </div>
         {% endif %}
-        <div class="card-grid card-grid__duo" data-container-name="more-ways-to-explore" id="analytics-more-ways-to-explore">
-            {% for link_page in link_pages %}
+        {% for link_page in link_pages %}
+            <div class="tna-column tna-column--flex-1 tna-column--full-tiny" data-container-name="more-ways-to-explore" id="analytics-more-ways-to-explore">
                 <div class="related-highlight-cards__card">
                     <a href="{% pageurl link_page %}" aria-labelledby="related-highlight-card-title-{{ forloop.counter }}" data-component-name="Navigation card: {% if value.heading %}{{ value.heading }}{% else %}{{ page.title }}{% endif %}" data-link-type="Card image" data-card-position="{{ forloop.counter0 }}" data-card-title="{{ link_page.title }}" tabindex="-1">
                         {% image link_page.teaser_image fill-540x350 as teaser_image %}
@@ -29,7 +31,34 @@
                         </p>
                     </div>
                 </div>
-            {% endfor %}
-        </div>
+            </div>
+        {% endfor %}
     </div>
 </div>
+
+<!-- <nav class="tna-index-grid tna-index-grid--demo" aria-label="Explore the collection">
+    {% if value.heading %}
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            <h2 class="tna-heading tna-heading--l tna-index-grid__heading">
+                {{ value.heading }}
+            </h2>
+        </div>
+    </div>
+    {% endif %}
+    <ul class="tna-index-grid__items tna-container">
+        {% for link_page in link_pages %}
+        <li class="tna-index-grid__item-wrapper tna-column tna-column--flex-1 tna-column--full-small tna-column--full-tiny">
+            <a href="{% pageurl link_page %}" class="tna-index-grid__item" title="{{ link_page.title }}" data-component-name="Navigation card: {% if value.heading %}{{ value.heading }}{% else %}{{ page.title }}{% endif %}" data-link-type="Card" data-card-position="{{ forloop.counter0 }}" data-card-title="{{ link_page.title }}">
+                {% image link_page.teaser_image fill-540x350 as teaser_image %}
+                <img src="{{ teaser_image.url }}" class="tna-index-grid__item-image" width="540" height="350" alt="">
+                <span class="tna-index-grid__item-content">
+                    <span class="tna-index-grid__item-title">
+                        {{ link_page.title }}
+                    </span>
+                </span>
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+</nav> -->

--- a/templates/blocks/large_links_block.html
+++ b/templates/blocks/large_links_block.html
@@ -35,30 +35,3 @@
         {% endfor %}
     </div>
 </div>
-
-<!-- <nav class="tna-index-grid tna-index-grid--demo" aria-label="Explore the collection">
-    {% if value.heading %}
-    <div class="tna-container">
-        <div class="tna-column tna-column--full">
-            <h2 class="tna-heading tna-heading--l tna-index-grid__heading">
-                {{ value.heading }}
-            </h2>
-        </div>
-    </div>
-    {% endif %}
-    <ul class="tna-index-grid__items tna-container">
-        {% for link_page in link_pages %}
-        <li class="tna-index-grid__item-wrapper tna-column tna-column--flex-1 tna-column--full-small tna-column--full-tiny">
-            <a href="{% pageurl link_page %}" class="tna-index-grid__item" title="{{ link_page.title }}" data-component-name="Navigation card: {% if value.heading %}{{ value.heading }}{% else %}{{ page.title }}{% endif %}" data-link-type="Card" data-card-position="{{ forloop.counter0 }}" data-card-title="{{ link_page.title }}">
-                {% image link_page.teaser_image fill-540x350 as teaser_image %}
-                <img src="{{ teaser_image.url }}" class="tna-index-grid__item-image" width="540" height="350" alt="">
-                <span class="tna-index-grid__item-content">
-                    <span class="tna-index-grid__item-title">
-                        {{ link_page.title }}
-                    </span>
-                </span>
-            </a>
-        </li>
-        {% endfor %}
-    </ul>
-</nav> -->

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -15,26 +15,28 @@
         </div>
     </div>
     
-    <div class="container">
-        <h2 class="tna-heading">{{ page.articles_title }}</h2>
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            <h2 class="tna-heading">{{ page.articles_title }}</h2>
+            <p>{{ page.articles_introduction }}</p>
 
-        <p>{{ page.articles_introduction }}</p>
-    </div>
+            {% if page.featured_article.live %}
+                {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
+            {% endif %}
+        </div>
 
-    {% if page.featured_article.live %}
-        {% include "includes/article-spotlight.html" with page=page.featured_article.specific %}
-    {% endif %}
-
-    <div class="container">
         {% include_block page.featured_articles with heading=page.articles_title %}
 
-        <div class="featured-articles__cta">
-            {% comment %} TODO: update BEM button styles for consistency across site {% endcomment %}
-            <a href="/stories"
-            class="tna-button--dark"
-            data-link-type="Button"
-            data-component-name="Articles section: {{ page.articles_title }}"
-            data-link="Browse all stories">Browse all stories</a>
+        <div class="tna-column tna-column--full">
+            <div class="featured-articles__cta">
+                {% comment %} TODO: update BEM button styles for consistency across site {% endcomment %}
+                <a href="/stories"
+                class="tna-button--dark"
+                data-link-type="Button"
+                data-component-name="Articles section: {{ page.articles_title }}"
+                data-link="Browse all stories">Browse all stories</a>
+            </div>
+
         </div>
     </div>
     

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -7,8 +7,7 @@
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
-    <div class="container mt-4">
-        <div class="row">
+    <div class="tna-container mt-4">
             <h2 class="sr-only">Select a time period</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-time-period" id="analytics-select-a-time-period">
                 {% for child in page.time_period_explorer_pages %}
@@ -17,13 +16,8 @@
             </ul>
         </div>
         {% if page.body %}
-            <div class="row">
-                <div class="col-md-12">
-                    {% include_block page.body %}
-                </div>
-            </div>
+            {% include_block page.body %}
         {% endif %}
-    </div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -7,8 +7,7 @@
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 
-    <div class="container mt-4">
-        <div class="row">
+    <div class="tna-container mt-4">
             <h2 class="sr-only">Select a topic</h2>
             <ul class="card-group--list-style-none" data-container-name="select-a-topic" id="analytics-select-a-topic">
                 {% for child in page.topic_explorer_pages %}
@@ -17,13 +16,8 @@
             </ul>
         </div>
         {% if page.body %}
-            <div class="row">
-                <div class="col-md-12">
-                    {% include_block page.body %}
-                </div>
-            </div>
+            {% include_block page.body %}
         {% endif %}
-    </div>
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -15,8 +15,8 @@
 
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
-    <div class="container pt-2">
-        <div class="row">
+    <div class="tna-container pt-2">
+        <div class="tna-column tna-column--full">
             {% for item in page.body %}
                 {% if item.value.paragraph or item.value.text %}
                     {{item}}

--- a/templates/includes/article-spotlight.html
+++ b/templates/includes/article-spotlight.html
@@ -1,6 +1,5 @@
 {% load wagtailimages_tags wagtailcore_tags i18n %}
 
-<div class="container">
     {% if title %}
         <h2 class="tna-heading extra-padding">{% translate title %}</h2>
     {% endif %}
@@ -42,4 +41,3 @@
             <a class="tna-button--dark" href="{% pageurl page %}" data-component-name="Featured Article: {{ page.title }}" data-link-type="Button" data-link="Read" {% if page.is_newly_published %}data-label="New"{% endif %}>Read about {{ page.title }}</a>
         </div>
     </div>
-</div>

--- a/templates/includes/card-group-secondary-nav.html
+++ b/templates/includes/card-group-secondary-nav.html
@@ -5,7 +5,7 @@
 {% image link_page.teaser_image fill-348x208 as teaser_image_large %}
 {% image link_page.teaser_image fill-508x304 as teaser_image_extra_large %}
 
-<li class="col-sm-12 col-md-6 col-lg-4 mb-3">
+<li class="tna-column tna-column--width-1-3 tna-column--width-1-2-medium tna-column--width-1-2-small tna-column--full-tiny mb-3">
     <div class="card-group-secondary-nav">
         <a
             href="{{ link_page.url }}"
@@ -37,7 +37,7 @@
             {% if show_type_label and link_page.type_label %}
                 <p class="card-group-secondary-nav__title-label">{{ link_page.type_label }}</p>
             {% endif %}
-            <h3 class="tna-heading card-group-secondary-nav__heading">
+            <h3 class="tna-heading tna-heading--m card-group-secondary-nav__heading">
                 <a
                     href="{{ link_page.url }}"
                     class="card-group-secondary-nav__title-link"

--- a/templates/includes/related-highlight-cards.html
+++ b/templates/includes/related-highlight-cards.html
@@ -1,9 +1,11 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 <section class="related-highlight-cards">
-    <div class="container">
-        <h2 class="tna-heading related-highlight-cards__title">{{ title }} highlights in pictures</h2>
-        <div class="card-grid card-grid__trio">
-            {% for card in cards %}
+    <div class="tna-container">
+        <div class="tna-column tna-column--full">
+            <h2 class="tna-heading related-highlight-cards__title">{{ title }} highlights in pictures</h2>
+        </div>
+        {% for card in cards %}
+        <div class="tna-column tna-column--width-1-3 tna-column--width-1-2-medium tna-column--width-1-2-small tna-column--full-tiny">
                 <div class="related-highlight-cards__card">
                     <a href="{{ card.url }}"
                     data-component-name="Featured card: {{ title }} highlights in pictures"
@@ -43,7 +45,7 @@
                         <p class="related-highlight-cards__text">{{ card.highlight_image_count }} images</p>
                     </div>
                 </div>
+            </div>
             {% endfor %}
-        </div>
     </div>
 </section>


### PR DESCRIPTION
## Breakpoints

Fix for DF-814 - changed breakpoints throughout from `rem` to `px` and all `min-width`s to 1px more than the breakpoint.

### Example breakpoint at 768px

```scss
// Before - both rules apply at 768px
@media only screen and (max-width: 768px}) {
  // 0-768px
}
@media only screen and (min-width: 768px}) {
  // 768px+
}

// After - two separate rules don't overlap
@media only screen and (max-width: 768px}) {
  // 0-768px
}
@media only screen and (min-width: 769px}) {
  // 769px+
}
```

## Containers and columns

- Attempted to standardise containers and columns under "Explore the collection"
- Removed nested `container` elements

### Example

```html
<body>
  <div class="tna-container">
    <div class="tna-column tna-column--full">
      <!-- CONTENT -->
    </div>
  </div>
</body>
```