### PR TITLE
DF-806-feedback-mechanism-buttons

### DIFF
--- a/etna/feedback/templates/feedback/widgets/response_submit_button_list.html
+++ b/etna/feedback/templates/feedback/widgets/response_submit_button_list.html
@@ -3,7 +3,7 @@
     <div{% if id %} id="{{ id }}" class="row justify-content-center"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>
         {% for group, options, index in widget.optgroups %}
             {% for option in options %}
-                <div class="feedback-response-option col-md-6">
+                <div class="feedback-response-option col-md-4">
                     {% include option.template_name with widget=option %}
                 </div>
             {% endfor %}

--- a/sass/includes/_feedback.scss
+++ b/sass/includes/_feedback.scss
@@ -24,7 +24,7 @@
     }
 
     &__response-button {
-        width: 60%;
+        //width: 100%;
         &:hover {
             cursor: pointer;
         }


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-806

## About these changes

Layout changes to allow three feedback mechanism buttons to display inline

## How to check these changes

Test Desktop and mobile view to check that three buttons display inline (see screenshot also)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

<img width="1361" alt="Screenshot 2023-09-05 at 11 26 01" src="https://github.com/nationalarchives/ds-wagtail/assets/110600556/b17ef487-2c71-4753-91c5-ec42124bfc80">


## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
