### PR TITLE
DF-316-moving-the-Apply-filters-button-within-the-Form-element

### DIFF
--- a/sass/includes/search/_long-filters.scss
+++ b/sass/includes/search/_long-filters.scss
@@ -129,3 +129,12 @@
         font-size: 1rem;
     }
 }
+
+.cancel-return {
+    float:none;
+
+    @media only screen and (min-width: #{$screen__md + 1px}) {
+        //background: green;
+        float:right;
+    }
+}

--- a/templates/search/long_filter_options.html
+++ b/templates/search/long_filter_options.html
@@ -10,11 +10,14 @@
 
     <div class="long-filters">
         <h1 class="tna-heading long-filters__heading">Select filters to apply to your results</h1>
+
+        <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results" class="cancel-return">Cancel and return to results</a>
+
         <form method="get" action="{% url url_name %}" data-id="long-filter-form" id="analytics-long-filter-form" data-long-filters>
-            
+
         <div class="long-filters__options">
             <input type="submit" value="Apply filters" class="search-filters__submit">
-            <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>
+<!--            <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>-->
         </div>
 
 

--- a/templates/search/long_filter_options.html
+++ b/templates/search/long_filter_options.html
@@ -10,11 +10,15 @@
 
     <div class="long-filters">
         <h1 class="tna-heading long-filters__heading">Select filters to apply to your results</h1>
+        <form method="get" action="{% url url_name %}" data-id="long-filter-form" id="analytics-long-filter-form" data-long-filters>
+            
         <div class="long-filters__options">
             <input type="submit" value="Apply filters" class="search-filters__submit">
             <a href="{% url url_name %}?{{ request.GET.urlencode }}" data-link-type="Search Link" data-link="Cancel and return to results">Cancel and return to results</a>
         </div>
-        <form method="get" action="{% url url_name %}" data-id="long-filter-form" id="analytics-long-filter-form" data-long-filters>
+
+
+
 
 
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/projects/DF/issues/DF-316

## About these changes

Moving the Apply Filters button within the form element on long filters page.

## How to check these changes

Check that the Apply Filters button is within the form and works as expected


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer.
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes.
- [x] Ensured that PR includes only commits relevant to the ticket.
- [x] Waited for all CI jobs to pass before requesting a review.
- [x] Added/updated tests and documentation where relevant.

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
