### PR TITLE
DF-759: FIX Rebuild Event sort search results

### DIFF
--- a/scripts/src/modules/analytics/search/search_sort_filters_tracking.js
+++ b/scripts/src/modules/analytics/search/search_sort_filters_tracking.js
@@ -3,7 +3,10 @@ import push_to_data_layer from "./../push_to_data_layer";
 const getSortBy = () => {
     // get filters after DOM has loaded and they have rendered on page
     window.addEventListener("load", () => {
-        const selectElement = document.querySelector("#id_sort_by");
+        var selectElement = document.querySelector("#id_sort_by_desktop");
+        if (selectElement.checkVisibility() == false) {
+            selectElement = document.querySelector("#id_sort_by_mobile");
+        }
 
         // check if selectElement exists to avoid errors on other search pages
         if (selectElement) {


### PR DESCRIPTION
Ticket URL: [DF-759]

## About these changes

Added logic to check if the user is on `id_sort_by_desktop` or `id_sort_by_mobile`, and then set the `selectElement` variable based on that condition.

## How to check these changes

I'm not entirely sure how to check as the dataLayer push happens on submitting the form - when you submit the form the page reloads and you lose it from the `dataLayer` command in the console.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[DF-759]: https://national-archives.atlassian.net/browse/DF-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ