### PR TITLE
Meta tag fixes and squashed loading

### DIFF
--- a/etna/users/templates/users/index.html
+++ b/etna/users/templates/users/index.html
@@ -1,8 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 
-{% load i18n %}
-{% load wagtailusers_tags %}
-{% load wagtailadmin_tags %}
+{% load i18n wagtailusers_tags wagtailadmin_tags %}
 
 {% block titletag %}{% trans "Beta Tester Users" %}{% endblock %}
 

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n %}
-{% load account %}
-{% load static %}
+{% load i18n account static %}
 
 {% block title %}{% trans "Login" %}{% endblock %}
 

--- a/templates/articles/article_index_page.html
+++ b/templates/articles/article_index_page.html
@@ -1,13 +1,7 @@
 {% extends 'base_page.html' %}
 
-{% load static %}
-{% load i18n %}
-{% load wagtailcore_tags %}
-{% load wagtailimages_tags %}
-{% load wagtailmetadata_tags %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
+{% load static i18n wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
+
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
     <div class="container">

--- a/templates/articles/article_page.html
+++ b/templates/articles/article_page.html
@@ -1,12 +1,7 @@
 {% extends 'base_page.html' %}
 
-{% load static %}
-{% load wagtailcore_tags %}
-{% load sections_tags %}
-{% load wagtailmetadata_tags %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
+{% load static wagtailcore_tags sections_tags wagtailmetadata_tags %}
+
 {% block breadcrumb %}{% endblock %}
 {% block content %}
     {% include 'includes/generic-intro.html' with breadcrumb=True title=page.title intro=page.intro %}

--- a/templates/articles/blocks/featured_collection.html
+++ b/templates/articles/blocks/featured_collection.html
@@ -1,5 +1,4 @@
-{% load wagtailimages_tags %}
-{% load wagtailcore_tags %}
+{% load wagtailimages_tags wagtailcore_tags %}
 
 <div class="featured-collection">
     <div class="tna-column tna-column--full">

--- a/templates/articles/focused_article_page.html
+++ b/templates/articles/focused_article_page.html
@@ -1,11 +1,7 @@
 {% extends 'base_page.html' %}
 
-{% load static wagtailcore_tags sections_tags wagtailmetadata_tags %}
+{% load static wagtailcore_tags sections_tags wagtailmetadata_tags wagtailimages_tags %}
 
-{% load wagtailimages_tags %}
-{% block meta_tag %}
-    {% meta_tags %}
-{% endblock %}
 {% block body_class %}template-focused-article{% endblock %}
 {% block breadcrumb %}{% endblock %}
 

--- a/templates/articles/record_article_page.html
+++ b/templates/articles/record_article_page.html
@@ -1,8 +1,7 @@
 {% extends "base_page.html" %}
+
 {% load static wagtailcore_tags sections_tags wagtailmetadata_tags %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
+
 {% block content %}
     {% include "includes/record-revealed-intro.html" with display_content_warning=page.display_content_warning custom_warning_text=page.custom_warning_text %}
     {% if page.gallery_items %}

--- a/templates/authors/author_index_page.html
+++ b/templates/authors/author_index_page.html
@@ -1,8 +1,7 @@
 {% extends 'base_page.html' %}
 
-{% load static %}
-{% load wagtailcore_tags %}
-{% load wagtailimages_tags %}
+{% load static wagtailcore_tags wagtailimages_tags %}
+
 {% block breadcrumb %}{% endblock %}
 {% block content %}
     {% include 'includes/generic-intro.html' with breadcrumb=True title=page.title intro=page.role %}

--- a/templates/authors/author_page.html
+++ b/templates/authors/author_page.html
@@ -1,8 +1,7 @@
 {% extends 'base_page.html' %}
 
-{% load static %}
-{% load wagtailcore_tags %}
-{% load wagtailimages_tags %}
+{% load static wagtailcore_tags wagtailimages_tags %}
+
 {% block breadcrumb %}{% endblock %}
 {% block content %}
     {% include 'includes/breadcrumb.html' %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,10 +17,12 @@
             {% endblock %}
             {% block title_suffix %}
                 {% wagtail_site as current_site %}
-                 - {{ current_site.site_name }}
+                 – {{ current_site.site_name }}
             {% endblock %}
         </title>
-        <meta name="description" content="" />
+        {% if meta_tags %}
+            {% meta_tags %}
+        {% endif %}
      {% endblock %}
         <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
         <meta name="format-detection" content="telephone=no" />

--- a/templates/collections/blocks/featured_articles.html
+++ b/templates/collections/blocks/featured_articles.html
@@ -1,5 +1,4 @@
-{% load wagtailimages_tags %}
-{% load wagtailcore_tags %}
+{% load wagtailimages_tags wagtailcore_tags %}
 
 <div class="featured-articles">
     <ul class="card-group--list-style-none">

--- a/templates/collections/explorer_index_page.html
+++ b/templates/collections/explorer_index_page.html
@@ -1,9 +1,7 @@
 {% extends 'base_page.html' %}
 
 {% load static wagtailmetadata_tags wagtailimages_tags wagtailcore_tags i18n %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
+
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 

--- a/templates/collections/highlight_gallery_page.html
+++ b/templates/collections/highlight_gallery_page.html
@@ -1,10 +1,7 @@
 {% extends 'base_page.html' %}
 
-{% load i18n static wagtailcore_tags wagtailimages_tags records_tags %}
-{% load wagtailmetadata_tags %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
+{% load i18n static wagtailcore_tags wagtailimages_tags records_tags wagtailmetadata_tags %}
+
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro display_content_warning=page.display_content_warning custom_warning_text=page.custom_warning_text %}
 

--- a/templates/collections/time_period_explorer_index_page.html
+++ b/templates/collections/time_period_explorer_index_page.html
@@ -1,9 +1,7 @@
 {% extends 'base_page.html' %}
+
 {% load static wagtailcore_tags wagtailmetadata_tags %}
 
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 

--- a/templates/collections/time_period_explorer_page.html
+++ b/templates/collections/time_period_explorer_page.html
@@ -1,8 +1,7 @@
 {% extends "base_page.html" %}
+
 {% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
-{% block meta_tag %}
-    {% meta_tags %}
-{% endblock meta_tag %}
+
 {% block content %}
     {% include "includes/highlight-intro.html" with background_image=page.hero_image title=page.title intro=page.intro %}
     {% if page.related_highlight_gallery_pages %}

--- a/templates/collections/topic_explorer_index_page.html
+++ b/templates/collections/topic_explorer_index_page.html
@@ -1,9 +1,7 @@
 {% extends 'base_page.html' %}
+
 {% load static wagtailcore_tags wagtailmetadata_tags %}
 
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}
 

--- a/templates/collections/topic_explorer_page.html
+++ b/templates/collections/topic_explorer_page.html
@@ -1,8 +1,7 @@
 {% extends "base_page.html" %}
+
 {% load i18n static wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
-{% block meta_tag %}
-    {% meta_tags %}
-{% endblock meta_tag %}
+
 {% block content %}
     {% include "includes/highlight-intro.html" with background_image=page.hero_image title=page.title intro=page.intro %}
     {% if page.related_highlight_gallery_pages %}

--- a/templates/generic_pages/general_page.html
+++ b/templates/generic_pages/general_page.html
@@ -1,7 +1,6 @@
 {% extends 'base_page.html' %}
 
-{% load static %}
-{% load wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
 
 

--- a/templates/home/home_page.html
+++ b/templates/home/home_page.html
@@ -1,17 +1,10 @@
 {% extends "base_page.html" %}
 
+{% load static i18n wagtailcore_tags wagtailmetadata_tags wagtailimages_tags %}
 
-{% load static %}
-{% load i18n %}
 {% block breadcrumb %}
 {% endblock %}
 {% block body_class %}template-homepage{% endblock %}
-{% load wagtailcore_tags %}
-{% load wagtailmetadata_tags %}
-{% load wagtailimages_tags %}
-{% block meta_tag %}
-    {% meta_tags %}
-{% endblock %}
 
 {% block content %}
     {% include "includes/generic-intro.html" with title=page.title intro=page.intro %}

--- a/templates/includes/card-group-record-summary-no-image.html
+++ b/templates/includes/card-group-record-summary-no-image.html
@@ -1,5 +1,4 @@
-{% load records_tags %}
-{% load wagtailimages_tags %}
+{% load records_tags wagtailimages_tags %}
 
 <li class="col-sm-12 col-md-6 col-lg-4">
     <div class="card-group-record-summary">

--- a/templates/includes/hero-img.html
+++ b/templates/includes/hero-img.html
@@ -1,5 +1,5 @@
-{% load wagtailimages_tags %}
-{% load wagtailcore_tags %}
+{% load wagtailimages_tags wagtailcore_tags %}
+
 {% if hero_image %}
     <div class="hero-image__container">
         {% if caption %}<figure class="hero-image__figure">{% endif %}

--- a/templates/password_pages/password_required.html
+++ b/templates/password_pages/password_required.html
@@ -1,9 +1,6 @@
 {% extends 'base_page.html' %}
 
 {% load static wagtailmetadata_tags wagtailimages_tags wagtailcore_tags i18n %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
 
 {% if breadcrumb %}
     {% include 'includes/breadcrumb.html' %}

--- a/templates/records/archive_detail.html
+++ b/templates/records/archive_detail.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
-{% load datalayer_tags %}
-{% load records_tags %}
+{% load static datalayer_tags records_tags %}
 
 {% block extra_gtm_js %}
     {% render_gtm_datalayer record %}

--- a/templates/records/image-browse.html
+++ b/templates/records/image-browse.html
@@ -1,8 +1,6 @@
 {% extends 'base-images.html' %}
 
-{% load static %}
-{% load datalayer_tags %}
-{% load records_tags %}
+{% load static datalayer_tags records_tags %}
 
 {% block extra_gtm_js %}
     {% image_browse_datalayer as datalayer %}

--- a/templates/records/image-viewer.html
+++ b/templates/records/image-viewer.html
@@ -1,6 +1,6 @@
 {% extends 'base-images.html' %}
-{% load records_tags %}
-{% load static %}
+
+{% load records_tags static %}
 
 {% block content %}
 

--- a/templates/records/record_creators.html
+++ b/templates/records/record_creators.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
-{% load datalayer_tags %}
-{% load records_tags %}
+{% load static datalayer_tags records_tags %}
 
 {% block extra_gtm_js %}
     {% render_gtm_datalayer record %}

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
-{% load datalayer_tags %}
-{% load records_tags %}
+{% load static datalayer_tags records_tags %}
 
 {% block extra_gtm_js %}
     {% render_gtm_datalayer record %}

--- a/templates/records/record_disambiguation_page.html
+++ b/templates/records/record_disambiguation_page.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
-{% load static %}
-{% load datalayer_tags %}
+{% load static datalayer_tags %}
 
 {% block content %}
     {% include "includes/generic-intro.html" with title="Several records share this reference" only %}

--- a/templates/search/blocks/featured-search__interpretive-card.html
+++ b/templates/search/blocks/featured-search__interpretive-card.html
@@ -1,5 +1,5 @@
-{% load records_tags %}
-{% load search_tags %}
+{% load records_tags search_tags %}
+
 <!--
 <div class="featured-search__interpretive-results-section">
     <h2 class="tna-heading featured-search__heading">{{ bucket.label }}</h2>

--- a/templates/search/blocks/featured-search__record-creator.html
+++ b/templates/search/blocks/featured-search__record-creator.html
@@ -1,5 +1,5 @@
-{% load records_tags %}
-{% load search_tags %}
+{% load records_tags search_tags %}
+
 <div class="featured-search__results-block">
     <h2 class="tna-heading featured-search__heading">{{ bucket.label }}</h2>
 

--- a/templates/search/blocks/featured-search__results-block.html
+++ b/templates/search/blocks/featured-search__results-block.html
@@ -1,5 +1,5 @@
-{% load records_tags %}
-{% load search_tags %}
+{% load records_tags search_tags %}
+
 <div class="featured-search__results-block">
     <h2 class="tna-heading featured-search__heading">{{ bucket.label }}</h2>
     <ul class="featured-search__results-list">

--- a/templates/search/blocks/search_pagination.html
+++ b/templates/search/blocks/search_pagination.html
@@ -1,5 +1,4 @@
-{% load search_tags %}
-{% load humanize %}
+{% load search_tags humanize %}
 
 <nav class="pagination" role="navigation" aria-label="Records pagination" data-container-name="Pagination"
      id="analytics-disambiguation-pagination">

--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -1,5 +1,4 @@
-{% load search_tags %}
-{% load humanize %}
+{% load search_tags humanize %}
 
 {{ selected_filters_count|json_script:"selected_filters_count" }}
 <script>

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load humanize %}
-{% load datalayer_tags %}
-{% load search_tags %}
+{% load humanize datalayer_tags search_tags static %}
 
 {% comment %} prepend number of search results to page title {% endcomment %}
 {% block prepend_title %}
@@ -18,7 +16,6 @@
 {% block extra_gtm_js %}
     {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
-{% load static %}
 {% block breadcrumb %}
 {% endblock %}
 

--- a/templates/search/featured_search.html
+++ b/templates/search/featured_search.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
 
-{% load datalayer_tags %}
-{% load search_tags %}
+{% load datalayer_tags search_tags humanize %}
 
 {% block extra_gtm_js %}
     {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
-{% load humanize %}
 {% block breadcrumb %}
 {% endblock %}
 {% block content %}

--- a/templates/search/long_filter_options.html
+++ b/templates/search/long_filter_options.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %}
 
-{% load humanize %}
-{% load search_tags %}
+{% load humanize search_tags static %}
 
-{% load static %}
 {% block breadcrumb %}
 {% endblock %}
 {% block content %}

--- a/templates/search/native_website_search.html
+++ b/templates/search/native_website_search.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load humanize %}
-{% load datalayer_tags %}
-{% load search_tags %}
+{% load humanize datalayer_tags search_tags static %}
 
 {% comment %} prepend number of search results to page title {% endcomment %}
 {% block prepend_title %}
@@ -12,8 +10,6 @@
 {% block extra_gtm_js %}
     {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
-{% load humanize %}
-{% load static %}
 {% block breadcrumb %}
 {% endblock %}
 {% block content %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -1,13 +1,9 @@
 {% extends "base.html" %}
-{% load alert_tags datalayer_tags %}
-
-{% load search_tags %}
-
+{% load alert_tags datalayer_tags search_tags humanize %}
 
 {% block extra_gtm_js %}
     {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
-{% load humanize %}
 {% block breadcrumb %}
 {% endblock %}
 {% block content %}

--- a/templates/search/website_search.html
+++ b/templates/search/website_search.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% load humanize %}
-{% load datalayer_tags %}
-{% load search_tags %}
+{% load humanize datalayer_tags search_tags static %}
 
 {% comment %} prepend number of search results to page title {% endcomment %}
 {% block prepend_title %}
@@ -18,8 +16,6 @@
 {% block extra_gtm_js %}
     {% render_gtm_datalayer view %}
 {% endblock extra_gtm_js %}
-{% load humanize %}
-{% load static %}
 {% block breadcrumb %}
 {% endblock %}
 {% block content %}

--- a/templates/whatson/event_page.html
+++ b/templates/whatson/event_page.html
@@ -1,6 +1,3 @@
 {% extends 'base_page.html' %}
 
 {% load static i18n wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}

--- a/templates/whatson/whats_on_page.html
+++ b/templates/whatson/whats_on_page.html
@@ -1,9 +1,6 @@
 {% extends 'base_page.html' %}
 
 {% load static i18n wagtailcore_tags wagtailimages_tags wagtailmetadata_tags %}
-{% block meta_tag %}
-  {% meta_tags %}
-{% endblock %}
 
 {# Breadcrumb is included inside the header area #}
 {% block breadcrumb %}


### PR DESCRIPTION
## About these changes

Squashed loading of tags into one line per page, and re-structured how we load meta tags so that we're not overwriting ourselves every time!

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
