### PR TITLE
DF-820:sort-by-covering-date

### DIFF
--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -219,7 +219,7 @@ class BaseCollectionSearchForm(forms.Form):
         label="Sort by",
         choices=[
             (SortBy.RELEVANCE.value, "Relevance"),
-            (SortBy.DATE_OPENING.value, "Date"),
+            (SortBy.DATE_CREATED.value, "Date"),
             (SortBy.TITLE.value, "Title"),
         ],
         required=False,


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DF-820

## About these changes

Changes the Date in Sort By filter to sort by `Covering Date` (which is API `dateCreated`) instead of `Record Opening date` (which is `dateOpening`)

## How to check these changes

- Navigate to Catalogue Search - TNA
- Select Sort By `Date` and Update.  (Also try filter on a smaller date range with this)
- The results should be sorted by Date in the Results area. (At the moment, there seems to be some data issues with KONG with the values returned. This has been identified and taken up separately)


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
