### PR TITLE
Fix date styling for iOS so we don't need a default value

### DIFF
--- a/sass/includes/_filters.scss
+++ b/sass/includes/_filters.scss
@@ -65,6 +65,7 @@
 
     &__date {
         min-height: 1.5rem;
+        min-width: 95%;
         width: auto;
         accent-color: $color__black; // otherwise the text is yellow in iOS
         color: $color__black;

--- a/templates/whatson/whats_on_page.html
+++ b/templates/whatson/whats_on_page.html
@@ -24,8 +24,7 @@
             <div class="filters__panel">
               <label for="event-date" class="filters__label filters__label--top">Choose a date</label>
               <p class="filters__help">Format: dd/mm/yyyy</p>
-              {# we need a default value for the date in iOS or it is displayed tiny #}
-              <input type="date" name="event-date" id="event-date" class="filters__date" value="{% now 'Y-m-d' %}">
+              <input type="date" name="event-date" id="event-date" class="filters__date" >
             </div>
           </fieldset>
 


### PR DESCRIPTION
Ticket URL: paste URL here

## About these changes

As per slack discussion with @jamesbiggs, we don't want to insist that a date has a default value. This branch fixes the iOS styling with a min-width instead.

## How to check these changes

View the whats on listing page and check the date style in IOS


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
