### PR TITLE
Filtering of featured event card

### DIFF
--- a/etna/whatson/models.py
+++ b/etna/whatson/models.py
@@ -305,7 +305,7 @@ class WhatsOnPage(BasePageWithIntro):
         return events
 
     # we need a separate query to check if the featured event is filtered out or not
-    def should_show_featured_event(self, filtered_events, featured_event):
+    def should_show_featured_event(self, filtered_events):
         try:
             # checks if the featured event is part of the filtered events queryset
             filtered_events.filter(id=self.featured_event_id).get()
@@ -337,11 +337,12 @@ class WhatsOnPage(BasePageWithIntro):
             else:
                 context["events"] = filtered_events
         else:
+            filtered_events = self.events
             context["events"] = self.events
         context["filter_form"] = filter_form
         if self.featured_event:
             context["show_fetured_event"] = self.should_show_featured_event(
-                filtered_events, self.featured_event
+                filtered_events
             )
 
         return context

--- a/etna/whatson/models.py
+++ b/etna/whatson/models.py
@@ -283,36 +283,6 @@ class WhatsOnPage(BasePageWithIntro):
         related_name="+",
     )
 
-    @cached_property
-    def events(self):
-        """
-        Returns a queryset of events that are children of this page.
-        """
-        return EventPage.objects.child_of(self).live().public().order_by("start_date")
-
-    def filter_form_data(self, filter_form_cleaned_data):
-        events = self.events
-
-        if date_filter := filter_form_cleaned_data.get("date"):
-            events = events.filter(start_date__date=date_filter)
-        if event_type_filter := filter_form_cleaned_data.get("event_type"):
-            events = events.filter(event_type=event_type_filter)
-        if filter_form_cleaned_data.get("is_online_event"):
-            events = events.filter(venue_type=VenueType.ONLINE)
-        if filter_form_cleaned_data.get("family_friendly"):
-            events = events.filter(event_audience_types__audience_type__slug="families")
-
-        return events
-
-    # we need a separate query to check if the featured event is filtered out or not
-    def should_show_featured_event(self, filtered_events):
-        try:
-            # checks if the featured event is part of the filtered events queryset
-            filtered_events.filter(id=self.featured_event_id).get()
-            return True
-        except EventPage.DoesNotExist:
-            return False
-
     def serve(self, request):
         # Check if the request comes from JavaScript
         # 'JS-Request' is a custom header added by the frontend
@@ -325,26 +295,73 @@ class WhatsOnPage(BasePageWithIntro):
             # Display whats on page as usual
             return super().serve(request)
 
-    def get_context(self, request, *args, **kwargs):
-        context = super().get_context(request, *args, **kwargs)
+    def get_events_queryset(self):
+        """
+        Returns a queryset of events that are children of this page.
+        """
+        return EventPage.objects.child_of(self).live().public().order_by("start_date")
 
+    def filter_events(self, events, filter_dict):
+        """
+        Filter the events queryset by any active filters.
+        """
+        if date_filter := filter_dict.get("date"):
+            events = events.filter(start_date__date=date_filter)
+        if event_type_filter := filter_dict.get("event_type"):
+            events = events.filter(event_type=event_type_filter)
+        if filter_dict.get("is_online_event"):
+            events = events.filter(venue_type=VenueType.ONLINE)
+        if filter_dict.get("family_friendly"):
+            events = events.filter(event_audience_types__audience_type__slug="families")
+
+        return events
+
+    def exclude_featured_event_from_listing(self, filtered_events):
+        """
+        Returns a tuple (events, should show featured event card).
+
+        If the featured event is excluded by the active filters, we shouldn't
+        render the featured event card.
+        """
+        if not self.featured_event:
+            return filtered_events, False
+
+        try:
+            # Is the featured event in the queryset?
+            filtered_events.get(id=self.featured_event_id)
+            # Didn't cause DoesNotExist, so it's not excluded by the filters - take
+            # it out of the main listing, and indicate that we should render the
+            # featured card.
+            return filtered_events.exclude(id=self.featured_event_id), True
+        except EventPage.DoesNotExist:
+            # The featured event is already excluded by the active filters, so don't
+            # render the featured event card.
+            return filtered_events, False
+
+    def get_context(self, request, *args, **kwargs):
+        """
+        Populate the context with the events to list on the page.
+
+        This should include a featured event, if one is selected, and if it
+        is not excluded by the active filters.
+
+        The list of non-featured events should not include the featured event
+        (if one is selected).
+
+        The list of non-featured events should have any active filters applied.
+        """
+        context = super().get_context(request, *args, **kwargs)
         filter_form = EventFilterForm(request.GET)
+        events = self.get_events_queryset()
 
         if filter_form.is_valid():
-            filtered_events = self.filter_form_data(filter_form.cleaned_data)
-            if self.featured_event:
-                context["events"] = filtered_events.exclude(id=self.featured_event_id)
-            else:
-                context["events"] = filtered_events
-        else:
-            filtered_events = self.events
-            context["events"] = self.events
-        context["filter_form"] = filter_form
-        if self.featured_event:
-            context["show_fetured_event"] = self.should_show_featured_event(
-                filtered_events
-            )
+            events = self.filter_events(events, filter_form.cleaned_data)
 
+        (
+            context["events"],
+            context["show_featured_event"],
+        ) = self.exclude_featured_event_from_listing(events)
+        context["filter_form"] = filter_form
         return context
 
     # DataLayerMixin overrides

--- a/etna/whatson/models.py
+++ b/etna/whatson/models.py
@@ -288,8 +288,11 @@ class WhatsOnPage(BasePageWithIntro):
         """
         Returns a queryset of events that are children of this page.
         """
-        # .exclude and check page id matches featured_event.id
-        return EventPage.objects.child_of(self).live().public().order_by("start_date").exclude(id=self.featured_event.id)
+
+        if self.featured_event:
+            return EventPage.objects.child_of(self).live().public().order_by("start_date").exclude(id=self.featured_event.id)
+        else:
+            return EventPage.objects.child_of(self).live().public().order_by("start_date")
 
     def filter_form_data(self, filter_form_cleaned_data):
         events = self.events
@@ -351,7 +354,8 @@ class WhatsOnPage(BasePageWithIntro):
             self.events = self.filter_form_data(filter_form.cleaned_data)
 
         context["filter_form"] = filter_form
-        context["show_fetured_event"] = self.show_featured_event(filter_form.cleaned_data, self.featured_event)
+        if self.featured_event:
+            context["show_fetured_event"] = self.show_featured_event(filter_form.cleaned_data, self.featured_event)
 
         return context
 

--- a/etna/whatson/models.py
+++ b/etna/whatson/models.py
@@ -290,9 +290,17 @@ class WhatsOnPage(BasePageWithIntro):
         """
 
         if self.featured_event:
-            return EventPage.objects.child_of(self).live().public().order_by("start_date").exclude(id=self.featured_event.id)
+            return (
+                EventPage.objects.child_of(self)
+                .live()
+                .public()
+                .order_by("start_date")
+                .exclude(id=self.featured_event.id)
+            )
         else:
-            return EventPage.objects.child_of(self).live().public().order_by("start_date")
+            return (
+                EventPage.objects.child_of(self).live().public().order_by("start_date")
+            )
 
     def filter_form_data(self, filter_form_cleaned_data):
         events = self.events
@@ -355,7 +363,9 @@ class WhatsOnPage(BasePageWithIntro):
 
         context["filter_form"] = filter_form
         if self.featured_event:
-            context["show_fetured_event"] = self.show_featured_event(filter_form.cleaned_data, self.featured_event)
+            context["show_fetured_event"] = self.show_featured_event(
+                filter_form.cleaned_data, self.featured_event
+            )
 
         return context
 

--- a/etna/whatson/tests/test_pages.py
+++ b/etna/whatson/tests/test_pages.py
@@ -1,6 +1,6 @@
-from datetime import date
+from datetime import date, datetime
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
 from etna.home.factories import HomePageFactory
@@ -10,6 +10,10 @@ from ..models import AudienceType, EventAudienceType, EventSession, EventType
 
 
 class TestWhatsOnPageEventFiltering(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+
     @classmethod
     def setUpTestData(cls):
         cls.home_page = HomePageFactory()
@@ -40,30 +44,25 @@ class TestWhatsOnPageEventFiltering(TestCase):
         )
         cls.event_audience_type.save()
 
-        cls.event_page1 = EventPageFactory(
+        cls.featured_event = EventPageFactory(
             title="Event page 1",
             parent=cls.whats_on_page,
             event_type=cls.talk_event_type,
             venue_type="online",
             min_price=0,
             max_price=0,
-            start_date=timezone.datetime(
-                2023, 10, 17, tzinfo=timezone.get_current_timezone()
-            ),
+            start_date=timezone.make_aware(datetime(2023, 10, 17)),
             sessions=[
                 EventSession(
                     page=cls.whats_on_page,
-                    start=timezone.datetime(
-                        2023, 10, 15, tzinfo=timezone.get_current_timezone()
-                    ),
-                    end=timezone.datetime(
-                        2023, 10, 16, tzinfo=timezone.get_current_timezone()
-                    ),
+                    start=timezone.make_aware(datetime(2023, 10, 15)),
+                    end=timezone.make_aware(datetime(2023, 10, 16)),
                 )
             ],
         )
+        cls.whats_on_page.featured_event = cls.featured_event
 
-        cls.event_page2 = EventPageFactory(
+        cls.event_page_2 = EventPageFactory(
             title="Event page 2",
             parent=cls.whats_on_page,
             event_type=cls.talk_event_type,
@@ -71,65 +70,56 @@ class TestWhatsOnPageEventFiltering(TestCase):
             venue_type="online",
             min_price=0,
             max_price=15,
-            start_date=timezone.datetime(2023, 10, 17),
+            start_date=timezone.make_aware(datetime(2023, 10, 17)),
             sessions=[
                 EventSession(
                     page=cls.whats_on_page,
-                    start=timezone.datetime(
-                        2023, 10, 17, tzinfo=timezone.get_current_timezone()
-                    ),
-                    end=timezone.datetime(
-                        2023, 10, 18, tzinfo=timezone.get_current_timezone()
-                    ),
+                    start=timezone.make_aware(datetime(2023, 10, 17)),
+                    end=timezone.make_aware(datetime(2023, 10, 18)),
                 )
             ],
         )
 
-        cls.event_page3 = EventPageFactory(
+        cls.event_page_3 = EventPageFactory(
             title="Event page 3",
             parent=cls.whats_on_page,
             event_type=cls.tour_event_type,
             venue_type="in_person",
             min_price=15,
             max_price=30,
-            start_date=timezone.datetime(
-                2023, 10, 20, tzinfo=timezone.get_current_timezone()
-            ),
+            start_date=timezone.make_aware(datetime(2023, 10, 20)),
             sessions=[
                 EventSession(
                     page=cls.whats_on_page,
-                    start=timezone.datetime(
-                        2023, 10, 20, tzinfo=timezone.get_current_timezone()
-                    ),
-                    end=timezone.datetime(
-                        2023, 10, 21, tzinfo=timezone.get_current_timezone()
-                    ),
+                    start=timezone.make_aware(datetime(2023, 10, 20)),
+                    end=timezone.make_aware(datetime(2023, 10, 21)),
                 )
             ],
         )
 
     def test_get_event_pages(self):
         self.assertQuerySetEqual(
-            self.whats_on_page.events,
-            [self.event_page1, self.event_page2, self.event_page3],
+            self.whats_on_page.get_events_queryset(),
+            [self.featured_event, self.event_page_2, self.event_page_3],
         )
 
     def assert_filtered_event_pages_equal(self, filter_params, expected_result):
+        events = self.whats_on_page.get_events_queryset()
         self.assertQuerySetEqual(
-            self.whats_on_page.filter_form_data(filter_params), expected_result
+            self.whats_on_page.filter_events(events, filter_params), expected_result
         )
 
     def test_filtered_event_pages(self):
         test_cases = (
-            ({}, [self.event_page1, self.event_page2, self.event_page3]),
-            ({"is_online_event": True}, [self.event_page1, self.event_page2]),
+            ({}, [self.featured_event, self.event_page_2, self.event_page_3]),
+            ({"is_online_event": True}, [self.featured_event, self.event_page_2]),
             (
                 {"event_type": self.talk_event_type},
-                [self.event_page1, self.event_page2],
+                [self.featured_event, self.event_page_2],
             ),
-            ({"event_type": self.tour_event_type}, [self.event_page3]),
-            ({"family_friendly": True}, [self.event_page2]),
-            ({"date": date(2023, 10, 20)}, [self.event_page3]),
+            ({"event_type": self.tour_event_type}, [self.event_page_3]),
+            ({"family_friendly": True}, [self.event_page_2]),
+            ({"date": date(2023, 10, 20)}, [self.event_page_3]),
         )
 
         for filter_params, expected in test_cases:
@@ -138,11 +128,42 @@ class TestWhatsOnPageEventFiltering(TestCase):
 
     def test_price_range(self):
         test_cases = (
-            (self.event_page1.price_range, "Free"),
-            (self.event_page2.price_range, "Free - 15"),
-            (self.event_page3.price_range, "15 - 30"),
+            (self.featured_event.price_range, "Free"),
+            (self.event_page_2.price_range, "Free - 15"),
+            (self.event_page_3.price_range, "15 - 30"),
         )
 
         for test_value, expected in test_cases:
             with self.subTest(test_value=test_value, expected=expected):
                 self.assertEqual(test_value, expected)
+
+    def test_should_not_show_featured_event(self):
+        self.assertEqual(self.featured_event.event_type, self.talk_event_type)
+        request = self.factory.get(
+            self.whats_on_page.url, {"event_type": self.tour_event_type.pk}
+        )
+
+        context = self.whats_on_page.get_context(request)
+        # We filtered for events with type "tour", featured event is type
+        # "talk", so should not be displayed
+        self.assertFalse(context["show_featured_event"])
+        self.assertNotIn(self.featured_event, context["events"])
+
+    def test_should_show_featured_event(self):
+        self.assertEqual(self.featured_event.event_type, self.talk_event_type)
+        request = self.factory.get(
+            self.whats_on_page.url, {"event_type": self.talk_event_type.pk}
+        )
+
+        context = self.whats_on_page.get_context(request)
+        self.assertTrue(context["show_featured_event"])
+        self.assertNotIn(self.featured_event, context["events"])
+
+    def test_featured_event_not_in_main_listing(self):
+        """
+        Featured event should never be in the main events listing
+        """
+        request = self.factory.get(self.whats_on_page.url)
+        context = self.whats_on_page.get_context(request)
+        self.assertIn(self.featured_event, self.whats_on_page.get_events_queryset())
+        self.assertNotIn(self.featured_event, context["events"])

--- a/templates/includes/whats-on-listing.html
+++ b/templates/includes/whats-on-listing.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags %}
 
 {# Featured event #}
-{% if page.featured_event and show_fetured_event %}
+{% if page.featured_event and show_featured_event %}
     {% image page.featured_event.teaser_image fill-1190x600 as featured_img %}
     {% include "../components/featured_card.html" with title=page.featured_event.title href=page.featured_event.url headingLevel="2" headingSize="l" htmlElement="article" imageSrc=featured_img.url imageAlt="featured card image alt" imageWidth=featured_img.width imageHeight=featured_img.height date=page.featured_event.start_date|date:"jS F Y" cost=page.featured_event.price_range venue_type=page.featured_event.get_venue_type_display event_type=page.featured_event.event_type access_descriptor=page.featured_event.primary_access_type %}
 {% endif %}

--- a/templates/includes/whats-on-listing.html
+++ b/templates/includes/whats-on-listing.html
@@ -1,5 +1,16 @@
 {% load wagtailimages_tags %}
 
+{# Featured event #}
+{% if page.featured_event and show_fetured_event %}
+    {% image page.featured_event.teaser_image fill-1190x600 as featured_img %}
+    {% include "../components/featured_card.html" with title=page.featured_event.title href=page.featured_event.url headingLevel="2" headingSize="l" htmlElement="article" imageSrc=featured_img.url imageAlt="featured card image alt" imageWidth=featured_img.width imageHeight=featured_img.height date=page.featured_event.start_date|date:"jS F Y" cost=page.featured_event.price_range venue_type=page.featured_event.get_venue_type_display event_type=page.featured_event.event_type access_descriptor=page.featured_event.primary_access_type %}
+{% endif %}
+
+<hgroup class="event-card-listing__heading-area">
+<h2 class="tna-heading tna-heading--l event-card-listing__heading">All events</h2>
+<p class="event-card-listing__summary">Showing 1 to 12 of {{ page.events|length }} events</p>
+</hgroup>
+
 <ul class="event-card-listing__list">
     {% if page.events %}
         {% for event in page.events %}

--- a/templates/includes/whats-on-listing.html
+++ b/templates/includes/whats-on-listing.html
@@ -8,12 +8,12 @@
 
 <hgroup class="event-card-listing__heading-area">
 <h2 class="tna-heading tna-heading--l event-card-listing__heading">All events</h2>
-<p class="event-card-listing__summary">Showing 1 to 12 of {{ page.events|length }} events</p>
+<p class="event-card-listing__summary">Showing 1 to 12 of {{ events|length }} events</p>
 </hgroup>
 
 <ul class="event-card-listing__list">
-    {% if page.events %}
-        {% for event in page.events %}
+    {% if events %}
+        {% for event in events %}
         <li class="event-card-listing__item">
             {% image event.teaser_image fill-720x448 as event_img %}
             {% include "../components/card.html" with title=event.short_title href=event.url headingLevel="2" headingSize="l" htmlElement="article" imageSrc=event_img.url imageAlt=event_image.width imageWidth=event_img.width imageHeight=event_img.height date=event.start_date|date:"jS F Y" cost=event.price_range venue_type=event.get_venue_type_display body=event.teaser_text horizontal=True event=True highlight="Sold out" highlight_color="yellow" event_type=event.event_type access_descriptor=event.primary_access_type classes="tna-card--event tna-card--horizontal-thirds" index=forloop.counter0 heading=heading %}

--- a/templates/whatson/whats_on_page.html
+++ b/templates/whatson/whats_on_page.html
@@ -62,10 +62,12 @@
 
   <div class="tna-container tna-container--offset-top tna-container--full-width-mobile event-card-listing">
     <div class="tna-column tna-column--full">
-      {% if page.featured_event %}
-        {% image page.featured_event.teaser_image fill-1190x600 as featured_img %}
-        {% include "../components/featured_card.html" with title=page.featured_event.title href=page.featured_event.url headingLevel="2" headingSize="l" htmlElement="article" imageSrc=featured_img.url imageAlt="featured card image alt" imageWidth=featured_img.width imageHeight=featured_img.height date=page.featured_event.start_date|date:"jS F Y" cost=page.featured_event.price_range venue_type=page.featured_event.get_venue_type_display event_type=page.featured_event.event_type access_descriptor=page.featured_event.primary_access_type %}
-      {% endif %}
+
+      {# Featured event #}
+        {% if page.featured_event and show_fetured_event %}
+          {% image page.featured_event.teaser_image fill-1190x600 as featured_img %}
+          {% include "../components/featured_card.html" with title=page.featured_event.title href=page.featured_event.url headingLevel="2" headingSize="l" htmlElement="article" imageSrc=featured_img.url imageAlt="featured card image alt" imageWidth=featured_img.width imageHeight=featured_img.height date=page.featured_event.start_date|date:"jS F Y" cost=page.featured_event.price_range venue_type=page.featured_event.get_venue_type_display event_type=page.featured_event.event_type access_descriptor=page.featured_event.primary_access_type %}
+        {% endif %}
 
       <hgroup class="event-card-listing__heading-area">
         <h2 class="tna-heading-l event-card-listing__heading">All events</h2>

--- a/templates/whatson/whats_on_page.html
+++ b/templates/whatson/whats_on_page.html
@@ -63,17 +63,6 @@
   <div class="tna-container tna-container--offset-top tna-container--full-width-mobile event-card-listing">
     <div class="tna-column tna-column--full">
 
-      {# Featured event #}
-        {% if page.featured_event and show_fetured_event %}
-          {% image page.featured_event.teaser_image fill-1190x600 as featured_img %}
-          {% include "../components/featured_card.html" with title=page.featured_event.title href=page.featured_event.url headingLevel="2" headingSize="l" htmlElement="article" imageSrc=featured_img.url imageAlt="featured card image alt" imageWidth=featured_img.width imageHeight=featured_img.height date=page.featured_event.start_date|date:"jS F Y" cost=page.featured_event.price_range venue_type=page.featured_event.get_venue_type_display event_type=page.featured_event.event_type access_descriptor=page.featured_event.primary_access_type %}
-        {% endif %}
-
-      <hgroup class="event-card-listing__heading-area">
-        <h2 class="tna-heading-l event-card-listing__heading">All events</h2>
-        <p class="event-card-listing__summary">Showing 1 to 12 of {{ page.events|length }} events</p>
-      </hgroup>
-
       <div data-js-whatson-listing>
         {% include "includes/whats-on-listing.html" %}
       </div>


### PR DESCRIPTION
No ticket

## About these changes

The featured event card is meant to have the filtering applied, just like the other event cards, and should not be repeated in the list below.

This adds some extra queries to work with the featured card, if it has been added. It also moves more of the markup from the whats on template to the whats on listing include, so that the featured card can be updated with JavaScript.

## How to check these changes

Add a few events to a whats on listing page, and also add a featured event. Check that the filtering behaves as you expect, and that the featured event is not repeated in the listing below.

Also check the page when there is no featured event selected.

You could also test that it works without JS by setting the `FEATURE_DISABLE_JS_WHATS_ON_LISTING` to True in your `.env` file (note that you need to run `fab stop` and `fab start`)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
