### PR TITLE
Add tracking to hero banner details toggle

### DIFF
--- a/scripts/src/article.js
+++ b/scripts/src/article.js
@@ -7,6 +7,7 @@ import add_unique_ids from "./modules/analytics/add_unique_ids";
 import mobile_tracking from "./modules/analytics/article_tracking/mobile_tracking";
 import remove_mobile_tracking from "./modules/analytics/article_tracking/remove_mobile_tracking";
 import link_list_tracking from "./modules/analytics/article_tracking/link_list_tracking";
+import trackHeroCaptions from "./modules/analytics/hero-captions";
 
 import accordion_functionality from "./modules/articles/accordion_functionality/accordion_functionality";
 import add_event from "./modules/articles/add_event";
@@ -31,6 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
     video_tracking();
     add_unique_ids();
     link_list_tracking();
+    trackHeroCaptions();
 });
 
 window.addEventListener("load", () => {

--- a/scripts/src/modules/analytics/hero-captions.js
+++ b/scripts/src/modules/analytics/hero-captions.js
@@ -1,0 +1,19 @@
+import push_to_data_layer from "./push_to_data_layer";
+
+const trackHeroCaptions = () => {
+    const $heroCaptions = document.querySelectorAll(".tna-hero__details");
+    $heroCaptions.forEach(($heroCaption) => {
+        $heroCaption.addEventListener("toggle", () =>
+            push_to_data_layer({
+                event: "Expand accordion",
+                "data-component-name": "Hero banner image",
+                "data-link-type": "Tooltip",
+                "data-link": $heroCaption.hasAttribute("open")
+                    ? "Expand caption"
+                    : "Collapse caption",
+            }),
+        );
+    });
+};
+
+export default trackHeroCaptions;


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/UN-616

Data should be added to the window's `dataLayer` object on opening and closing hero element captions:

- http://localhost:8000/explore-the-collection/stories/Policing-migration/
- http://localhost:8000/explore-the-collection/stories/richard-iii/