### PR TITLE
UN-808: Author Page BE analytics

### DIFF
--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -1,5 +1,8 @@
+from typing import Any, Dict
+
 from django.conf import settings
 from django.db import models
+from django.http import HttpRequest
 from django.utils.functional import cached_property
 
 from modelcluster.fields import ParentalKey
@@ -59,6 +62,9 @@ class AuthorPage(BasePage):
         verbose_name = "Author page"
         verbose_name_plural = "Author pages"
 
+    # DataLayerMixin overrides
+    gtm_content_group = "Author page"
+
     parent_page_types = ["authors.AuthorIndexPage"]
     subpage_types = []
 
@@ -70,6 +76,11 @@ class AuthorPage(BasePage):
             .order_by("-first_published_at")
             .select_related("teaser_image")
         )
+
+    def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
+        data = super().get_datalayer_data(request)
+        data.update(customDimension3="Author page")
+        return data
 
 
 class AuthorTag(models.Model):


### PR DESCRIPTION
Ticket URL: [UN-808]

## About these changes

Added `gtm_content_group` and `get_datalayer_data` overrides, with the required data as per the ticket

## How to check these changes

Load up an Author page, enter dev tools and type `dataLayer` into the console. You should see `contentGroup1` and `customDimension3` both set to "Author page"

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[UN-808]: https://national-archives.atlassian.net/browse/UN-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ