### PR TITLE
Off-black header colour for whats on pages

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -594,3 +594,8 @@ Modified to match the existing site (for now)
         }
     }
 }
+
+// off-black header
+.tna-header--off-black {
+    background-color: $color--off-black;
+}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -2,7 +2,7 @@
 
 {% include 'includes/login-status.html' %}
 
-<header class="tna-header tna-header--accent" data-module="tna-header">
+<header class="tna-header tna-header--accent {{ classes }}" data-module="tna-header">
   <div class="tna-header__exit">
     <div class="tna-container">
       <div class="tna-column tna-column--full">

--- a/templates/whatson/event_page.html
+++ b/templates/whatson/event_page.html
@@ -4,6 +4,10 @@
 
 {% block html_class %}tna-template--pink-accent{% endblock %}
 
+{% block header %}
+    {% include 'includes/header.html' with classes="tna-header--off-black" %}
+{% endblock %}
+
 {# Breadcrumb is included inside the event_hero component #}
 {% block breadcrumb %}
 {% endblock %}

--- a/templates/whatson/whats_on_page.html
+++ b/templates/whatson/whats_on_page.html
@@ -4,6 +4,10 @@
 
 {% block html_class %}tna-template--pink-accent{% endblock %}
 
+{% block header %}
+    {% include 'includes/header.html' with classes="tna-header--off-black" %}
+{% endblock %}
+
 {# Breadcrumb is included inside the header area #}
 {% block breadcrumb %}
 {% endblock %}


### PR DESCRIPTION
[ part of this ticket](https://national-archives.atlassian.net/jira/software/projects/DSWO/boards/121?selectedIssue=DSWO-46)

## About these changes

This adds the correct header colour for the what's on pages. Note that the solution was not simply to completely remove the `tna-header--accent ` class from the header, as that left the background colour as black, whereas the designs use the off-black `#1e1e1e` which isn't currently available in `tna-frontend`. Therefore I've added another override in `etna.scss` to set the correct background class for the whats on header - this can be moved to `tna-frontend` in the future.

## How to check these changes

In your local build, test the whats on listing page, and an individual event page.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
