### PR TITLE
DF-834 Improvements to website results tab

### DIFF
--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -26,7 +26,7 @@ class BucketKeys(StrEnum):
 class SearchTabs(StrEnum):
     ALL = "All results"
     CATALOGUE = "Catalogue results"
-    WEBSITE = "Website results"
+    WEBSITE = "Our website results"
 
 
 class Aggregation(StrEnum):

--- a/templates/search/blocks/search_sort_and_view_options.html
+++ b/templates/search/blocks/search_sort_and_view_options.html
@@ -2,6 +2,7 @@
 
 
 <div class="search-sort-view">
+    <p class="search-results__explainer">Results for everything on our website that matches your search term.</p>
     <form method="GET" class="search-sort-view__form search-sort-view__desktop" data-id="sort-form-desktop" id="catalogue-sort-form-desktop" data-search-type="{{ view.search_tab }}" data-search-bucket="{{ buckets.current.label }}" data-search-filter-name="Sort results" data-search-filter-value="">
 
         <h2 class="tna-heading-l search-sort-view__heading">


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/projects/DF/issues/DF-834

## About these changes

Change to the 'Website results' tab and adding in some helper text on 'Website results' page.

## How to check these changes

Check that the tab now reads 'Our website results'
Check that the helper text 'Results for everything on our website that matches your search term.'


## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
