### PR TITLE
CHORE:update search, record details templates to accommodate specific bucket details

### DIFF
--- a/templates/includes/records/record-details.html
+++ b/templates/includes/records/record-details.html
@@ -1,267 +1,293 @@
 {% load records_tags %}
 
-<div class="record-details">
-    <table class="record-details__table">
-        <tbody>
-            {% if record.reference_number %}
-                <tr>
-                    <th scope="row">{{ 'reference_number'|as_label }}</th>
-                    <td id="analytics-record-reference">{{ record.reference_number }}</td>
-                </tr>
-            {% endif %}
-            {% if record.title %}
-            <tr>
-                <th scope="row">{{ 'title'|as_label }}</th>
-                <td id="analytics-record-reference">{{ record.title }}</td>
-            </tr>
-            {% endif %}
-            {% if record.date_created %}
-                <tr>
-                    <th scope="row">{{ 'date_created'|as_label }}</th>
-                    <td>{{ record.date_created }}</td>
-                </tr>
-            {% endif %}
-            {% if record.description %}
-                <tr>
-                    <th scope="row">{{ 'description'|as_label }}</th>
-                    <td class="xslt_patches">{{ record.description }}</td>
-                </tr>
-            {% endif %}
-            {% if record.note %}
-                <tr>
-                    <th scope="row">{{ 'note'|as_label }}</th>
-                    <td>
-                    {% for item in record.note %}
-                        <p>{{ item }}</p>
-                    {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}                        
-            {% if record.arrangement %}
-                <tr>
-                    <th scope="row">{{ 'arrangement'|as_label }}</th>
-                    <td>{{ record.arrangement }}</td>
-                </tr>
-            {% endif %}
-            {% if record.related_materials %}
-                <tr>
-                    <th scope="row">{{ 'related_materials'|as_label }}</th>
-                    <td>
-                        {% for related_material in record.related_materials %}
-                            {% if related_material.description %}
-                                <p>{{related_material.description}}
-                                {% if related_material.links %}
-                                    {% for link in related_material.links %}
-                                        <a href="{{ link.href }}">{{ link.text }}</a>
-                                    {% endfor %}
-                                {% endif %}
-                                </p>
-                            {% endif %}
+{% if record.reference_number %}
+    <tr>
+        <th scope="row">{{ 'reference_number'|as_label }}</th>
+        <td id="analytics-record-reference">{{ record.reference_number }}</td>
+    </tr>
+{% endif %}
+
+{% if record.title %}
+    <tr>
+        <th scope="row">{{ 'title'|as_label }}</th>
+        <td id="analytics-record-reference">{{ record.title }}</td>
+    </tr>
+{% endif %}
+
+{% if record.date_created %}
+    <tr>
+        <th scope="row">{{ 'date_created'|as_label }}</th>
+        <td>{{ record.date_created }}</td>
+    </tr>
+{% endif %}
+
+{% if record.description %}
+    <tr>
+        <th scope="row">{{ 'description'|as_label }}</th>
+        <td class="xslt_patches">{{ record.description }}</td>
+    </tr>
+{% endif %}
+
+{% if record.note %}
+    <tr>
+        <th scope="row">{{ 'note'|as_label }}</th>
+        <td>
+            {% for item in record.note %}
+                <p>{{ item }}</p>
+            {% endfor %}
+        </td>
+    </tr>
+{% endif %} 
+
+{% if record.arrangement %}
+    <tr>
+        <th scope="row">{{ 'arrangement'|as_label }}</th>
+        <td>{{ record.arrangement }}</td>
+    </tr>
+{% endif %}
+
+{% if record.related_materials %}
+    <tr>
+        <th scope="row">{{ 'related_materials'|as_label }}</th>
+        <td>
+            {% for related_material in record.related_materials %}
+                {% if related_material.description %}
+                    <p>{{related_material.description}}
+                    {% if related_material.links %}
+                        {% for link in related_material.links %}
+                            <a href="{{ link.href }}">{{ link.text }}</a>
                         {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}            
-            {% if record.separated_materials %}
-                <tr>
-                    <th scope="row">{{ 'separated_materials'|as_label }}</th>
-                    <td>
-                        {% for separated_material in record.separated_materials %}
-                            {% if separated_material.description %}
-                                <p>{{ separated_material.description }}</p>
-                            {% endif %}
-                            {% if separated_material.links %}
-                                {% for link in separated_material.links %}
-                                    <p><a href="{{ link.href }}">{{ link.text }}</a></p>
-                                {% endfor %}
-                            {% endif %}
-                        {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% if record.held_by %}
-                <tr>
-                    <th scope="row">{{ 'held_by'|as_label }}</th>
-                    <td>
-                    {% if record.held_by_url %}
-                        <a href="{{ record.held_by_url }}">{{ record.held_by }}</a>
-                    {% else %}
-                        {{ record.held_by }}
                     {% endif %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% if record.former_department_reference %}
-                <tr>
-                    <th scope="row">{{ 'former_department_reference'|as_label }}</th>
-                    <td>{{ record.former_department_reference }}</td>
-                </tr>
-            {% endif %}
-            {% if record.former_pro_reference %}
-                <tr>
-                    <th scope="row">{{ 'former_pro_reference'|as_label }}</th>
-                    <td>{{ record.former_pro_reference }}</td>
-                </tr>
-            {% endif %}
-            {% if record.location_of_originals %}
-                <tr>
-                    <th scope="row">{{ 'location_of_originals'|as_label }}</th>
-                    <td>
-                    {% for item in record.location_of_originals %}
-                        <p>{{ item }}</p>
+                    </p>
+                {% endif %}
+            {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.separated_materials %}
+    <tr>
+        <th scope="row">{{ 'separated_materials'|as_label }}</th>
+        <td>
+            {% for separated_material in record.separated_materials %}
+                {% if separated_material.description %}
+                    <p>{{ separated_material.description }}</p>
+                {% endif %}
+                {% if separated_material.links %}
+                    {% for link in separated_material.links %}
+                        <p><a href="{{ link.href }}">{{ link.text }}</a></p>
                     {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% if record.legal_status %}
-                <tr>
-                    <th scope="row">{{ 'legal_status'|as_label }}</th>
-                    <td>{{ record.legal_status }}</td>
-                </tr>
-            {% endif %}
-            {% if record.language %}
-                <tr>
-                    <th scope="row">{{ 'language'|as_label }}</th>
-                    <td>
-                    {% for item in record.language %}
-                        <p>{{ item }}</p>
-                    {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% if record.map_designation %}
-                <tr>
-                    <th scope="row">{{ 'map_designation'|as_label }}</th>
-                    <<td>{{ record.map_designation }}</td>
-                </tr>
-            {% endif %}
-            {% if record.creator %}
-                <tr>
-                    <th scope="row">{{ 'creator'|as_label }}</th>
-                    <td>
-                    {% for item in record.creator %}
-                        <p>{{ item }}</p>
-                    {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% if record.physical_description %}
-                <tr>
-                    <th scope="row">{{ 'physical_description'|as_label }}</th>
-                    <td>{{ record.physical_description }}</td>
-                </tr>
-            {% endif %}           
-            {% if record.restrictions_on_use %}
-                <tr>
-                    <th scope="row">{{ 'restrictions_on_use'|as_label }}</th>
-                    <td>{{ record.restrictions_on_use }}</td>
-                </tr>
-            {% endif %}
-            {% if record.dimensions %}
-                <tr>
-                    <th scope="row">{{ 'dimensions'|as_label }}</th>
-                    <td>{{ record.dimensions }}</td>
-                </tr>
-            {% endif %}
-            {% if record.access_condition %}
-                <tr>
-                    <th scope="row">{{ 'access_condition'|as_label }}</th>
-                    <td>{{ record.access_condition }}</td>
-                </tr>
-            {% endif %}
-            {% if record.immediate_source_of_acquisition %}
-                <tr>
-                    <th scope="row">{{ 'immediate_source_of_acquisition'|as_label }}</th>
-                    <td>
-                    {% for item in record.immediate_source_of_acquisition %}
-                        <p>{{ item }}</p>
-                    {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% if record.map_scale %}
-                <tr>
-                    <th scope="row">{{ 'map_scale'|as_label }}</th>
-                    <td>{{ record.map_scale }}</td>
-                </tr>
-            {% endif %}
-            {% if record.physical_condition %}
-                <tr>
-                    <th scope="row">{{ 'physical_condition'|as_label }}</th>
-                    <td>{{ record.physical_condition }}</td>
-                </tr>
-            {% endif %}            
-            {% if record.closure_status %}
-                <tr>
-                    <th scope="row">{{ 'closure'|as_label }}</th>
-                    <td>{{ record.closure_status }}</td>
-                </tr>
-            {% endif %} 
-            {% if record.custodial_history %}
-                <tr>
-                    <th scope="row">{{ 'custodial_history'|as_label }}</th>
-                    <td>{{ record.custodial_history }}</td>
-                </tr>
-            {% endif %}
-            {% if record.accumulation_dates %}
-                <tr>
-                    <th scope="row">{{ 'accumulation_dates'|as_label }}</th>
-                    <td>{{ record.accumulation_dates }}</td>
-                </tr>
-            {% endif %}
-            {% if record.accruals %}
-                <tr>
-                    <th scope="row">{{ 'accruals'|as_label }}</th>
-                    <td>{{ record.accruals }}</td>
-                </tr>
-            {% endif %}
-            {% if record.unpublished_finding_aids %}
-                <tr>
-                    <th scope="row">{{ 'unpublished_finding_aids'|as_label }}</th>
-                    <td>
-                        {% for item in record.unpublished_finding_aids %}
-                            <p>{{ item }}</p>
-                        {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}            
-            {% if record.appraisal_information %}
-                <tr>
-                    <th scope="row">{{ 'appraisal_information'|as_label }}</th>
-                    <td>{{ record.appraisal_information }}</td>
-                </tr>
-            {% endif %}
-            {% if record.administrative_background %}
-                <tr>
-                    <th scope="row">{{ 'administrative_background'|as_label }}</th>
-                    <td>{{ record.administrative_background }}</td>
-                </tr>
-            {% endif %}
-            {% if record.copies_information %}
-                <tr>
-                    <th scope="row">{{ 'copies_information'|as_label }}</th>
-                    <td>
-                        {% for item in record.copies_information %}
-                            <p>{{ item }}</p>
-                        {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}            
-            {% if record.publication_note %}
-                <tr>
-                    <th scope="row">{{ 'publication_note'|as_label }}</th>
-                    <td>
-                        {% for item in record.publication_note %}
-                            <p>{{ item }}</p>
-                        {% endfor %}
-                    </td>
-                </tr>
-            {% endif %}            
-            {% if record.record_opening %}
-                <tr>
-                    <th scope="row">{{ 'record_opening'|as_label }}</th>
-                    <td>{{ record.record_opening }}</td>
-                </tr>
-            {% endif %}
-        </tbody>
-    </table>
-</div>
+                {% endif %}
+            {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.held_by %}
+    <tr>
+        <th scope="row">{{ 'held_by'|as_label }}</th>
+        <td>
+        {% if record.held_by_url %}
+            <a href="{{ record.held_by_url }}">{{ record.held_by }}</a>
+        {% else %}
+            {{ record.held_by }}
+        {% endif %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.former_department_reference %}
+    <tr>
+        <th scope="row">{{ 'former_department_reference'|as_label }}</th>
+        <td>{{ record.former_department_reference }}</td>
+    </tr>
+{% endif %}
+
+{% if record.former_pro_reference %}
+    <tr>
+        <th scope="row">{{ 'former_pro_reference'|as_label }}</th>
+        <td>{{ record.former_pro_reference }}</td>
+    </tr>
+{% endif %}
+
+{% if record.location_of_originals %}
+    <tr>
+        <th scope="row">{{ 'location_of_originals'|as_label }}</th>
+        <td>
+        {% for item in record.location_of_originals %}
+            <p>{{ item }}</p>
+        {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.legal_status %}
+    <tr>
+        <th scope="row">{{ 'legal_status'|as_label }}</th>
+        <td>{{ record.legal_status }}</td>
+    </tr>
+{% endif %}
+
+{% if record.language %}
+    <tr>
+        <th scope="row">{{ 'language'|as_label }}</th>
+        <td>
+        {% for item in record.language %}
+            <p>{{ item }}</p>
+        {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.map_designation %}
+    <tr>
+        <th scope="row">{{ 'map_designation'|as_label }}</th>
+        <<td>{{ record.map_designation }}</td>
+    </tr>
+{% endif %}
+
+{% if record.creator %}
+    <tr>
+        <th scope="row">{{ 'creator'|as_label }}</th>
+        <td>
+        {% for item in record.creator %}
+            <p>{{ item }}</p>
+        {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.physical_description %}
+    <tr>
+        <th scope="row">{{ 'physical_description'|as_label }}</th>
+        <td>{{ record.physical_description }}</td>
+    </tr>
+{% endif %}
+
+{% if record.restrictions_on_use %}
+    <tr>
+        <th scope="row">{{ 'restrictions_on_use'|as_label }}</th>
+        <td>{{ record.restrictions_on_use }}</td>
+    </tr>
+{% endif %}
+
+{% if record.dimensions %}
+    <tr>
+        <th scope="row">{{ 'dimensions'|as_label }}</th>
+        <td>{{ record.dimensions }}</td>
+    </tr>
+{% endif %}
+
+{% if record.access_condition %}
+    <tr>
+        <th scope="row">{{ 'access_condition'|as_label }}</th>
+        <td>{{ record.access_condition }}</td>
+    </tr>
+{% endif %}
+
+{% if record.immediate_source_of_acquisition %}
+    <tr>
+        <th scope="row">{{ 'immediate_source_of_acquisition'|as_label }}</th>
+        <td>
+        {% for item in record.immediate_source_of_acquisition %}
+            <p>{{ item }}</p>
+        {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.map_scale %}
+    <tr>
+        <th scope="row">{{ 'map_scale'|as_label }}</th>
+        <td>{{ record.map_scale }}</td>
+    </tr>
+{% endif %}
+
+{% if record.physical_condition %}
+    <tr>
+        <th scope="row">{{ 'physical_condition'|as_label }}</th>
+        <td>{{ record.physical_condition }}</td>
+    </tr>
+{% endif %}
+
+{% if record.closure_status %}
+    <tr>
+        <th scope="row">{{ 'closure'|as_label }}</th>
+        <td>{{ record.closure_status }}</td>
+    </tr>
+{% endif %}
+
+{% if record.custodial_history %}
+    <tr>
+        <th scope="row">{{ 'custodial_history'|as_label }}</th>
+        <td>{{ record.custodial_history }}</td>
+    </tr>
+{% endif %}
+
+{% if record.accumulation_dates %}
+    <tr>
+        <th scope="row">{{ 'accumulation_dates'|as_label }}</th>
+        <td>{{ record.accumulation_dates }}</td>
+    </tr>
+{% endif %}
+
+{% if record.accruals %}
+    <tr>
+        <th scope="row">{{ 'accruals'|as_label }}</th>
+        <td>{{ record.accruals }}</td>
+    </tr>
+{% endif %}
+
+{% if record.unpublished_finding_aids %}
+    <tr>
+        <th scope="row">{{ 'unpublished_finding_aids'|as_label }}</th>
+        <td>
+            {% for item in record.unpublished_finding_aids %}
+                <p>{{ item }}</p>
+            {% endfor %}
+        </td>
+    </tr>
+{% endif %} 
+
+{% if record.appraisal_information %}
+    <tr>
+        <th scope="row">{{ 'appraisal_information'|as_label }}</th>
+        <td>{{ record.appraisal_information }}</td>
+    </tr>
+{% endif %}
+
+{% if record.administrative_background %}
+    <tr>
+        <th scope="row">{{ 'administrative_background'|as_label }}</th>
+        <td>{{ record.administrative_background }}</td>
+    </tr>
+{% endif %}
+
+{% if record.copies_information %}
+    <tr>
+        <th scope="row">{{ 'copies_information'|as_label }}</th>
+        <td>
+            {% for item in record.copies_information %}
+                <p>{{ item }}</p>
+            {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.publication_note %}
+    <tr>
+        <th scope="row">{{ 'publication_note'|as_label }}</th>
+        <td>
+            {% for item in record.publication_note %}
+                <p>{{ item }}</p>
+            {% endfor %}
+        </td>
+    </tr>
+{% endif %}
+
+{% if record.record_opening %}
+    <tr>
+        <th scope="row">{{ 'record_opening'|as_label }}</th>
+        <td>{{ record.record_opening }}</td>
+    </tr>
+{% endif %}

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -19,8 +19,14 @@
 
         <h2 id="record-details-heading" class="tna-heading-l">Description and record details</h2>
 
-        {% include "includes/records/record-details.html" %}
-        {% include "includes/records/record-crosslink-panel.html" %}
+        <div class="record-details">
+            <table class="record-details__table">
+                <tbody>
+                    {% include "includes/records/record-details.html" %}            
+                </tbody>
+            </table>
+        </div>
+        {% include "includes/records/record-crosslink-panel.html" %}        
 
         {% if record.hierarchy %}
             {% if record.hierarchy|length > 2 %}

--- a/templates/search/blocks/search_results__list-card--grid.html
+++ b/templates/search/blocks/search_results__list-card--grid.html
@@ -36,62 +36,7 @@
             {{ record.listing_description }}
         </p>
         <dl class="search-results__list-card-metadata">
-            {% if record.held_by %}
-                <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-held-by-icon">
-                    Held by:
-                </dt>
-                <dd>{{ record.held_by }}</dd>
-            {% endif %}
-
-            {% if record.date_created %}
-                <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
-                    Date:
-                </dt>
-                <dd> {{ record.date_created }}</dd>
-            {% endif %}
-
-            {% if record.reference_number %}
-            <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-data-icon">
-
-                {% if form.group.value == 'archive' %}
-                Archon code:
-                {% else %}
-                Reference:
-                {% endif %}
-
-
-            </dt>
-            <dd>{{ record.reference_number }}</dd>
-            {% endif %}
-
-            <!--
-            {% if record.record_opening %}
-                <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-subjects-icon">
-                    Record opening date:
-                </dt>
-                <dd>{{ record.record_opening }}</dd>
-            {% endif %}
-            -->
-            {% if form.group.value == bucketkeys.CREATOR.value and record.type %}
-                <dt class="search-results__list-card-metadata-item">
-                    Type:
-                </dt>
-                <dd>{{ record.type }}</dd>
-            {% endif %}
-
-            {% comment %}Debug attributes. Output to allow k-int to adjust the ES index{% endcomment %}
-            <!--
-            <dt class="search-results__list-card-metadata-item">
-                IAID:
-            </dt>
-
-            <dd>{{ record.iaid }}</dd>>
-            <dt class="search-results__list-card-metadata-item">
-                Score:
-            </dt>
-            <dd;>{{ record.score }}</dd>
-            -->
-            {% comment %}End debug attributes.{% endcomment %}
+            {% include "search/includes/results-details.html" %}
         </dl>
 
 

--- a/templates/search/blocks/search_results__list-card.html
+++ b/templates/search/blocks/search_results__list-card.html
@@ -26,40 +26,7 @@
         </p>
 
         <dl class="search-results__list-card-metadata">
-            {% if record.held_by %}
-            <dt class="search-results__list-card-metadata-item-held-by-icon">Held by:</dt>
-            <dd>{{ record.held_by }}</dd>
-            {% endif %}
-
-
-
-            {% if record.date_created %}
-            <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
-                Date:</dt>
-            <dd>
-                <date>{{ record.date_created }}</date></dd>
-            {% endif %}
-
-            {% if record.reference_number %}
-            <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-data-icon">
-                {% if form.group.value == 'archive' %}
-                Archon code:
-                {% else %}
-                Reference:
-                {% endif %}
-            </dt>
-            <dd>{{ record.reference_number }}
-            </dd>
-            {% endif %}
-
-            {% if form.group.value == bucketkeys.CREATOR.value and record.type %}
-            <dt class="search-results__list-card-metadata-item">
-                Type:</dt>
-            <dd>{{ record.type }}
-            </dd>
-            {% endif %}
-
-
+            {% include "search/includes/results-details.html" %}
         </dl>
 
     </div>

--- a/templates/search/includes/results-details.html
+++ b/templates/search/includes/results-details.html
@@ -1,0 +1,57 @@
+{% if record.held_by %}
+    <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-held-by-icon">
+        Held by:
+    </dt>
+    <dd>{{ record.held_by }}</dd>
+{% endif %}
+
+{% if record.date_created %}
+    <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-date-icon">
+        Date:
+    </dt>
+    <dd> {{ record.date_created }}</dd>
+{% endif %}
+
+{% if record.reference_number %}
+    <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-data-icon">
+
+        {% if form.group.value == 'archive' %}
+        Archon code:
+        {% else %}
+        Reference:
+        {% endif %}
+
+
+    </dt>
+    <dd>{{ record.reference_number }}</dd>
+{% endif %}
+
+<!--
+{% if record.record_opening %}
+    <dt class="search-results__list-card-metadata-item search-results__list-card-metadata-item-subjects-icon">
+        Record opening date:
+    </dt>
+    <dd>{{ record.record_opening }}</dd>
+{% endif %}
+-->
+
+{% if form.group.value == bucketkeys.CREATOR.value and record.type %}
+    <dt class="search-results__list-card-metadata-item">
+        Type:
+    </dt>
+    <dd>{{ record.type }}</dd>
+{% endif %}
+
+{% comment %}Debug attributes. Output to allow k-int to adjust the ES index{% endcomment %}
+<!--
+<dt class="search-results__list-card-metadata-item">
+    IAID:
+</dt>
+
+<dd>{{ record.iaid }}</dd>>
+<dt class="search-results__list-card-metadata-item">
+    Score:
+</dt>
+<dd;>{{ record.score }}</dd>
+-->
+{% comment %}End debug attributes.{% endcomment %}


### PR DESCRIPTION
Ticket URL: N/A

## About these changes

- There are effectively no changes in terms of UI.
- Update search, record details templates to accommodate specific bucket details. The specific bucket would be for OHOS - which is forked out from Etna or any other buckets in the future. (Eg. for OHOS it is results-details-community.html, record-details-community.html - in terms of choice of attributes and ordering of fields.)
- If required, in the future for Etna, a specific bucket will use a specific results/details template.


## How to check these changes

Search results
http://127.0.0.1:8000/search/catalogue/?group=tna
http://127.0.0.1:8000/search/catalogue/?group=tna&display=list
http://127.0.0.1:8000/search/catalogue/?group=tna&display=grid

Record Details
http://127.0.0.1:8000/catalogue/id/C8077549/

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
