### PR TITLE
FIX:Fix test compatible with python 3.12

### DIFF
--- a/etna/ciim/tests/test_utils.py
+++ b/etna/ciim/tests/test_utils.py
@@ -114,7 +114,7 @@ class TestResolveLinks(SimpleTestCase):
 
         stripped_markup = format_description_markup(markup)
 
-        self.assertEquals(
+        self.assertEqual(
             '<span><a href="/catalogue/id/C11996672/">link text</a></span>',
             stripped_markup,
         )
@@ -124,7 +124,7 @@ class TestResolveLinks(SimpleTestCase):
 
         stripped_markup = format_description_markup(markup)
 
-        self.assertEquals("<span/>", stripped_markup)
+        self.assertEqual("<span/>", stripped_markup)
 
     def test_multiple_links(self):
         markup = (
@@ -136,7 +136,7 @@ class TestResolveLinks(SimpleTestCase):
 
         stripped_markup = format_description_markup(markup)
 
-        self.assertEquals(
+        self.assertEqual(
             (
                 "<span>"
                 '<a href="/catalogue/id/C11996672/">link text one</a>'
@@ -155,7 +155,7 @@ class TestResolveLinks(SimpleTestCase):
 
         stripped_markup = format_description_markup(markup)
 
-        self.assertEquals(
+        self.assertEqual(
             ("<span>" '<a href="http://example.com/">link text one</a>' "</span>"),
             stripped_markup,
         )
@@ -166,7 +166,7 @@ class TestResolveLinks(SimpleTestCase):
 
         stripped_markup = format_description_markup(markup)
 
-        self.assertEquals(
+        self.assertEqual(
             ("<span></span>"),
             stripped_markup,
         )
@@ -327,46 +327,46 @@ class TestConvertSortKeyToIndex(SimpleTestCase):
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 0)
+        self.assertEqual(index, 0)
 
     def test_empty_string(self):
         sort = None
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 0)
+        self.assertEqual(index, 0)
 
     def test_converts_sort_key_with_leading_zero(self):
         sort = "01"
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 0)
+        self.assertEqual(index, 0)
 
     def test_converts_sort_key_at_three_digit_boundary(self):
         sort = "31000"
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 999)
+        self.assertEqual(index, 999)
 
     def test_converts_sort_key_at_four_digit_boundary(self):
         sort = "31001"
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 1000)
+        self.assertEqual(index, 1000)
 
     def test_index_is_zero_for_invalid_sort_key(self):
         sort = "10000"
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 0)
+        self.assertEqual(index, 0)
 
     def test_index_is_zero_for_non_int_sort_key(self):
         sort = "NaN"
 
         index = convert_sort_key_to_index(sort)
 
-        self.assertEquals(index, 0)
+        self.assertEqual(index, 0)

--- a/etna/collections/tests/test_models.py
+++ b/etna/collections/tests/test_models.py
@@ -22,7 +22,7 @@ class TestTopicExplorerIndexPages(TestCase):
         root_page.add_child(instance=self.topic_explorer_index_page)
 
     def test_no_child_pages(self):
-        self.assertEquals(
+        self.assertEqual(
             self.topic_explorer_index_page.topic_explorer_pages.count(), 0
         )
 
@@ -33,7 +33,7 @@ class TestTopicExplorerIndexPages(TestCase):
         self.topic_explorer_index_page.add_child(instance=unpublished_topic_page)
         unpublished_topic_page.unpublish()
 
-        self.assertEquals(
+        self.assertEqual(
             self.topic_explorer_index_page.topic_explorer_pages.count(), 0
         )
 
@@ -47,7 +47,7 @@ class TestTopicExplorerIndexPages(TestCase):
         self.topic_explorer_index_page.add_child(instance=private_topic_page)
         PageViewRestriction.objects.create(page=private_topic_page)
 
-        self.assertEquals(
+        self.assertEqual(
             self.topic_explorer_index_page.topic_explorer_pages.count(), 0
         )
 
@@ -57,7 +57,7 @@ class TestTopicExplorerIndexPages(TestCase):
         )
         self.topic_explorer_index_page.add_child(instance=topic_page)
 
-        self.assertEquals(
+        self.assertEqual(
             self.topic_explorer_index_page.topic_explorer_pages.count(), 1
         )
 
@@ -71,7 +71,7 @@ class TestTopicExplorerIndexPages(TestCase):
         )
         self.topic_explorer_index_page.add_child(instance=topic_page)
 
-        self.assertEquals(
+        self.assertEqual(
             self.topic_explorer_index_page.topic_explorer_pages.count(), 0
         )
 
@@ -158,7 +158,7 @@ class TestTimePeriodExplorerIndexPages(TestCase):
         root_page.add_child(instance=self.time_period_explorer_index_page)
 
     def test_no_child_pages(self):
-        self.assertEquals(
+        self.assertEqual(
             self.time_period_explorer_index_page.time_period_explorer_pages.count(), 0
         )
 
@@ -173,7 +173,7 @@ class TestTimePeriodExplorerIndexPages(TestCase):
         self.time_period_explorer_index_page.add_child(instance=unpublished_topic_page)
         unpublished_topic_page.unpublish()
 
-        self.assertEquals(
+        self.assertEqual(
             self.time_period_explorer_index_page.time_period_explorer_pages.count(), 0
         )
 
@@ -191,7 +191,7 @@ class TestTimePeriodExplorerIndexPages(TestCase):
         self.time_period_explorer_index_page.add_child(instance=private_topic_page)
         PageViewRestriction.objects.create(page=private_topic_page)
 
-        self.assertEquals(
+        self.assertEqual(
             self.time_period_explorer_index_page.time_period_explorer_pages.count(), 0
         )
 
@@ -205,7 +205,7 @@ class TestTimePeriodExplorerIndexPages(TestCase):
         )
         self.time_period_explorer_index_page.add_child(instance=topic_page)
 
-        self.assertEquals(
+        self.assertEqual(
             self.time_period_explorer_index_page.time_period_explorer_pages.count(), 1
         )
 
@@ -215,6 +215,6 @@ class TestTimePeriodExplorerIndexPages(TestCase):
         )
         self.time_period_explorer_index_page.add_child(instance=topic_page)
 
-        self.assertEquals(
+        self.assertEqual(
             self.time_period_explorer_index_page.time_period_explorer_pages.count(), 0
         )

--- a/etna/collections/tests/test_models.py
+++ b/etna/collections/tests/test_models.py
@@ -22,9 +22,7 @@ class TestTopicExplorerIndexPages(TestCase):
         root_page.add_child(instance=self.topic_explorer_index_page)
 
     def test_no_child_pages(self):
-        self.assertEqual(
-            self.topic_explorer_index_page.topic_explorer_pages.count(), 0
-        )
+        self.assertEqual(self.topic_explorer_index_page.topic_explorer_pages.count(), 0)
 
     def test_unpublish_page_excluded(self):
         unpublished_topic_page = TopicExplorerPage(
@@ -33,9 +31,7 @@ class TestTopicExplorerIndexPages(TestCase):
         self.topic_explorer_index_page.add_child(instance=unpublished_topic_page)
         unpublished_topic_page.unpublish()
 
-        self.assertEqual(
-            self.topic_explorer_index_page.topic_explorer_pages.count(), 0
-        )
+        self.assertEqual(self.topic_explorer_index_page.topic_explorer_pages.count(), 0)
 
     @unittest.skip(
         "Disabled test due to all child pages on home being private during beta."
@@ -47,9 +43,7 @@ class TestTopicExplorerIndexPages(TestCase):
         self.topic_explorer_index_page.add_child(instance=private_topic_page)
         PageViewRestriction.objects.create(page=private_topic_page)
 
-        self.assertEqual(
-            self.topic_explorer_index_page.topic_explorer_pages.count(), 0
-        )
+        self.assertEqual(self.topic_explorer_index_page.topic_explorer_pages.count(), 0)
 
     def test_published_public_pages(self):
         topic_page = TopicExplorerPage(
@@ -57,9 +51,7 @@ class TestTopicExplorerIndexPages(TestCase):
         )
         self.topic_explorer_index_page.add_child(instance=topic_page)
 
-        self.assertEqual(
-            self.topic_explorer_index_page.topic_explorer_pages.count(), 1
-        )
+        self.assertEqual(self.topic_explorer_index_page.topic_explorer_pages.count(), 1)
 
     def test_published_time_period_pages_excluded(self):
         topic_page = TimePeriodExplorerPage(
@@ -71,9 +63,7 @@ class TestTopicExplorerIndexPages(TestCase):
         )
         self.topic_explorer_index_page.add_child(instance=topic_page)
 
-        self.assertEqual(
-            self.topic_explorer_index_page.topic_explorer_pages.count(), 0
-        )
+        self.assertEqual(self.topic_explorer_index_page.topic_explorer_pages.count(), 0)
 
 
 class TestTopicExplorerPage(TestCase):

--- a/etna/core/tests/test_decorators.py
+++ b/etna/core/tests/test_decorators.py
@@ -71,7 +71,7 @@ class SettingControlledLoginRequiredTest(WagtailTestUtils, TestCase):
         for url in CONDITIONALLY_PROTECTED_URLS:
             with self.subTest(f"URL: {url}"):
                 response = self.client.get(url)
-                self.assertEquals(response.status_code, 200)
+                self.assertEqual(response.status_code, 200)
 
     @responses.activate
     @override_settings(
@@ -83,4 +83,4 @@ class SettingControlledLoginRequiredTest(WagtailTestUtils, TestCase):
         for url in CONDITIONALLY_PROTECTED_URLS:
             with self.subTest(f"URL: {url}"):
                 response = self.client.get(url)
-                self.assertEquals(response.status_code, 200)
+                self.assertEqual(response.status_code, 200)

--- a/etna/core/tests/test_middleware.py
+++ b/etna/core/tests/test_middleware.py
@@ -14,15 +14,15 @@ class TestMaintenanceMode(TestCase):
     @prevent_request_warnings
     def test_without_maintenance_mode_ends(self):
         response = self.client.get("/")
-        self.assertEquals(response.status_code, 503)
+        self.assertEqual(response.status_code, 503)
         self.assertNotIn("Retry-After", response.headers)
 
     @prevent_request_warnings
     @override_settings(MAINTENENCE_MODE_ENDS="2011-11-04T00:05:23+04:00")
     def test_maintenance_mode_ends_with_timezone_info(self):
         response = self.client.get("/")
-        self.assertEquals(response.status_code, 503)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
             response.headers["Retry-After"], "Thu, 03 Nov 2011 20:05:23 GMT"
         )
 
@@ -30,8 +30,8 @@ class TestMaintenanceMode(TestCase):
     @override_settings(MAINTENENCE_MODE_ENDS="2011-11-04T00:05:23")
     def test_maintenance_mode_ends_without_timezone_info(self):
         response = self.client.get("/")
-        self.assertEquals(response.status_code, 503)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
             response.headers["Retry-After"], "Fri, 04 Nov 2011 00:05:23 GMT"
         )
 
@@ -40,7 +40,7 @@ class TestMaintenanceMode(TestCase):
     def test_maintenance_mode_bypassed_when_ip_in_allow_list(self, *args):
         response = self.client.get("/")
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     @prevent_request_warnings
     @override_settings(MAINTENENCE_MODE_ALLOW_IPS=["123.4.5.6"])
@@ -49,7 +49,7 @@ class TestMaintenanceMode(TestCase):
         self, mock_get_client_ip
     ):
         response = self.client.get("/")
-        self.assertEquals(response.status_code, 503)
+        self.assertEqual(response.status_code, 503)
 
 
 class TestInterpretCookiesMiddleware(SimpleTestCase):

--- a/etna/records/tests/test_blocks.py
+++ b/etna/records/tests/test_blocks.py
@@ -234,4 +234,4 @@ class TestFeaturedRecordBlockIntegration(WagtailPageTestCase):
             reverse("wagtailadmin_pages:edit", args=(self.article_page.id,))
         )
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -588,7 +588,7 @@ class ImageTestCase(TestCase):
         images = Image.search.filter(rid="")
         image = images[0]
 
-        self.assertEquals(
+        self.assertEqual(
             image.thumbnail_url, "https://media.preview/path/to/thumbnail.jpeg"
         )
 
@@ -610,7 +610,7 @@ class ImageTestCase(TestCase):
         image = images[0]
 
         # Fallback serves image through Wagtail instead of from Client API
-        self.assertEquals(image.thumbnail_url, "/records/image/path/to/image.jpeg")
+        self.assertEqual(image.thumbnail_url, "/records/image/path/to/image.jpeg")
 
 
 @override_settings(CLIENT_BASE_URL=f"{settings.CLIENT_BASE_URL}")

--- a/etna/records/tests/test_urls.py
+++ b/etna/records/tests/test_urls.py
@@ -141,7 +141,7 @@ class TestMachineReadableDetailsRouteResolution(TestCase):
     def test_iaid_with_non_standard_prefix(self):
         resolver = resolve("/catalogue/id/C123456/")
 
-        self.assertEquals(resolver.view_name, "details-page-machine-readable")
+        self.assertEqual(resolver.view_name, "details-page-machine-readable")
         self.assertEqual(resolver.kwargs["iaid"], "C123456")
 
     def test_resolves_uuid(self):

--- a/etna/records/tests/test_views.py
+++ b/etna/records/tests/test_views.py
@@ -33,10 +33,10 @@ class TestRecordDisambiguationView(TestCase):
 
         response = self.client.get("/catalogue/ref/AD/2/2/")
 
-        self.assertEquals(
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-human-readable"
         )
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     @responses.activate
     def test_disambiguation_page_rendered_for_multiple_results(self):
@@ -53,7 +53,7 @@ class TestRecordDisambiguationView(TestCase):
 
         response = self.client.get("/catalogue/ref/ADM/223/3/")
 
-        self.assertEquals(
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-human-readable"
         )
         self.assertTemplateUsed(response, "records/record_disambiguation_page.html")
@@ -82,8 +82,8 @@ class TestRecordDisambiguationView(TestCase):
 
         response = self.client.get("/catalogue/ref/ADM/223/3/", follow=False)
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-human-readable"
         )
         self.assertTemplateUsed(response, "records/record_detail.html")
@@ -101,8 +101,8 @@ class TestRecordView(TestCase):
 
         response = self.client.get("/catalogue/id/C123456/")
 
-        self.assertEquals(response.status_code, 404)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-machine-readable"
         )
 
@@ -120,8 +120,8 @@ class TestRecordView(TestCase):
 
         response = self.client.get("/catalogue/id/C123456/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-machine-readable"
         )
         self.assertTemplateUsed(response, "records/record_detail.html")
@@ -149,8 +149,8 @@ class TestRecordView(TestCase):
 
         response = self.client.get("/catalogue/id/C123456/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-machine-readable"
         )
         self.assertTemplateUsed(response, "records/record_detail.html")
@@ -190,7 +190,7 @@ class TestRecordView(TestCase):
 
         response = self.client.get("/catalogue/id/C123456/")
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "records/record_detail.html")
         self.assertTemplateUsed(response, "includes/records/image-viewer-panel.html")
 
@@ -213,8 +213,8 @@ class TestRecordView(TestCase):
 
         response = self.client.get("/catalogue/id/A13532479/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-machine-readable"
         )
         self.assertTemplateUsed(response, "records/archive_detail.html")
@@ -255,8 +255,8 @@ class TestRecordView(TestCase):
 
         response = self.client.get("/catalogue/id/F74321/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
             response.resolver_match.view_name, "details-page-machine-readable"
         )
         self.assertTemplateUsed(response, "records/record_creators.html")
@@ -451,7 +451,7 @@ class TestImageServeView(TestCase):
     def test_no_location_404s(self):
         response = self.client.get("/records/media/")
 
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     @responses.activate
     def test_404_response_from_client_api_is_forwarded(self):
@@ -463,8 +463,8 @@ class TestImageServeView(TestCase):
 
         response = self.client.get("/records/image/missing/image.jpeg")
 
-        self.assertEquals(response.status_code, 404)
-        self.assertEquals(response.resolver_match.url_name, "image-serve")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.resolver_match.url_name, "image-serve")
 
     @responses.activate
     def test_success(self):
@@ -478,8 +478,8 @@ class TestImageServeView(TestCase):
 
         response = self.client.get("/records/image/valid/path.jpg")
 
-        self.assertEquals(response["content-type"], "image/jpeg")
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response["content-type"], "image/jpeg")
+        self.assertEqual(response.status_code, 200)
         self.assertTrue(response.streaming)
 
 
@@ -500,8 +500,8 @@ class TestImageBrowseView(TestCase):
         )
         response = self.client.get("/records/images/C123456/")
 
-        self.assertEquals(response.status_code, 404)
-        self.assertEquals(response.resolver_match.url_name, "image-browse")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.resolver_match.url_name, "image-browse")
 
     @responses.activate
     def test_image_browse_record_with_no_media(self):
@@ -518,8 +518,8 @@ class TestImageBrowseView(TestCase):
         )
         response = self.client.get("/records/images/C123456/")
 
-        self.assertEquals(response.status_code, 404)
-        self.assertEquals(response.resolver_match.url_name, "image-browse")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.resolver_match.url_name, "image-browse")
 
     @responses.activate
     def test_success(self):
@@ -550,8 +550,8 @@ class TestImageBrowseView(TestCase):
 
         response = self.client.get("/records/images/C123456/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.resolver_match.url_name, "image-browse")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.resolver_match.url_name, "image-browse")
 
 
 @unittest.skip(
@@ -581,8 +581,8 @@ class TestImageViewerView(TestCase):
         )
         response = self.client.get("/records/images/C123456/01/")
 
-        self.assertEquals(response.status_code, 404)
-        self.assertEquals(response.resolver_match.url_name, "image-viewer")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.resolver_match.url_name, "image-viewer")
 
     @responses.activate
     def test_image_browse_record_with_no_media(self):
@@ -599,8 +599,8 @@ class TestImageViewerView(TestCase):
         )
         response = self.client.get("/records/images/C123456/01/")
 
-        self.assertEquals(response.status_code, 404)
-        self.assertEquals(response.resolver_match.url_name, "image-viewer")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.resolver_match.url_name, "image-viewer")
 
     @responses.activate
     def test_success(self):
@@ -633,13 +633,13 @@ class TestImageViewerView(TestCase):
 
         response = self.client.get("/records/images/C123456/02/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.resolver_match.url_name, "image-viewer")
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.resolver_match.url_name, "image-viewer")
+        self.assertEqual(
             response.context["previous_image"].location, "path/to/previous-image.jpeg"
         )
-        self.assertEquals(response.context["image"].location, "path/to/image.jpeg")
-        self.assertEquals(
+        self.assertEqual(response.context["image"].location, "path/to/image.jpeg")
+        self.assertEqual(
             response.context["next_image"].location, "path/to/next-image.jpeg"
         )
 
@@ -667,13 +667,13 @@ class TestImageViewerView(TestCase):
 
         response = self.client.get("/records/images/C123456/02/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.resolver_match.url_name, "image-viewer")
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.resolver_match.url_name, "image-viewer")
+        self.assertEqual(
             response.context["previous_image"].location, "path/to/previous-image.jpeg"
         )
-        self.assertEquals(response.context["image"].location, "path/to/image.jpeg")
-        self.assertEquals(response.context["next_image"], None)
+        self.assertEqual(response.context["image"].location, "path/to/image.jpeg")
+        self.assertEqual(response.context["next_image"], None)
 
     @responses.activate
     def test_no_previous_image(self):
@@ -699,11 +699,11 @@ class TestImageViewerView(TestCase):
 
         response = self.client.get("/records/images/C123456/01/")
 
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.resolver_match.url_name, "image-viewer")
-        self.assertEquals(response.context["previous_image"], None)
-        self.assertEquals(response.context["image"].location, "path/to/image.jpeg")
-        self.assertEquals(
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.resolver_match.url_name, "image-viewer")
+        self.assertEqual(response.context["previous_image"], None)
+        self.assertEqual(response.context["image"].location, "path/to/image.jpeg")
+        self.assertEqual(
             response.context["next_image"].location, "path/to/next-image.jpeg"
         )
 
@@ -732,7 +732,7 @@ class TestImageViewerView(TestCase):
 
         response = self.client.get("/records/images/C123456/02/")
 
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     @responses.activate
     def test_invalid_response_from_client_api_raises_404(self):
@@ -766,7 +766,7 @@ class TestImageViewerView(TestCase):
 
         response = self.client.get("/records/images/C123456/11000000000000000000/")
 
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
 
 class RecordDetailBackToSearchTest(TestCase):


### PR DESCRIPTION
Ticket URL: NA

## About these changes

- issue running tests says
```
ERROR: test_no_links (etna.ciim.tests.test_utils.TestResolveLinks.test_no_links)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/etna/ciim/tests/test_utils.py", line 127, in test_no_links
    self.assertEquals("<span/>", stripped_markup)
    ^^^^^^^^^^^^^^^^^
AttributeError: 'TestResolveLinks' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?

FAILED (errors=38, skipped=37)
```

- update assertEquals to assertEqual that is [compatible with python 3.12](https://docs.python.org/3/whatsnew/3.12.html#id3) 

## How to check these changes

Run test locally should not throw failures

```
----------------------------------------------------------------------
Ran 476 tests in 18.196s

OK (skipped=37)
```

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
