### PR TITLE
EDEV-32: Article Pages API response

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -280,10 +280,8 @@ class ArticlePage(
             APIField("similar_items", serializer=PageSerializer(many=True)),
             APIField("latest_items", serializer=PageSerializer(many=True)),
             APIField("body"),
-            # TODO
-            # APIField("topics"),
-            # APIField("time_periods"),
         ]
+        + TopicalPageMixin.api_fields
     )
 
     def get_datalayer_data(self, request: HttpRequest) -> Dict[str, Any]:
@@ -439,6 +437,7 @@ class FocusedArticlePage(
             APIField("body"),
             APIField("authors", serializer=AuthorSerializer(many=True)),
         ]
+        + TopicalPageMixin.api_fields
     )
 
     def save(self, *args, **kwargs):
@@ -699,6 +698,7 @@ class RecordArticlePage(
             # APIField("gallery_items"),
             # APIField("gallery_text"),
         ]
+        + TopicalPageMixin.api_fields
     )
 
     @cached_property

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -199,13 +199,6 @@ class PageSerializer(serializers.ModelSerializer):
         )
 
 
-# TODO: Make better
-class AuthorSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = AuthorTag
-        fields = ("author",)
-
-
 class ArticlePage(
     TopicalPageMixin,
     RequiredHeroImageMixin,
@@ -435,9 +428,9 @@ class FocusedArticlePage(
         + [
             APIField("type_label"),
             APIField("body"),
-            APIField("authors", serializer=AuthorSerializer(many=True)),
         ]
         + TopicalPageMixin.api_fields
+        + AuthorPageMixin.api_fields
     )
 
     def save(self, *args, **kwargs):

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -27,7 +27,7 @@ from wagtail.snippets.models import register_snippet
 from rest_framework import serializers
 from taggit.models import ItemBase, TagBase
 
-from etna.authors.models import AuthorPageMixin, AuthorTag
+from etna.authors.models import AuthorPageMixin
 from etna.collections.models import TopicalPageMixin
 from etna.core.models import (
     BasePageWithIntro,

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -166,7 +166,7 @@ class AuthorSerializer(LinkedPageSerializer):
             "title",
             "teaser_image_jpeg",
             "teaser_image_webp",
-            "url_path",
+            "url",
             "full_url",
             "role",
         )

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -160,7 +160,13 @@ class AuthorSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = AuthorTag
-        fields = ("id", "title", "image", "url_path", "role",)
+        fields = (
+            "id",
+            "title",
+            "image",
+            "url_path",
+            "role",
+        )
 
 
 class AuthorPageMixin:
@@ -194,5 +200,5 @@ class AuthorPageMixin:
         """
         if self.authors:
             return ", ".join([author.title for author in self.authors])
-        
+
     api_fields = [APIField("authors", serializer=AuthorSerializer(many=True))]

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -154,11 +154,15 @@ class AuthorTag(models.Model):
 
 class AuthorSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
-    teaser_image_jpeg = ImageRenditionField("fill-400x400|format-jpeg|jpegquality-60", source="image")
-    teaser_image_webp = ImageRenditionField("fill-400x400|format-webp|webpquality-80", source="image")
+    teaser_image_jpeg = ImageRenditionField(
+        "fill-400x400|format-jpeg|jpegquality-60", source="image"
+    )
+    teaser_image_webp = ImageRenditionField(
+        "fill-400x400|format-webp|webpquality-80", source="image"
+    )
     url_path = serializers.SerializerMethodField()
     role = serializers.CharField()
-    
+
     def get_url_path(self, obj):
         return obj.get_url()
 

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -154,7 +154,8 @@ class AuthorTag(models.Model):
 
 class AuthorSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
-    image = ImageRenditionField("fill-256x256|format-jpeg|jpegquality-60")
+    teaser_image_jpeg = ImageRenditionField("fill-400x400|format-jpeg|jpegquality-60", source="image")
+    teaser_image_webp = ImageRenditionField("fill-400x400|format-webp|webpquality-80", source="image")
     url_path = serializers.CharField()
     role = serializers.CharField()
 
@@ -163,7 +164,8 @@ class AuthorSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "title",
-            "image",
+            "teaser_image_jpeg",
+            "teaser_image_webp",
             "url_path",
             "role",
         )

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -161,6 +161,7 @@ class AuthorSerializer(serializers.ModelSerializer):
         "fill-400x400|format-webp|webpquality-80", source="image"
     )
     url_path = serializers.SerializerMethodField()
+    full_url = serializers.URLField()
     role = serializers.CharField()
 
     def get_url_path(self, obj):
@@ -174,6 +175,7 @@ class AuthorSerializer(serializers.ModelSerializer):
             "teaser_image_jpeg",
             "teaser_image_webp",
             "url_path",
+            "full_url",
             "role",
         )
 

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -14,6 +14,7 @@ from wagtail.images.api.fields import ImageRenditionField
 from wagtail.models import Page
 
 from rest_framework import serializers
+from etna.core.serializers import LinkedPageSerializer
 
 from etna.core.models import BasePage
 
@@ -152,20 +153,11 @@ class AuthorTag(models.Model):
     )
 
 
-class AuthorSerializer(serializers.ModelSerializer):
-    title = serializers.CharField()
-    teaser_image_jpeg = ImageRenditionField(
-        "fill-400x400|format-jpeg|jpegquality-60", source="image"
+class AuthorSerializer(LinkedPageSerializer):
+    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(
+        rendition_size="fill-400x400", jpeg_quality=60, webp_quality=80, source="image"
     )
-    teaser_image_webp = ImageRenditionField(
-        "fill-400x400|format-webp|webpquality-80", source="image"
-    )
-    url_path = serializers.SerializerMethodField()
-    full_url = serializers.URLField()
     role = serializers.CharField()
-
-    def get_url_path(self, obj):
-        return obj.get_url()
 
     class Meta:
         model = AuthorTag

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -154,7 +154,7 @@ class AuthorTag(models.Model):
 
 class AuthorSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
-    image = ImageRenditionField("fill-512x512|format-jpeg|jpegquality-60")
+    image = ImageRenditionField("fill-256x256|format-jpeg|jpegquality-60")
     url_path = serializers.CharField()
     role = serializers.CharField()
 

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -156,8 +156,11 @@ class AuthorSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     teaser_image_jpeg = ImageRenditionField("fill-400x400|format-jpeg|jpegquality-60", source="image")
     teaser_image_webp = ImageRenditionField("fill-400x400|format-webp|webpquality-80", source="image")
-    url_path = serializers.CharField()
+    url_path = serializers.SerializerMethodField()
     role = serializers.CharField()
+    
+    def get_url_path(self, obj):
+        return obj.get_url()
 
     class Meta:
         model = AuthorTag

--- a/etna/authors/models.py
+++ b/etna/authors/models.py
@@ -14,9 +14,9 @@ from wagtail.images.api.fields import ImageRenditionField
 from wagtail.models import Page
 
 from rest_framework import serializers
-from etna.core.serializers import LinkedPageSerializer
 
 from etna.core.models import BasePage
+from etna.core.serializers import LinkedPageSerializer
 
 
 class AuthorIndexPage(BasePage):

--- a/etna/authors/tests/test_models.py
+++ b/etna/authors/tests/test_models.py
@@ -59,7 +59,7 @@ class TestAuthorPages(TestCase):
     def test_focused_article_author(self):
         for i in self.focused_articles:
             self.assertEqual(
-                self.focused_articles[i].author_tags.first().title, "John Doe"
+                self.focused_articles[i].author_tags.first().author.title, "John Doe"
             )
 
     def test_authored_focused_articles(self):

--- a/etna/authors/tests/test_models.py
+++ b/etna/authors/tests/test_models.py
@@ -59,7 +59,7 @@ class TestAuthorPages(TestCase):
     def test_focused_article_author(self):
         for i in self.focused_articles:
             self.assertEqual(
-                self.focused_articles[i].author_tags.first().author.title, "John Doe"
+                self.focused_articles[i].author_tags.first().title, "John Doe"
             )
 
     def test_authored_focused_articles(self):

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -15,6 +15,7 @@ from wagtail.admin.panels import (
     PageChooserPanel,
 )
 from wagtail.api import APIField
+from wagtail.images.api.fields import ImageRenditionField
 from wagtail.fields import StreamField
 from wagtail.images import get_image_model_string
 from wagtail.models import Orderable, Page
@@ -651,19 +652,11 @@ class TimePeriodSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     start_year = serializers.IntegerField()
     end_year = serializers.IntegerField()
-    teaser_image = serializers.SerializerMethodField()
+    teaser_image = ImageRenditionField("fill-200x200")
 
     class Meta:
         model = PageTimePeriod
         fields = ("id", "title", "start_year", "end_year", "teaser_image",)
-
-    def get_teaser_image(self, obj):
-        if obj.teaser_image:
-            return {
-                "id": obj.teaser_image.id,
-                "url": obj.teaser_image.get_rendition("fill-200x200").url,
-            }
-        return None
 
 
 class TopicalPageMixin:

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -22,6 +22,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from rest_framework import serializers
+
 from etna.core.serializers import LinkedPageSerializer
 
 from ..alerts.models import AlertMixin
@@ -648,15 +649,26 @@ class BaseModelSerializer(serializers.ModelSerializer):
 
 
 class TopicSerializer(LinkedPageSerializer):
-    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(rendition_size="fill-900x400", jpeg_quality=60, webp_quality=80)
+    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(
+        rendition_size="fill-900x400", jpeg_quality=60, webp_quality=80
+    )
 
     class Meta:
         model = PageTopic
-        fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url", "full_url")
+        fields = (
+            "id",
+            "title",
+            "teaser_image_jpeg",
+            "teaser_image_webp",
+            "url",
+            "full_url",
+        )
 
 
 class TimePeriodSerializer(LinkedPageSerializer):
-    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(rendition_size="fill-900x400", jpeg_quality=60, webp_quality=80)
+    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(
+        rendition_size="fill-900x400", jpeg_quality=60, webp_quality=80
+    )
     start_year = serializers.IntegerField()
     end_year = serializers.IntegerField()
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -652,7 +652,7 @@ class TimePeriodSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     start_year = serializers.IntegerField()
     end_year = serializers.IntegerField()
-    teaser_image = ImageRenditionField("fill-200x200")
+    teaser_image = ImageRenditionField("fill-200x200") # TODO: Needs a proper rendition size
 
     class Meta:
         model = PageTimePeriod

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -635,10 +635,12 @@ class BaseModelSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     teaser_image = ImageRenditionField("fill-200x200") # TODO: Needs a proper rendition size
 
+
 class TopicSerializer(BaseModelSerializer):
     class Meta:
         model = PageTopic
         fields = ("id", "title", "teaser_image",)
+
 
 class TimePeriodSerializer(BaseModelSerializer):
     start_year = serializers.IntegerField()
@@ -646,7 +648,7 @@ class TimePeriodSerializer(BaseModelSerializer):
 
     class Meta:
         model = PageTimePeriod
-        fields = ("id", "title", "start_year", "end_year", "teaser_image",)
+        fields = ("id", "title", "teaser_image", "start_year", "end_year",)
 
 
 class TopicalPageMixin:

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -15,9 +15,9 @@ from wagtail.admin.panels import (
     PageChooserPanel,
 )
 from wagtail.api import APIField
-from wagtail.images.api.fields import ImageRenditionField
 from wagtail.fields import StreamField
 from wagtail.images import get_image_model_string
+from wagtail.images.api.fields import ImageRenditionField
 from wagtail.models import Orderable, Page
 from wagtail.search import index
 
@@ -633,7 +633,9 @@ class PageTimePeriod(Orderable):
 
 class BaseModelSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
-    teaser_image = ImageRenditionField("fill-200x200") # TODO: Needs a proper rendition size
+    teaser_image = ImageRenditionField(
+        "fill-200x200"
+    )  # TODO: Needs a proper rendition size
     url_path = serializers.CharField()
 
 
@@ -649,7 +651,14 @@ class TimePeriodSerializer(BaseModelSerializer):
 
     class Meta:
         model = PageTimePeriod
-        fields = ("id", "title", "teaser_image", "url_path", "start_year", "end_year",)
+        fields = (
+            "id",
+            "title",
+            "teaser_image",
+            "url_path",
+            "start_year",
+            "end_year",
+        )
 
 
 class TopicalPageMixin:

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -634,12 +634,13 @@ class PageTimePeriod(Orderable):
 class BaseModelSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     teaser_image = ImageRenditionField("fill-200x200") # TODO: Needs a proper rendition size
+    url_path = serializers.CharField()
 
 
 class TopicSerializer(BaseModelSerializer):
     class Meta:
         model = PageTopic
-        fields = ("id", "title", "teaser_image",)
+        fields = ("id", "title", "teaser_image", "url_path")
 
 
 class TimePeriodSerializer(BaseModelSerializer):
@@ -648,7 +649,7 @@ class TimePeriodSerializer(BaseModelSerializer):
 
     class Meta:
         model = PageTimePeriod
-        fields = ("id", "title", "teaser_image", "start_year", "end_year",)
+        fields = ("id", "title", "teaser_image", "url_path", "start_year", "end_year",)
 
 
 class TopicalPageMixin:

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -634,7 +634,7 @@ class PageTimePeriod(Orderable):
 class BaseModelSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     teaser_image = ImageRenditionField(
-        "fill-200x200"
+        "fill-600x400|format-jpeg|jpegquality-60"
     )  # TODO: Needs a proper rendition size
     url_path = serializers.CharField()
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -631,28 +631,18 @@ class PageTimePeriod(Orderable):
     )
 
 
-class TopicSerializer(serializers.ModelSerializer):
+class BaseModelSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
-    teaser_image = serializers.SerializerMethodField()
-    
+    teaser_image = ImageRenditionField("fill-200x200") # TODO: Needs a proper rendition size
+
+class TopicSerializer(BaseModelSerializer):
     class Meta:
         model = PageTopic
         fields = ("id", "title", "teaser_image",)
 
-    def get_teaser_image(self, obj):
-        if obj.teaser_image:
-            return {
-                "id": obj.teaser_image.id,
-                "url": obj.teaser_image.get_rendition("fill-200x200").url,
-            }
-        return None
-
-
-class TimePeriodSerializer(serializers.ModelSerializer):
-    title = serializers.CharField()
+class TimePeriodSerializer(BaseModelSerializer):
     start_year = serializers.IntegerField()
     end_year = serializers.IntegerField()
-    teaser_image = ImageRenditionField("fill-200x200") # TODO: Needs a proper rendition size
 
     class Meta:
         model = PageTimePeriod

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -652,7 +652,7 @@ class TopicSerializer(LinkedPageSerializer):
 
     class Meta:
         model = PageTopic
-        fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url_path", "full_url")
+        fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url", "full_url")
 
 
 class TimePeriodSerializer(LinkedPageSerializer):
@@ -667,7 +667,7 @@ class TimePeriodSerializer(LinkedPageSerializer):
             "title",
             "teaser_image_jpeg",
             "teaser_image_webp",
-            "url_path",
+            "url",
             "full_url",
             "start_year",
             "end_year",

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -22,6 +22,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 
 from rest_framework import serializers
+from etna.core.serializers import LinkedPageSerializer
 
 from ..alerts.models import AlertMixin
 from ..core.models import (
@@ -646,13 +647,16 @@ class BaseModelSerializer(serializers.ModelSerializer):
         return obj.get_url()
 
 
-class TopicSerializer(BaseModelSerializer):
+class TopicSerializer(LinkedPageSerializer):
+    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(rendition_size="fill-900x400", jpeg_quality=60, webp_quality=80)
+
     class Meta:
         model = PageTopic
         fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url_path", "full_url")
 
 
-class TimePeriodSerializer(BaseModelSerializer):
+class TimePeriodSerializer(LinkedPageSerializer):
+    teaser_image_jpeg, teaser_image_webp = LinkedPageSerializer.teaser_images(rendition_size="fill-900x400", jpeg_quality=60, webp_quality=80)
     start_year = serializers.IntegerField()
     end_year = serializers.IntegerField()
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -633,16 +633,17 @@ class PageTimePeriod(Orderable):
 
 class BaseModelSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
-    teaser_image = ImageRenditionField(
-        "fill-600x400|format-jpeg|jpegquality-60"
-    )  # TODO: Needs a proper rendition size
+    teaser_image_jpeg = ImageRenditionField(
+        "fill-600x400|format-jpeg|jpegquality-60", source="teaser_image"
+    )
+    teaser_image_webp = ImageRenditionField("fill-600x400|format-webp|webpquality-80", source="teaser_image")
     url_path = serializers.CharField()
 
 
 class TopicSerializer(BaseModelSerializer):
     class Meta:
         model = PageTopic
-        fields = ("id", "title", "teaser_image", "url_path")
+        fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url_path")
 
 
 class TimePeriodSerializer(BaseModelSerializer):
@@ -654,7 +655,8 @@ class TimePeriodSerializer(BaseModelSerializer):
         fields = (
             "id",
             "title",
-            "teaser_image",
+            "teaser_image_jpeg",
+            "teaser_image_webp",
             "url_path",
             "start_year",
             "end_year",

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -636,7 +636,9 @@ class BaseModelSerializer(serializers.ModelSerializer):
     teaser_image_jpeg = ImageRenditionField(
         "fill-600x400|format-jpeg|jpegquality-60", source="teaser_image"
     )
-    teaser_image_webp = ImageRenditionField("fill-600x400|format-webp|webpquality-80", source="teaser_image")
+    teaser_image_webp = ImageRenditionField(
+        "fill-600x400|format-webp|webpquality-80", source="teaser_image"
+    )
     url_path = serializers.SerializerMethodField()
 
     def get_url_path(self, obj):

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -640,6 +640,7 @@ class BaseModelSerializer(serializers.ModelSerializer):
         "fill-600x400|format-webp|webpquality-80", source="teaser_image"
     )
     url_path = serializers.SerializerMethodField()
+    full_url = serializers.URLField()
 
     def get_url_path(self, obj):
         return obj.get_url()
@@ -648,7 +649,7 @@ class BaseModelSerializer(serializers.ModelSerializer):
 class TopicSerializer(BaseModelSerializer):
     class Meta:
         model = PageTopic
-        fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url_path")
+        fields = ("id", "title", "teaser_image_jpeg", "teaser_image_webp", "url_path", "full_url")
 
 
 class TimePeriodSerializer(BaseModelSerializer):
@@ -663,6 +664,7 @@ class TimePeriodSerializer(BaseModelSerializer):
             "teaser_image_jpeg",
             "teaser_image_webp",
             "url_path",
+            "full_url",
             "start_year",
             "end_year",
         )

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -630,6 +630,42 @@ class PageTimePeriod(Orderable):
     )
 
 
+class TopicSerializer(serializers.ModelSerializer):
+    title = serializers.CharField()
+    teaser_image = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = PageTopic
+        fields = ("id", "title", "teaser_image",)
+
+    def get_teaser_image(self, obj):
+        if obj.teaser_image:
+            return {
+                "id": obj.teaser_image.id,
+                "url": obj.teaser_image.get_rendition("fill-200x200").url,
+            }
+        return None
+
+
+class TimePeriodSerializer(serializers.ModelSerializer):
+    title = serializers.CharField()
+    start_year = serializers.IntegerField()
+    end_year = serializers.IntegerField()
+    teaser_image = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PageTimePeriod
+        fields = ("id", "title", "start_year", "end_year", "teaser_image",)
+
+    def get_teaser_image(self, obj):
+        if obj.teaser_image:
+            return {
+                "id": obj.teaser_image.id,
+                "url": obj.teaser_image.get_rendition("fill-200x200").url,
+            }
+        return None
+
+
 class TopicalPageMixin:
     """
     A mixin for pages that use the ``PageTopic`` and ``PageTimePeriod`` models
@@ -637,6 +673,11 @@ class TopicalPageMixin:
     adds a few properies to support robust, efficient access the related topic
     and time period pages.
     """
+
+    api_fields = [
+        APIField("topics", serializer=TopicSerializer(many=True)),
+        APIField("time_periods", serializer=TimePeriodSerializer(many=True)),
+    ]
 
     @classmethod
     def get_time_periods_inlinepanel(cls, max_num: Optional[int] = 4) -> InlinePanel:
@@ -764,6 +805,7 @@ class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIn
             # APIField("highlights", serializer=HighlightSerializer(many=True)),
             APIField("page_highlights", serializer=HighlightSerializer(many=True)),
         ]
+        + TopicalPageMixin.api_fields
     )
 
     class Meta:

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -637,7 +637,10 @@ class BaseModelSerializer(serializers.ModelSerializer):
         "fill-600x400|format-jpeg|jpegquality-60", source="teaser_image"
     )
     teaser_image_webp = ImageRenditionField("fill-600x400|format-webp|webpquality-80", source="teaser_image")
-    url_path = serializers.CharField()
+    url_path = serializers.SerializerMethodField()
+
+    def get_url_path(self, obj):
+        return obj.get_url()
 
 
 class TopicSerializer(BaseModelSerializer):

--- a/etna/core/serializers.py
+++ b/etna/core/serializers.py
@@ -9,7 +9,7 @@ class LinkedPageSerializer(serializers.ModelSerializer):
 
     Fields returned must be set in the `Meta.fields` attribute of the subclass.
     """
-    
+
     def teaser_images(rendition_size: str, jpeg_quality: str, webp_quality: int, source: str = "teaser_image", quality: int = 80):
         """
         This method returns a tuple of two ImageRenditionField instances for the
@@ -34,11 +34,11 @@ class LinkedPageSerializer(serializers.ModelSerializer):
         )
     
     title = serializers.CharField()
-    url_path = serializers.SerializerMethodField()
+    url = serializers.SerializerMethodField()
     full_url = serializers.URLField()
     teaser_image_jpeg, teaser_image_webp = teaser_images(rendition_size="fill-600x400", jpeg_quality=60, webp_quality=80)
 
-    def get_url_path(self, obj):
+    def get_url(self, obj):
         return obj.get_url()
     
     

--- a/etna/core/serializers.py
+++ b/etna/core/serializers.py
@@ -1,0 +1,26 @@
+from rest_framework import serializers
+from wagtail.images.api.fields import ImageRenditionField
+
+class LinkedPageSerializer(serializers.ModelSerializer):
+    """
+    This Serializer should be inherited as a base class for all "linked" or "secondary"
+    page serializers. It provides a common set of fields that are useful for
+    serializing linked pages - otherwise it only provides a page ID.
+
+    Fields returned must be set in the `Meta.fields` attribute of the subclass.
+    """
+    def teaser_images(rendition_size, jpeg_quality, webp_quality, source="teaser_image", quality=80):
+        return (
+            ImageRenditionField(f"{rendition_size}|format-jpeg|jpegquality-{jpeg_quality or quality}", source=source),
+            ImageRenditionField(f"{rendition_size}|format-webp|webpquality-{webp_quality or quality}", source=source),
+        )
+    
+    title = serializers.CharField()
+    url_path = serializers.SerializerMethodField()
+    full_url = serializers.URLField()
+    teaser_image_jpeg, teaser_image_webp = teaser_images(rendition_size="fill-600x400", jpeg_quality=60, webp_quality=80)
+
+    def get_url_path(self, obj):
+        return obj.get_url()
+    
+    

--- a/etna/core/serializers.py
+++ b/etna/core/serializers.py
@@ -10,6 +10,16 @@ class LinkedPageSerializer(serializers.ModelSerializer):
     Fields returned must be set in the `Meta.fields` attribute of the subclass.
     """
     def teaser_images(rendition_size, jpeg_quality, webp_quality, source="teaser_image", quality=80):
+        """
+        This method returns a tuple of two ImageRenditionField instances for the
+        given rendition size, JPEG quality and WebP quality. The source parameter
+        is used to specify the source image field to use for the rendition.
+        
+        To override the default rendition size, quality, or source, you should
+        override this in the subclass, following the same structure as teaser_image_jpeg
+        and teaser_image_webp below. This will allow for flexibility around the
+        types of images that we can supply on a case-by-case basis.
+        """
         return (
             ImageRenditionField(f"{rendition_size}|format-jpeg|jpegquality-{jpeg_quality or quality}", source=source),
             ImageRenditionField(f"{rendition_size}|format-webp|webpquality-{webp_quality or quality}", source=source),

--- a/etna/core/serializers.py
+++ b/etna/core/serializers.py
@@ -1,5 +1,7 @@
-from rest_framework import serializers
 from wagtail.images.api.fields import ImageRenditionField
+
+from rest_framework import serializers
+
 
 class LinkedPageSerializer(serializers.ModelSerializer):
     """
@@ -10,12 +12,18 @@ class LinkedPageSerializer(serializers.ModelSerializer):
     Fields returned must be set in the `Meta.fields` attribute of the subclass.
     """
 
-    def teaser_images(rendition_size: str, jpeg_quality: str, webp_quality: int, source: str = "teaser_image", quality: int = 80):
+    def teaser_images(
+        rendition_size: str,
+        jpeg_quality: str,
+        webp_quality: int,
+        source: str = "teaser_image",
+        quality: int = 80,
+    ):
         """
         This method returns a tuple of two ImageRenditionField instances for the
         given rendition size, JPEG quality and WebP quality. The source parameter
         is used to specify the source image field to use for the rendition.
-        
+
         To override the default rendition size, quality, or source, you should
         override this in the subclass, following the same structure as teaser_image_jpeg
         and teaser_image_webp below. This will allow for flexibility around the
@@ -29,16 +37,22 @@ class LinkedPageSerializer(serializers.ModelSerializer):
         quality: The quality to use for the rendition - only used if no jpeg or webp_quality is set.
         """
         return (
-            ImageRenditionField(f"{rendition_size}|format-jpeg|jpegquality-{jpeg_quality or quality}", source=source),
-            ImageRenditionField(f"{rendition_size}|format-webp|webpquality-{webp_quality or quality}", source=source),
+            ImageRenditionField(
+                f"{rendition_size}|format-jpeg|jpegquality-{jpeg_quality or quality}",
+                source=source,
+            ),
+            ImageRenditionField(
+                f"{rendition_size}|format-webp|webpquality-{webp_quality or quality}",
+                source=source,
+            ),
         )
-    
+
     title = serializers.CharField()
     url = serializers.SerializerMethodField()
     full_url = serializers.URLField()
-    teaser_image_jpeg, teaser_image_webp = teaser_images(rendition_size="fill-600x400", jpeg_quality=60, webp_quality=80)
+    teaser_image_jpeg, teaser_image_webp = teaser_images(
+        rendition_size="fill-600x400", jpeg_quality=60, webp_quality=80
+    )
 
     def get_url(self, obj):
         return obj.get_url()
-    
-    

--- a/etna/core/serializers.py
+++ b/etna/core/serializers.py
@@ -9,7 +9,8 @@ class LinkedPageSerializer(serializers.ModelSerializer):
 
     Fields returned must be set in the `Meta.fields` attribute of the subclass.
     """
-    def teaser_images(rendition_size, jpeg_quality, webp_quality, source="teaser_image", quality=80):
+    
+    def teaser_images(rendition_size: str, jpeg_quality: str, webp_quality: int, source: str = "teaser_image", quality: int = 80):
         """
         This method returns a tuple of two ImageRenditionField instances for the
         given rendition size, JPEG quality and WebP quality. The source parameter
@@ -19,6 +20,13 @@ class LinkedPageSerializer(serializers.ModelSerializer):
         override this in the subclass, following the same structure as teaser_image_jpeg
         and teaser_image_webp below. This will allow for flexibility around the
         types of images that we can supply on a case-by-case basis.
+
+        Args:
+        rendition_size: The size of the rendition to return.
+        jpeg_quality: The quality of the JPEG rendition.
+        webp_quality: The quality of the WebP rendition.
+        source: The source image field to use for the rendition - defaults to "teaser_image" if un-set.
+        quality: The quality to use for the rendition - only used if no jpeg or webp_quality is set.
         """
         return (
             ImageRenditionField(f"{rendition_size}|format-jpeg|jpegquality-{jpeg_quality or quality}", source=source),

--- a/templates/articles/focused_article_page.html
+++ b/templates/articles/focused_article_page.html
@@ -20,7 +20,7 @@
                             <ul class="tna-ul tna-ul--plain">
                                 <li>By 
                                     {% for author in page.authors %}
-                                        <a href="{% pageurl author.author %}" rel="author" data-component-name="Page header" data-link-type="Link" data-link="{{ author.author.title }}">{{ author.author.title }}</a>{% if not forloop.last %}{% if forloop.counter == page.authors|length|add:"-1" %} and {% else %}, {% endif %}{% endif %}
+                                        <a href="{% pageurl author %}" rel="author" data-component-name="Page header" data-link-type="Link" data-link="{{ author.title }}">{{ author.title }}</a>{% if not forloop.last %}{% if forloop.counter == page.authors|length|add:"-1" %} and {% else %}, {% endif %}{% endif %}
                                     {% endfor %}
                                 </li>                    
                             </ul>
@@ -57,17 +57,17 @@
                         <div class="tna-author tna-author--summary">
                             <h2 class="tna-chip tna-chip--plain">About the author{% if page.authors|length > 1 %}s{% endif %}</h2>
                                 {% for author in page.authors %}
-                                    {% image author.author.image fill-500x500 as author_img %}
+                                    {% image author.image fill-500x500 as author_img %}
                                     <div class="tna-author__image tna-author__image--small">
                                         <img src="{{ author_img.url }}" alt="{{ author_img.alt }}" width="500" height="500">
                                     </div>
                                     <p>
                                         <strong>
-                                            <a href="{% pageurl author.author %}" rel="author" data-component-name="About the author" data-link-type="Link" data-link="{{ author.author.title }}">{{ author.author.title }}</a>
+                                            <a href="{% pageurl author %}" rel="author" data-component-name="About the author" data-link-type="Link" data-link="{{ author.title }}">{{ author.title }}</a>
                                         </strong>
                                     </p>
-                                    {% if author.author.role %}
-                                        <p>{{ author.author.role }}</p>
+                                    {% if author.role %}
+                                        <p>{{ author.role }}</p>
                                     {% endif %}
                                 {% endfor %}
                             </div>


### PR DESCRIPTION
Ticket URL: [EDEV-32]

## About these changes

This PR is a bit of a combined one - but they're both in the same vein so made sense to do them together. They both follow the same structure so thought it best to do it all in one.

This covers:
[EDEV-37] and [EDEV-55]

EDEV-37 covers the `topics` and `time_periods` fields - which are used on multiple other page types, not just article pages.
EDEV-55 covers the `authors` fields - which are only used on `FocusedArticlePages` but as I mentioned, follow the same structure as the `topics` and `time_periods`. This serializes the data so that we get a bit more useful info rather than just a page ID.

I also had to slightly restructure how we manage `authors` because I didn't do it too well the first time round. These function the exact same as `topic` and `time_periods` now.

The current/old response doesn't return anything for `topics/time_periods` because we've commented these out.

Old response:
![image](https://github.com/nationalarchives/ds-wagtail/assets/62654785/30948889-49f3-46c2-b2b0-0d96b0b55021)


New response:
![image](https://github.com/nationalarchives/ds-wagtail/assets/62654785/bdadec56-4246-49d9-ba08-cb86b88c5dd8)


## How to check these changes

http://localhost:8000/api/v2/pages/261/ is a `FocusedArticlePage`. These can have `topics`, `time_periods`, and `authors`.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[EDEV-32]: https://national-archives.atlassian.net/browse/EDEV-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDEV-37]: https://national-archives.atlassian.net/browse/EDEV-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDEV-55]: https://national-archives.atlassian.net/browse/EDEV-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ