### PR TITLE
DOR-35: Fix navigation styles

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -165,16 +165,29 @@ Modified to match the existing site (for now)
 }
 
 .tna-header__navigation-item-link {
+    color: $color--white;
+
+    &:visited {
+        color: $color--white;
+    }
+
     &:hover,
     &--selected,
     &--selected:visited {
         background: #fff !important;
+        color: $color--off-black;
+
+        &::after {
+            display: none;
+        }
     }
 }
 
 @include media.on-mobile {
     .tna-header__navigation-items {
         background: #fff !important;
+        color: $color--off-black;
+        border: 0;
     }
 }
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DOR-35

## About these changes

This PR addresses the general styling issues of the navigation. This was raised as part of the record detail page review but it's a global issue not specific to that page template, so I'm addressing it here to review separately.

In the ticket we discussed removing or hiding the nav bar, but I've adjusted the styling instead to avoid completely removing the nav on the detail page. Saves any potential problems down the line or inconsistencies between templates which show/don't show the nav.

Note that this is a temporary fix for now while we don't have the new header built, to reduce accessibility issues with the current styles which are a bit broken.

## How to check these changes

Check any page on the site and click through the tabs to make sure all styles are working as expected.

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
