### PR TITLE
DOR-56: 'No results' search results page (FE)

### DIFF
--- a/sass/etna.scss
+++ b/sass/etna.scss
@@ -113,6 +113,7 @@ These are Etna specific components, created using BEM and following our guidelin
 @import "includes/search/search-landing-buckets";
 @import "includes/search/featured-search";
 @import "includes/search/long-filters";
+@import "includes/search/no-results";
 @import "includes/section";
 @import "includes/sub-heading";
 @import "includes/cookie-consent";

--- a/sass/includes/search/_featured-search.scss
+++ b/sass/includes/search/_featured-search.scss
@@ -127,18 +127,18 @@
     }
 }
 
-.no-results {
-    .featured-search__heading {
-        padding: 1rem;
+// .no-results {
+//     .featured-search__heading {
+//         padding: 1rem;
 
-        @media only screen and (min-width: #{$screen__md + 1px}) {
-            padding: 1rem 2rem;
-        }
-    }
+//         @media only screen and (min-width: #{$screen__md + 1px}) {
+//             padding: 1rem 2rem;
+//         }
+//     }
 
-    ul {
-        @media only screen and (min-width: #{$screen__md + 1px}) {
-            margin-left: 1rem;
-        }
-    }
-}
+//     ul {
+//         @media only screen and (min-width: #{$screen__md + 1px}) {
+//             margin-left: 1rem;
+//         }
+//     }
+// }

--- a/sass/includes/search/_no-results.scss
+++ b/sass/includes/search/_no-results.scss
@@ -1,0 +1,7 @@
+.no-results {
+    margin: 1rem;
+
+    @include media.on-larger-than-mobile {
+        margin: 2rem;
+    }
+}

--- a/templates/search/blocks/no_results.html
+++ b/templates/search/blocks/no_results.html
@@ -7,16 +7,14 @@
 </style>
 
 <div class="no-results">
-    <h2 class="tna-heading-l featured-search__heading">We did not find any results for your search</h2>
+    <h2 class="tna-heading-l">We did not find any results for your search</h2>
     <p>Some record descriptions are much less detailed than others, so you may not find what you are looking for using a simple keyword search.</p> 
 
-    <p>
-        <ul>
-            <li>Try different spellings or search terms</li>
-            <li>Use the advanced search options such as the "AND", "OR" and "NOT" operators</li>
-            <li>Look at our <a href ="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides-keywords/" target="_blank">research guides</a> for search tips</li>
-        </ul>
-    </p>
+    <ul>
+        <li>Try different spellings or search terms</li>
+        <li>Use the advanced search options such as the "AND", "OR" and "NOT" operators</li>
+        <li>Look at our <a href ="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides-keywords/" target="_blank">research guides</a> for search tips</li>
+    </ul>
 </div>
     
 <!--end no results message for All results-->

--- a/templates/search/blocks/no_results.html
+++ b/templates/search/blocks/no_results.html
@@ -8,13 +8,15 @@
 
 <div class="no-results">
     <h2 class="tna-heading-l featured-search__heading">We did not find any results for your search</h2>
-    <p class="search-results__explainer">Some record descriptions are much less detailed than others, so you may not find what you are looking for using a simple keyword search.</p> 
+    <p>Some record descriptions are much less detailed than others, so you may not find what you are looking for using a simple keyword search.</p> 
 
-    <ul>
-        <li>Try different spellings or search terms</li>
-        <li>Use the advanced search options such as the "AND", "OR" and "NOT" operators</li>
-        <li>Look at our <a href ="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides-keywords/" target="_blank">research guides</a> for search tips</li>
-    </ul>
+    <p>
+        <ul>
+            <li>Try different spellings or search terms</li>
+            <li>Use the advanced search options such as the "AND", "OR" and "NOT" operators</li>
+            <li>Look at our <a href ="https://www.nationalarchives.gov.uk/help-with-your-research/research-guides-keywords/" target="_blank">research guides</a> for search tips</li>
+        </ul>
+    </p>
 </div>
     
 <!--end no results message for All results-->

--- a/templates/search/blocks/search_results_hero.html
+++ b/templates/search/blocks/search_results_hero.html
@@ -16,15 +16,15 @@
             </form>
 
             {% with request.resolver_match.url_name as url_name  %}
-                <nav class="search-results-hero__nav" aria-label="Search result types">
+                {% comment %} <nav class="search-results-hero__nav" aria-label="Search result types">
                     <ul class="search-results-hero__nav-list">
-                        {% comment %} <li class="search-results-hero__nav-list-item">
+                        <li class="search-results-hero__nav-list-item">
                             {% if url_name == 'search-featured' %}
                                 <span aria-current="true" class="search-results-hero__nav-link">{{searchtabs.ALL.value}}</span>
                             {% else %}
                             <a class="search-results-hero__nav-link" href="{% url 'search-featured' %}{% if form.q.value %}?q={{ form.q.value }}{% endif %}">{{searchtabs.ALL.value}}</a>
                             {% endif %}
-                        </li> {% endcomment %}
+                        </li>
                         <li class="search-results-hero__nav-list-item">
                             {% if url_name == 'search-catalogue' %}
                                 <span aria-current="true" class="search-results-hero__nav-link">{{searchtabs.CATALOGUE.value}}</span>
@@ -32,7 +32,7 @@
                             <a class="search-results-hero__nav-link" href="{% url 'search-catalogue' %}{% if form.q.value %}?q={{ form.q.value }}{% endif %}">{{searchtabs.CATALOGUE.value}}</a>
                             {% endif %}
                         </li>
-                        {% comment %} <li class="search-results-hero__nav-list-item">
+                        <li class="search-results-hero__nav-list-item">
                             {% if url_name == 'search-website' %}
                                 <span aria-current="true" class="search-results-hero__nav-link">{{searchtabs.WEBSITE.value}}</span>
                             {% else %}
@@ -43,9 +43,9 @@
                             <div>
                                 <a href="/search/featured/" data-link-type="Link" data-link="Start a new search">Start new search</a>
                             </div>
-                        </li> {% endcomment %}
+                        </li>
                     </ul>
-                </nav>
+                </nav> {% endcomment %}
             {% endwith %}
         </div>
     </div>

--- a/templates/search/catalogue_search.html
+++ b/templates/search/catalogue_search.html
@@ -77,7 +77,11 @@
         {% else %}
             {# No results were found when searching with the 'q' param value for all buckets ... #}
             {# ... or for only current bucket while some other buckets have results #}
-            {% include './blocks/no_results.html' %}
+            <div class="tna-container">
+                <div class="tna-column tna-column--full">
+                    {% include './blocks/no_results.html' %}
+                </div>
+            </div>
         {% endif %}
 
         {% if page.paginator.count %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/jira/software/c/projects/DOR/boards/128?selectedIssue=DOR-56

## About these changes

This PR addresses the styling issues for the 'no search results found' page.

## How to check these changes

Load up the [search page locally ](http://localhost:8000/search/catalogue/) and search for something that doesn't exist : )

Before:

<img width="1354" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/65badb88-5a75-41e9-a48a-a9a723853bbe">


After:

<img width="1311" alt="image" src="https://github.com/nationalarchives/ds-wagtail/assets/8680557/1528139d-8dec-4c42-96fd-8b587c7bc24b">


## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
