### PR TITLE
[DOR-55] Limit search results to digitised records only

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -104,10 +104,14 @@ public_urls = [
         ),
         name="search-featured",
     ),
+    # This was originally using CatalogueSearchView instead of EscapeAndEvasionCatalogueSearchView.
+    # This is a temporary measure for the experimental Escape and Evasion search.
+    # https://national-archives.atlassian.net/browse/DOR-55
     path(
         r"search/catalogue/",
         setting_controlled_login_required(
-            search_views.CatalogueSearchView.as_view(), "SEARCH_VIEWS_REQUIRE_LOGIN"
+            search_views.EscapeAndEvasionCatalogueSearchView.as_view(),
+            "SEARCH_VIEWS_REQUIRE_LOGIN",
         ),
         name="search-catalogue",
     ),

--- a/etna/ciim/constants.py
+++ b/etna/ciim/constants.py
@@ -116,6 +116,16 @@ class BucketList:
         yield from self.buckets
 
 
+_DIGITISED_BUCKET = Bucket(
+    key="digitised",
+    label="Online records at The National Archives",
+    description="Results for records available to download and held at The National Archives that match your search term.",
+    aggregations=DEFAULT_AGGREGATIONS
+    + [Aggregation.COLLECTION, Aggregation.LEVEL, Aggregation.CLOSURE],
+)
+
+ESCAPE_AND_EVASION_CATALOGUE_BUCKETS = BucketList([_DIGITISED_BUCKET])
+
 CATALOGUE_BUCKETS = BucketList(
     [
         Bucket(
@@ -125,13 +135,7 @@ CATALOGUE_BUCKETS = BucketList(
             aggregations=DEFAULT_AGGREGATIONS
             + [Aggregation.COLLECTION, Aggregation.LEVEL, Aggregation.CLOSURE],
         ),
-        Bucket(
-            key="digitised",
-            label="Online records at The National Archives",
-            description="Results for records available to download and held at The National Archives that match your search term.",
-            aggregations=DEFAULT_AGGREGATIONS
-            + [Aggregation.COLLECTION, Aggregation.LEVEL, Aggregation.CLOSURE],
-        ),
+        _DIGITISED_BUCKET,
         Bucket(
             key="nonTna",
             label="Records at other UK archives",

--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -13,6 +13,7 @@ from ..ciim.client import SortBy, SortOrder
 from ..ciim.constants import (
     CATALOGUE_BUCKETS,
     COLLECTION_CHOICES,
+    ESCAPE_AND_EVASION_CATALOGUE_BUCKETS,
     LEVEL_CHOICES,
     TYPE_CHOICES,
     WEBSITE_BUCKETS,
@@ -274,6 +275,14 @@ class CatalogueSearchForm(BaseCollectionSearchForm):
     group = forms.ChoiceField(
         label="bucket",
         choices=CATALOGUE_BUCKETS.as_choices(),
+        required=False,
+    )
+
+
+class EscapeAndEvasionsCatalogueSearchForm(CatalogueSearchForm):
+    group = forms.ChoiceField(
+        label="bucket",
+        choices=ESCAPE_AND_EVASION_CATALOGUE_BUCKETS.as_choices(),
         required=False,
     )
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DOR-55

## About these changes

- Limit the search results to digitised records only, ignore the URL `group` param's value.
- Refactor of #1550. Using subclass instead of overriding code directly.

## How to check these changes

Use the search catalogue: http://localhost:8000/search/catalogue/
- Should only return the digitised results, whatever happens.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
