### PR TITLE
[DOR-59 DOR-47] IIIF manifest fetch testing

### DIFF
--- a/etna/ciim/tests/factories.py
+++ b/etna/ciim/tests/factories.py
@@ -87,7 +87,7 @@ def create_record(
                 detail[key] = value
 
     # return {"_source": source}  # TODO:Rosetta
-    return {"metadata": [detail]}
+    return detail
 
 
 def create_media(
@@ -122,19 +122,19 @@ def create_response(records=None, aggregations=None, total_count=None):
     If testing pagination or batch fetches, the total count can be optionally
     modified.
     """
-    if not records:
+    if records is None:
         records = []
 
-    if not aggregations:
+    if aggregations is None:
         aggregations = {}
 
-    if not total_count:
+    if total_count is None:
         total_count = len(records)
 
     return {
-        "hits": {
+        "metadata": [r for r in records],
+        "stats": {
             "total": {"value": total_count, "relation": "eq"},
-            "hits": [r for r in records],
         },
         "aggregations": aggregations,
     }

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -628,7 +628,7 @@ class ClientFetchTest(SimpleTestCase):
         responses.add(
             responses.GET,
             f"{settings.CLIENT_BASE_URL}/fetch",
-            json=create_record(iaid="C198022"),
+            json=create_response(records=[create_record(iaid="C198022")]),
         )
 
     @responses.activate

--- a/etna/core/tests/test_decorators.py
+++ b/etna/core/tests/test_decorators.py
@@ -33,20 +33,21 @@ class SettingControlledLoginRequiredTest(WagtailTestUtils, TestCase):
         responses.add(
             responses.GET,
             f"{settings.CLIENT_BASE_URL}/fetch",
-            json=create_record(
-                iaid="C123456",
-                description=[{"value": "This is the description from the Client API"}],
+            json=create_response(
+                records=[
+                    create_record(
+                        iaid="C123456",
+                        description=[
+                            {"value": "This is the description from the Client API"}
+                        ],
+                    )
+                ]
             ),
-            # json=create_response(
-            #     records=[
-            #         create_record(
-            #             iaid="C123456",
-            #             description=[
-            #                 {"value": "This is the description from the Client API"}
-            #             ],
-            #         )
-            #     ]
-            # ),
+        )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            status=404,
         )
 
     @override_settings(

--- a/etna/records/tests/test_views.py
+++ b/etna/records/tests/test_views.py
@@ -16,7 +16,12 @@ import responses
 from etna.core.test_utils import prevent_request_warnings
 from etna.records.views.records import SEARCH_URL_RETAIN_DELTA
 
-from ...ciim.tests.factories import create_media, create_record, create_response
+from ...ciim.tests.factories import (
+    create_iiif_manifest_response,
+    create_media,
+    create_record,
+    create_response,
+)
 
 User = get_user_model()
 
@@ -80,8 +85,26 @@ class TestRecordDisambiguationView(TestCase):
                 ]
             ),
         )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            json=create_iiif_manifest_response("C123456"),
+        )
 
         response = self.client.get("/catalogue/ref/ADM/223/3/", follow=False)
+
+        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(
+            responses.calls[0].response.url, f"{settings.CLIENT_BASE_URL}/searchUnified"
+        )
+        self.assertEqual(
+            responses.calls[1].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
+        self.assertEqual(
+            responses.calls[2].response.url,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -95,13 +118,14 @@ class TestRecordView(TestCase):
     @responses.activate
     @prevent_request_warnings
     def test_no_matches_respond_with_404(self):
-        responses.add(
-            responses.GET,
-            f"{settings.CLIENT_BASE_URL}/fetch",
-            json=create_response(records=[]),
-        )
-
+        responses.add(responses.GET, f"{settings.CLIENT_BASE_URL}/fetch", json={})
         response = self.client.get("/catalogue/id/C123456/")
+
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(
@@ -119,14 +143,103 @@ class TestRecordView(TestCase):
                 ]
             ),
         )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            json=create_iiif_manifest_response("C123456"),
+        )
 
         response = self.client.get("/catalogue/id/C123456/")
+
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
+        self.assertEqual(
+            responses.calls[1].response.url,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.resolver_match.view_name, "details-page-machine-readable"
         )
         self.assertTemplateUsed(response, "records/record_detail.html")
+
+    @responses.activate
+    def test_record_rendered_for_single_result_with_iiif_manifest(self):
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_BASE_URL}/fetch",
+            json=create_response(
+                records=[
+                    create_record(iaid="C123456"),
+                ]
+            ),
+        )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            json=create_iiif_manifest_response("C123456"),
+        )
+
+        response = self.client.get("/catalogue/id/C123456/")
+
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
+        self.assertEqual(responses.calls[0].response.status_code, 200)
+        self.assertEqual(
+            responses.calls[1].response.url,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # IIIF viewer shown for responses with IIIF viewer.
+        self.assertTrue(response.context["show_iiif_viewer"])
+        self.assertEqual(
+            response.context["iiif_manifest_url"],
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
+
+    @responses.activate
+    def test_record_rendered_for_single_result_without_iiif_manifest(self):
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_BASE_URL}/fetch",
+            json=create_response(
+                records=[
+                    create_record(iaid="C123456"),
+                ]
+            ),
+        )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            status=404,
+        )
+
+        response = self.client.get("/catalogue/id/C123456/")
+
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
+        self.assertEqual(
+            responses.calls[1].response.url,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # IIIF viewer shown for responses with IIIF viewer.
+        self.assertFalse(response.context["show_iiif_viewer"])
+        self.assertIsNone(response.context["iiif_manifest_url"])
 
     @unittest.skip(
         "Client API open beta API does not support media. Re-enable/update once media is available."
@@ -142,6 +255,11 @@ class TestRecordView(TestCase):
                 ]
             ),
         )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            json=create_iiif_manifest_response("C123456"),
+        )
 
         responses.add(
             responses.GET,
@@ -150,6 +268,17 @@ class TestRecordView(TestCase):
         )
 
         response = self.client.get("/catalogue/id/C123456/")
+
+        # TODO: Should this include assertion for the search endpoint as well?
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
+        self.assertEqual(
+            responses.calls[1].response.url,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -172,6 +301,11 @@ class TestRecordView(TestCase):
                 ]
             ),
         )
+        responses.add(
+            responses.GET,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+            json=create_iiif_manifest_response("C123456"),
+        )
 
         responses.add(
             responses.GET,
@@ -191,6 +325,18 @@ class TestRecordView(TestCase):
         )
 
         response = self.client.get("/catalogue/id/C123456/")
+
+        # TODO: Should this include assertion for the search endpoint as well?
+        # TODO: Should this include assertion for the media endpoint as well?
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=C123456",
+        )
+        self.assertEqual(
+            responses.calls[1].response.url,
+            f"{settings.CLIENT_IIIF_MANIFEST_BASE_URL}/manifest/C123456",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "records/record_detail.html")
@@ -214,6 +360,12 @@ class TestRecordView(TestCase):
         )
 
         response = self.client.get("/catalogue/id/A13532479/")
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=A13532479",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -256,6 +408,12 @@ class TestRecordView(TestCase):
         )
 
         response = self.client.get("/catalogue/id/F74321/")
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].response.url,
+            f"{settings.CLIENT_BASE_URL}/fetch?id=F74321",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(


### PR DESCRIPTION
Ticket URL: 
- https://national-archives.atlassian.net/browse/DOR-59
- https://national-archives.atlassian.net/browse/DOR-47

## About these changes

- Test that the IIIF manifest fetch is done only when necessary.
- Test that other Rosetta API calls are made as expected, right now there does not seem to be any assertions for this.

## How to check these changes

Run unit tests.

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
