### PR TITLE
EDEV-89: Fix media chooser

### DIFF
--- a/etna/media/templates/wagtailmedia/chooser/chooser.html
+++ b/etna/media/templates/wagtailmedia/chooser/chooser.html
@@ -10,7 +10,9 @@
         <form class="media-search search-bar" action="{% url 'wagtailmedia:chooser' %}" method="GET" novalidate id="analytics-chooser">
             <ul class="fields">
                 {% for field in searchform %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                    <li>
+                        {% include "wagtailadmin/shared/field.html" with field=field %}
+                    </li>
                 {% endfor %}
                 {% if collections %}
                     {% include "wagtailadmin/shared/collection_chooser.html" %}

--- a/etna/media/templates/wagtailmedia/chooser/chooser.html
+++ b/etna/media/templates/wagtailmedia/chooser/chooser.html
@@ -5,7 +5,7 @@
 {% trans "Choose a media item" as  choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str tabbed=1 merged=1 icon="media" %}
 
-<div class="tab-content">
+<div>
     <section id="search" class="{% if not uploadforms.audio.errors and not uploadforms.video.errors %}active {% endif %}nice-padding">
         <form class="media-search search-bar" action="{% url 'wagtailmedia:chooser' %}" method="GET" novalidate id="analytics-chooser">
             <ul class="fields">


### PR DESCRIPTION
Ticket URL: [EDEV-89]

## About these changes

Updated media chooser HTML to use `field.html` wrapped in `<li>` tags rather than `field_as_li.html` which was recently deprecated.

## How to check these changes

Find an article with a media chooser (or add one) and then select a media item from the chooser panel.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[EDEV-89]: https://national-archives.atlassian.net/browse/EDEV-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ