### PR TITLE
Make strtobool() return a boolean value, not an integer (0, 1)

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -70,7 +70,7 @@ if DEBUG and DEBUG_TOOLBAR_ENABLED:
         "debug_toolbar.middleware.DebugToolbarMiddleware",
     ]
 
-    def show_toolbar(request):
+    def show_toolbar(request) -> bool:
         return strtobool(os.getenv("DEBUG_TOOLBAR", "False"))
 
     DEBUG_TOOLBAR_CONFIG = {

--- a/config/settings/util.py
+++ b/config/settings/util.py
@@ -1,4 +1,4 @@
-def strtobool(val):
+def strtobool(val) -> bool:
     """Convert a string representation of truth to true (1) or false (0).
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
     are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
@@ -6,8 +6,8 @@ def strtobool(val):
     """
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
-        return 1
+        return True
     elif val in ("n", "no", "f", "false", "off", "0"):
-        return 0
+        return False
     else:
         raise ValueError("invalid truth value %r" % (val,))

--- a/config/settings/util.py
+++ b/config/settings/util.py
@@ -1,5 +1,5 @@
-def strtobool(val) -> bool:
-    """Convert a string representation of truth to true (1) or false (0).
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to true or false.
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
     are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
     'val' is anything else.

--- a/etna/tests/test_config.py
+++ b/etna/tests/test_config.py
@@ -1,0 +1,78 @@
+# This file lives here rather than in the config package, because the test runner
+# does not seem able to find it there. Also the test.py setting file is being
+# discovered as a test.
+import django.test
+
+from config.settings.util import strtobool
+
+
+class TestStrToBool(django.test.SimpleTestCase):
+    TRUTHY_VALUES = (
+        "y",
+        "yes",
+        "t",
+        "true",
+        "on",
+        "1",
+        "Y",
+        "YES",
+        "T",
+        "TRUE",
+        "ON",
+        "oN",
+        "tRuE",
+        "YeS",
+        "Yes",
+    )
+
+    def test_truthy_values(self) -> None:
+        for value in self.TRUTHY_VALUES:
+            with self.subTest(value=value):
+                self.assertIs(strtobool(value), True)
+
+    FALSY_VALUES = (
+        "n",
+        "no",
+        "f",
+        "false",
+        "off",
+        "0",
+        "N",
+        "NO",
+        "F",
+        "FALSE",
+        "OFF",
+        "fALsE",
+        "nO",
+        "No",
+        "ofF",
+    )
+
+    def test_falsy_values(self) -> None:
+        for value in self.FALSY_VALUES:
+            with self.subTest(value=value):
+                self.assertIs(strtobool(value), False)
+
+    INCORRECT_VALUES = (
+        "",
+        " ",
+        "\t",
+        " n",
+        " no ",
+        " f ",
+        " false ",
+        " off ",
+        "random value",
+    )
+
+    def test_incorrect_values(self):
+        for value in self.INCORRECT_VALUES:
+            exception_message = f"invalid truth value {value!r}"
+            with self.subTest(value=value, exception_message=exception_message):
+                with self.assertRaises(ValueError) as cm:
+                    strtobool(value)
+                # We are using assertRaises instead of assertRaisesRegex
+                # because we want to test values like "\t" which won't work
+                # with assertRaisesRegex. Therefore we need to test the message
+                # with assertEqual separately.
+                self.assertEqual(str(cm.exception), exception_message)


### PR DESCRIPTION
## About these changes

`strtobool` function was returning an integer.

I realised this because we were passing `1` instead of `True` to the verify certificates option in HTTP requests in the CIIM client. It only broke when making requests to HTTPS, because requests were looking at a custom certificate at a filesystem path `1`, rather than just using the default verify certificate behaviour.

It might be because this is the first time we used HTTPS instead of HTTP using this API client.

`strtobool` is used heavily in the codebase, and if the rest of the code was not changing an integer to the boolean, there may be side effects once this is merged.

Alternatively, we could ensure whenever this function is used, we explicitly cast return values to the boolean at the call time. I don't know the original reason for returning 0s and 1s in the first place.

## How to check these changes

- CIIM client works as expected over HTTPS.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
