### PR TITLE
[DOR-81]: Temporarily hide records without thumbnails from search results

### DIFF
--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -54,6 +54,7 @@
         <h2 class="sr-only">Results</h2>
             <ul class="search-results__list" id="analytics-results-list">
                 {% for record in page %}
+                    {% comment %} TODO: DOR-82 - Remove this if statement to show all records after user testing {% endcomment %}
                     {% if record.thumbnail %}
                         {% include './search_results__list-card.html' %}
                     {% endif %}

--- a/templates/search/blocks/search_results.html
+++ b/templates/search/blocks/search_results.html
@@ -54,7 +54,9 @@
         <h2 class="sr-only">Results</h2>
             <ul class="search-results__list" id="analytics-results-list">
                 {% for record in page %}
-                    {% include './search_results__list-card.html' %}
+                    {% if record.thumbnail %}
+                        {% include './search_results__list-card.html' %}
+                    {% endif %}
                 {% endfor %}
             </ul>
     {% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DOR-81

## About these changes

Hides any results which don't contain a thumbnail. This is a temporary fix for user testing, to hide parent records in our subset of record results which don't contain thumbnails. 

**Note:** this will need to be reverted after user testing (or at an agreed time) to ensure we don't unintentionally hide any records without thumbnails in future (see ticket https://national-archives.atlassian.net/browse/DOR-82)

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
