### PR TITLE
EDEV-95:Remove call to mark_safe

### DIFF
--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -3,7 +3,6 @@ import re
 from typing import Any, Dict, Optional
 
 from django.urls import NoReverseMatch, reverse
-from django.utils.safestring import mark_safe
 
 import nh3
 

--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -277,4 +277,4 @@ def strip_html(value: str, *, preserve_marks, ensure_spaces):
         closing_regex = rf"</{tag}>"
         clean_html = re.sub(opening_regex, " ", clean_html)
         clean_html = re.sub(closing_regex, "", clean_html)
-    return mark_safe(clean_html.lstrip())
+    return clean_html.lstrip()


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/EDEV-95

## About these changes

strip_html is already called with mark_safe exclusively [here ](https://github.com/nationalarchives/ds-wagtail/blob/71a126411d748aaa3d0faed8664f7ad33307797b/etna/records/models.py#L159)and [here](https://github.com/nationalarchives/ds-wagtail/blob/71a126411d748aaa3d0faed8664f7ad33307797b/etna/records/models.py#L270). 

and is not originally called from [here ](https://github.com/nationalarchives/ds-wagtail/blob/71a126411d748aaa3d0faed8664f7ad33307797b/etna/records/models.py#L292)
This removes the duplicate call in strip_html method and restore original functionality for content attribute

## How to check these changes
- View search results - http://127.0.0.1:8000/search/catalogue/
- View record details from the search results

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
