### PR TITLE
[DOR-83] HTML-only record viewer

### DIFF
--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -15,9 +15,9 @@ from etna.ciim.tests.factories import (
     create_response,
     create_search_response,
 )
+from etna.records import iiif
 from etna.records.api import get_records_client
 from etna.records.models import Record
-from etna.records import iiif
 
 from ..client import ResultList, SortBy, SortOrder, Stream, Template
 from ..exceptions import (

--- a/etna/ciim/tests/test_client.py
+++ b/etna/ciim/tests/test_client.py
@@ -16,7 +16,8 @@ from etna.ciim.tests.factories import (
     create_search_response,
 )
 from etna.records.api import get_records_client
-from etna.records.models import IIIFManifest, Record
+from etna.records.models import Record
+from etna.records import iiif
 
 from ..client import ResultList, SortBy, SortOrder, Stream, Template
 from ..exceptions import (
@@ -1178,7 +1179,7 @@ class ClientFetchIIIFManifest(SimpleTestCase):
             ],
         )
 
-        self.assertIsInstance(result, IIIFManifest)
+        self.assertIsInstance(result, iiif.IIIFManifest)
         self.assertEqual(result.content, manifest)
 
     @responses.activate

--- a/etna/records/iiif.py
+++ b/etna/records/iiif.py
@@ -94,6 +94,7 @@ class ManifestParser:
         if item["type"] != "Canvas":
             raise InvalidManifestFormat("Item is not a canvas.")
         canvas_items = item["items"]
+        images = []
         for canvas_item in canvas_items:
             if canvas_item["type"] == "AnnotationPage":
                 for annotation_page_item in canvas_item["items"]:
@@ -105,5 +106,7 @@ class ManifestParser:
                                 "width": body.get("width"),
                                 "height": body.get("height"),
                             }
-                            return [image_dict]
-        raise ImageNotFoundInItem
+                            images.append(image_dict)
+        if not images:
+            raise ImageNotFoundInItem
+        return images

--- a/etna/records/iiif.py
+++ b/etna/records/iiif.py
@@ -1,0 +1,109 @@
+from collections.abc import Sequence
+from typing import Literal, NotRequired, TypedDict
+
+
+class InvalidManifestFormat(Exception):
+    pass
+
+
+class AnnotationItemBody(TypedDict):
+    id: str
+    type: Literal["Image"]
+    height: NotRequired[int]
+    width: NotRequired[int]
+
+
+class AnnotationItem(TypedDict):
+    id: str
+    type: Literal["Annotation"]
+    motivation: Literal["painting"]
+    body: AnnotationItemBody
+    target: str
+
+
+class AnnotationPageItem(TypedDict):
+    id: str
+    type: Literal["AnnotationPage"]
+    items: Sequence[AnnotationItem]
+
+
+class ManifestItem(TypedDict):
+    id: str
+    height: int
+    width: int
+    type: Literal["Canvas"]
+    items: Sequence[AnnotationPageItem]
+
+
+class IIIFResourceJSON(TypedDict):
+    type: Literal["Manifest"]
+    items: list[ManifestItem]
+
+
+class IIIFResource:
+    content: IIIFResourceJSON
+
+    def __init__(self, *, raw_data: IIIFResourceJSON) -> None:
+        self.content = raw_data
+
+
+class IIIFManifest(IIIFResource):
+    pass
+
+
+def create_resource(resource_json: IIIFResourceJSON) -> "IIIFResource":
+    if resource_json["type"] == "Manifest":
+        return IIIFManifest(raw_data=resource_json)
+    return IIIFResource(raw_data=resource_json)
+
+
+class ImageNotFoundInItem(Exception):
+    pass
+
+
+class ItemImage:
+    url: str
+    width: int | None
+    height: int | None
+
+
+class ManifestParser:
+    manifest: IIIFManifest
+    __items: list[ManifestItem] | None = None
+
+    def __init__(self, *, manifest: IIIFManifest) -> None:
+        self.manifest = manifest
+
+    def get_items(self) -> list[ManifestItem]:
+        if self.__items is not None:
+            return self.__items
+        self.__items = self.manifest.content["items"]
+        return self.__items
+
+    def get_item_at_index(self, index: int) -> ManifestItem:
+        return self.get_items()[index]
+
+    def get_last_index(self) -> int:
+        return len(self.get_items()) - 1
+
+    def get_items_count(self) -> int:
+        return len(self.get_items())
+
+    @classmethod
+    def get_images_for_item(cls, item: ManifestItem) -> list[ItemImage]:
+        if item["type"] != "Canvas":
+            raise InvalidManifestFormat("Item is not a canvas.")
+        canvas_items = item["items"]
+        for canvas_item in canvas_items:
+            if canvas_item["type"] == "AnnotationPage":
+                for annotation_page_item in canvas_item["items"]:
+                    body = annotation_page_item.get("body")
+                    if body is not None and body["type"] == "Image":
+                        if image_id := body["id"]:
+                            image_dict: ItemImage = {
+                                "url": image_id,
+                                "width": body.get("width"),
+                                "height": body.get("height"),
+                            }
+                            return [image_dict]
+        raise ImageNotFoundInItem

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import logging
 import re
 
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Self, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from django.conf import settings
 from django.http import HttpRequest
@@ -980,17 +979,6 @@ class Record(DataLayerMixin, APIModel):
     @cached_property
     def publication_note(self) -> str:
         return self.template.get("publicationNote", str)
-
-
-class IIIFManifest(APIModel):
-    content: Mapping[str, Any]
-
-    def __init__(self, *, raw_data: Mapping[str, Any]) -> None:
-        self.content = raw_data
-
-    @classmethod
-    def from_api_response(cls, response: Mapping[str, Any]) -> Self:
-        return cls(raw_data=response)
 
 
 @dataclass

--- a/scripts/src/iiif-viewer.js
+++ b/scripts/src/iiif-viewer.js
@@ -5,7 +5,10 @@ document.addEventListener("DOMContentLoaded", () => {
     document
         .querySelectorAll("[data-js-iiif-viewer-manifest-url]")
         .forEach((element) => {
-            const { jsIiifViewerManifestUrl: manifestUrl } = element.dataset;
+            const {
+                jsIiifViewerManifestUrl: manifestUrl,
+                jsIiifViewerCanvasIndex: rawCanvasIndex,
+            } = element.dataset;
             if (!manifestUrl) {
                 throw new Error(
                     "No manifest URL provided in data-js-iiif-viewer-manifest-url attribute.",
@@ -14,6 +17,17 @@ document.addEventListener("DOMContentLoaded", () => {
             const data = {
                 iiifManifestId: manifestUrl,
             };
+
+            if (rawCanvasIndex) {
+                const parsedCanvasIndex = parseInt(rawCanvasIndex, 10);
+                if (
+                    parsedCanvasIndex !== null &&
+                    !isNaN(parsedCanvasIndex) &&
+                    parsedCanvasIndex >= 0
+                ) {
+                    data.canvasIndex = parsedCanvasIndex;
+                }
+            }
 
             const uv = window.UV.init(element, data);
 

--- a/templates/includes/records/record-viewer.html
+++ b/templates/includes/records/record-viewer.html
@@ -1,23 +1,32 @@
-{% if iiif_manifest_url %}
-    <div class="uv" id="uv" data-jjs-iiif-viewer-manifest-url="{{ iiif_manifest_url }}">
-        {% if html_only_record_viewer %}
-            {% if html_only_record_viewer.prev_page_url %}
-                <a href="{{ html_only_record_viewer.prev_page_url }}">
-                    Prev page
-                </a>
-            {% endif %}
-
-            {{ html_only_record_viewer.current_item }} out of {{ html_only_record_viewer.item_count }}
-
-            {% if html_only_record_viewer.next_page_url %}
-                <a href="{{ html_only_record_viewer.next_page_url }}">
-                    Next page
-                </a>
-            {% endif %}
-
-            {% for image in html_only_record_viewer.images %}
-                <img src="{{ image.url }}" alt="" />
-            {% endfor %}
-        {% endif %}
-    </div>
+{% if show_js_record_viewer %}
+    <div
+        class="uv"
+        id="uv"
+        data-js-iiif-viewer-manifest-url="{{ iiif_manifest_url }}"
+        {% if canvas_index is not None %} data-js-iiif-viewer-canvas-index="{{ canvas_index }}" {% endif %}
+    >
+{% else %}
+    <div>
 {% endif %}
+
+{% if html_only_record_viewer %}
+    {% if html_only_record_viewer.prev_page_url %}
+        <a href="{{ html_only_record_viewer.prev_page_url }}">
+            Prev page
+        </a>
+    {% endif %}
+
+    {{ html_only_record_viewer.current_item }} out of {{ html_only_record_viewer.item_count }}
+
+    {% if html_only_record_viewer.next_page_url %}
+        <a href="{{ html_only_record_viewer.next_page_url }}">
+            Next page
+        </a>
+    {% endif %}
+
+    {% for image in html_only_record_viewer.images %}
+        <img src="{{ image.url }}" alt="" />
+    {% endfor %}
+{% endif %}
+
+</div>

--- a/templates/includes/records/record-viewer.html
+++ b/templates/includes/records/record-viewer.html
@@ -1,0 +1,23 @@
+{% if iiif_manifest_url %}
+    <div class="uv" id="uv" data-jjs-iiif-viewer-manifest-url="{{ iiif_manifest_url }}">
+        {% if html_only_record_viewer %}
+            {% if html_only_record_viewer.prev_page_url %}
+                <a href="{{ html_only_record_viewer.prev_page_url }}">
+                    Prev page
+                </a>
+            {% endif %}
+
+            {{ html_only_record_viewer.current_item }} out of {{ html_only_record_viewer.item_count }}
+
+            {% if html_only_record_viewer.next_page_url %}
+                <a href="{{ html_only_record_viewer.next_page_url }}">
+                    Next page
+                </a>
+            {% endif %}
+
+            {% for image in html_only_record_viewer.images %}
+                <img src="{{ image.url }}" alt="" />
+            {% endfor %}
+        {% endif %}
+    </div>
+{% endif %}

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -67,11 +67,12 @@
                     </tbody>
                 </table>
             </div>
-
-            {% if show_iiif_viewer %}
+            {% if show_record_viewer %}
                 <h2 id="record-viewer" class="tna-heading-l">Record viewer</h2>
+                    Record viewer
+                </h2>
 
-                <div class="uv" id="uv" data-js-iiif-viewer-manifest-url="{{ iiif_manifest_url }}">Loading</div>
+                {% include "includes/records/record-viewer.html" with html_only_record_viewer=html_only_record_viewer iiif_manifest_url=iiif_manifest_url %}
             {% endif %}
 
             {% comment %}  
@@ -174,7 +175,7 @@
 {% block extra_js %}
     <script src="{% static 'scripts/details.js' %}"></script>
 
-    {% if show_iiif_viewer %}
+    {% if show_record_viewer %}
         <script src="{% static 'uv/UV.js' %}"></script>
         <script src="{% static 'scripts/iiif_viewer.js' %}"></script>
     {% endif %}

--- a/templates/records/record_detail.html
+++ b/templates/records/record_detail.html
@@ -34,7 +34,7 @@
                         </a>
                     </li>
                 
-                    {% if show_iiif_viewer %}
+                    {% if show_record_viewer %}
                         <li class="jumplinks__list-item">
                             <a class="jumplink" href="#record-viewer" data-component-name="Desktop in page navigation" data-link-type="Jump links" data-position="1" data-link="Record viewer">
                                 Record viewer
@@ -71,8 +71,8 @@
                 <h2 id="record-viewer" class="tna-heading-l">Record viewer</h2>
                     Record viewer
                 </h2>
-
-                {% include "includes/records/record-viewer.html" with html_only_record_viewer=html_only_record_viewer iiif_manifest_url=iiif_manifest_url %}
+                
+                {% include "includes/records/record-viewer.html" with html_only_record_viewer=html_only_record_viewer show_js_record_viewer=show_js_record_viewer iiif_manifest_url=iiif_manifest_url %}
             {% endif %}
 
             {% comment %}  
@@ -175,7 +175,7 @@
 {% block extra_js %}
     <script src="{% static 'scripts/details.js' %}"></script>
 
-    {% if show_record_viewer %}
+    {% if show_js_record_viewer %}
         <script src="{% static 'uv/UV.js' %}"></script>
         <script src="{% static 'scripts/iiif_viewer.js' %}"></script>
     {% endif %}


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DOR-83


## About these changes

This is a basic implementation of the HTML-only viewer.

- See more notes on this implementation here: https://national-archives.atlassian.net/wiki/spaces/DE/pages/347144228/Progressive+Enhancement+implementation

- Simplistic IIIF manifest parser that looks for images on an IIIF canvas. If images are stored in different structures, this won't work.
   - We load the image from the `id` key. We don't reach out to the image API so we don't know what other formats are available. That means that by default we may be fetching quite a big image. This can be improved upon.
- Add query parameters to the record detail view:
   - `record_viewer_index` contains the current canvas index (the zero-indexed IIIF manifest's `items` array index).
   - `show_record_viewer` query parameter that either takes `js` (the default) or `html-only`. That way you can easily force an HTML-only viewer to show for testing.
 - If JavaScript viewer (i.e. Universal Viewer) loads with the value in the `record_viewer_index` query parameter, then the Universal Vierwer loads that canvas index on the initial load. However, after the initial load nothing happens to it. An improvement may be to get UV to update the URL parameter to update as the canvas is changed in UV by the user.

## How to check these changes

You can see the HTML-only version by forcing it in the query parameter:

- http://localhost:8000/catalogue/id/C11050044/?show_record_viewer=html-only

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
