### PR TITLE
[DOR-79] Fix sidebar / jumplinks focus state being cut off

### DIFF
--- a/sass/includes/_jumplinks.scss
+++ b/sass/includes/_jumplinks.scss
@@ -16,11 +16,12 @@
     &__heading {
         @include font-size(xl);
         font-family: $font__body;
+        padding: 0 0.5rem;
         margin: 0;
     }
 
     &__list {
-        padding-right: 0.5rem;
+        padding: 0 0.5rem;
         list-style: none;
     }
 


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/DOR-79

## About these changes

This change adds a small left padding to the nav, which does mean its no longer completely flush with the left hand side. This will likely be re-factored later anyway, so this is a fairly short-term fix for now until the new front-end is brought in properly.

Before:
![tna-jumplinks-focus-before](https://github.com/nationalarchives/ds-wagtail/assets/8680557/135e6b12-7870-4baa-87d2-b6b9e83ff6eb)

After:
![tna-jumplinks-focus-after](https://github.com/nationalarchives/ds-wagtail/assets/8680557/3277a452-db6c-47b6-9a94-29cfc2eda18e)

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
