### PR TITLE
EDEV-93: Image Block transcript + translations

### DIFF
--- a/etna/core/blocks/image.py
+++ b/etna/core/blocks/image.py
@@ -72,7 +72,10 @@ class APIImageChooserBlock(ImageChooserBlock):
                     else None
                 ),
                 "translation": (
-                    {"heading": value.get_translation_heading_display(), "text": value.translation}
+                    {
+                        "heading": value.get_translation_heading_display(),
+                        "text": value.translation,
+                    }
                     if value.translation
                     else None
                 ),

--- a/etna/core/blocks/image.py
+++ b/etna/core/blocks/image.py
@@ -63,6 +63,19 @@ class APIImageChooserBlock(ImageChooserBlock):
                     "width": webp_image.width,
                     "height": webp_image.height,
                 },
+                "transcript": (
+                    {
+                        "heading": value.transcription_heading,
+                        "text": value.transcription,
+                    }
+                    if value.transcription
+                    else None
+                ),
+                "translation": (
+                    {"heading": value.translation_heading, "text": value.translation}
+                    if value.translation
+                    else None
+                ),
             }
         return None
 

--- a/etna/core/blocks/image.py
+++ b/etna/core/blocks/image.py
@@ -65,14 +65,14 @@ class APIImageChooserBlock(ImageChooserBlock):
                 },
                 "transcript": (
                     {
-                        "heading": value.transcription_heading,
+                        "heading": value.get_transcription_heading_display(),
                         "text": value.transcription,
                     }
                     if value.transcription
                     else None
                 ),
                 "translation": (
-                    {"heading": value.translation_heading, "text": value.translation}
+                    {"heading": value.get_translation_heading_display(), "text": value.translation}
                     if value.translation
                     else None
                 ),


### PR DESCRIPTION
Ticket URL: [EDEV-93]

## About these changes

Added transcript + translation values from the CustomImage model to the returned JSON when the APIImageChooserBlock is turned into the API representation.

## How to check these changes

http://localhost:8000/api/v2/pages/202/ and look at some images

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[EDEV-93]: https://national-archives.atlassian.net/browse/EDEV-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ