### PR TITLE
EDEV-88: Content warning

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -269,6 +269,7 @@ class ArticlePage(
         BasePageWithIntro.api_fields
         + RequiredHeroImageMixin.api_fields
         + ContentWarningMixin.api_fields
+        + NewLabelMixin.api_fields
         + ArticleTagMixin.api_fields
         + [
             APIField("verbose_name_public"),
@@ -426,6 +427,7 @@ class FocusedArticlePage(
         BasePageWithIntro.api_fields
         + HeroImageMixin.api_fields
         + ContentWarningMixin.api_fields
+        + NewLabelMixin.api_fields
         + ArticleTagMixin.api_fields
         + [
             APIField("type_label"),

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -268,6 +268,7 @@ class ArticlePage(
     api_fields = (
         BasePageWithIntro.api_fields
         + RequiredHeroImageMixin.api_fields
+        + ContentWarningMixin.api_fields
         + ArticleTagMixin.api_fields
         + [
             APIField("verbose_name_public"),
@@ -423,9 +424,9 @@ class FocusedArticlePage(
     )
     api_fields = (
         BasePageWithIntro.api_fields
-        + ArticleTagMixin.api_fields
         + HeroImageMixin.api_fields
         + ContentWarningMixin.api_fields
+        + ArticleTagMixin.api_fields
         + [
             APIField("type_label"),
             APIField("body"),
@@ -667,9 +668,9 @@ class RecordArticlePage(
 
     api_fields = (
         BasePageWithIntro.api_fields
-        + ArticleTagMixin.api_fields
-        + NewLabelMixin.api_fields
         + ContentWarningMixin.api_fields
+        + NewLabelMixin.api_fields
+        + ArticleTagMixin.api_fields
         + [
             APIField("type_label"),
             APIField("date_text"),

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -801,8 +801,8 @@ class HighlightGalleryPage(TopicalPageMixin, ContentWarningMixin, BasePageWithIn
     )
 
     api_fields = (
-        ContentWarningMixin.api_fields
-        + BasePageWithIntro.api_fields
+        BasePageWithIntro.api_fields
+        + ContentWarningMixin.api_fields
         + [
             APIField("featured_record_article"),
             APIField("featured_article"),

--- a/etna/core/models/mixins.py
+++ b/etna/core/models/mixins.py
@@ -41,6 +41,7 @@ class ContentWarningMixin(models.Model):
     )
 
     api_fields = [
+        APIField("display_content_warning"),
         APIField("custom_warning_text", serializer=RichTextSerializer()),
     ]
 


### PR DESCRIPTION
Ticket URL: [EDEV-88]

## About these changes

Added `ContentWarningMixin`'s `api_fields` to `ArticlePage`'s `api_fields`.
Added `display_content_warning` to the Mixin's `api_fields` so the front-end knows whether to display the default (or custom) warning.

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[EDEV-88]: https://national-archives.atlassian.net/browse/EDEV-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ