### PR TITLE
EDEV-38: verbose_public_name

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -264,13 +264,11 @@ class ArticlePage(
         ]
     )
 
-    verbose_name_public = Meta.verbose_name_public
     api_fields = (
         BasePageWithIntro.api_fields
         + RequiredHeroImageMixin.api_fields
         + ArticleTagMixin.api_fields
         + [
-            APIField("verbose_name_public"),
             APIField("similar_items", serializer=PageSerializer(many=True)),
             APIField("latest_items", serializer=PageSerializer(many=True)),
             APIField("body"),


### PR DESCRIPTION
Ticket URL: [EDEV-38]

## About these changes

Removed verbose_public_name APIFields - we get this coming through, capitalised, in `type_label` which we are sending to the API response via BasePage.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)


[EDEV-38]: https://national-archives.atlassian.net/browse/EDEV-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ