### PR TITLE
Feature/EDEV-98: updates for strip html

### DIFF
--- a/etna/ciim/utils.py
+++ b/etna/ciim/utils.py
@@ -257,20 +257,39 @@ def format_link(link_html: str) -> Dict[str, str]:
     return {"href": href, "id": id, "text": document.text()}
 
 
-def strip_html(value: str, *, preserve_marks, ensure_spaces):
+def strip_html(
+    value: str,
+    *,
+    preserve_marks: bool = False,
+    ensure_spaces: bool = False,
+    allow_tags: Optional[set] = None,
+) -> str:
     """
     Temporary HTML sanitiser to remove unwanted tags from data.
-    K-int will eventually sanitise this at API level.
-    preserve_marks=True will keep <mark> tags in the output, otherwise they are removed.
+    TODO:this will eventually be sanitised at API level.
 
-    Replacing <span> and <p> tags is necessary to prevent "bunched" data,
-    "This is a<span>test</span>example" will return as "This is atestexample"
-    without the placement of the space.
+    value:
+        the value to be sanitised
+    preserver_marks:
+        allow pre-defined tags for styling
+    ensure_spaces:
+        allow pre-defined tags and replaces them with whitespace
+    allow_tags:
+        sets the tags that are allowed
     """
     clean_tags = {"span", "p"} if ensure_spaces else set()
-    clean_html = nh3.clean(
-        value, tags={*clean_tags, "mark"} if preserve_marks else clean_tags
-    )
+
+    if allow_tags is None:
+        allow_tags = set()
+
+    tags = set()
+    if preserve_marks:
+        tags.add("mark")
+    tags.update(clean_tags)
+    tags.update(allow_tags)
+
+    clean_html = nh3.clean(value, tags=tags)
+
     for tag in clean_tags:
         opening_regex = rf"<{tag}[^>]*>"
         closing_regex = rf"</{tag}>"


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/EDEV-98

## About these changes

- Update method comments
- Set method defaults
- Added allow_tags (used for OHOS, does not change existing functionality)
- Added tests

## How to check these changes

Regression:
- http://127.0.0.1:8000/search/catalogue/?q=D7376859&group=digitised
- http://127.0.0.1:8000/catalogue/id/D7376859/

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
