### PR TITLE
Update API for pages endpoint

### DIFF
--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -60,7 +60,13 @@ class CustomImagesAPIViewSet(ImagesAPIViewSet):
 
 
 class CustomPagesAPIViewSet(PagesAPIViewSet):
-    base_serializer_class = DefaultPageSerializer
+    def listing_view(self, request):
+        queryset = self.get_queryset()
+        self.check_query_parameters(queryset)
+        queryset = self.filter_queryset(queryset)
+        queryset = self.paginate_queryset(queryset)
+        serializer = DefaultPageSerializer(queryset, many=True)
+        return self.get_paginated_response(serializer.data)
 
 
 api_router = WagtailAPIRouter("wagtailapi")

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -1,5 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 
+from etna.core.serializers.pages import DefaultPageSerializer
+
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import PagesAPIViewSet
 from wagtail.images.api.v2.views import ImagesAPIViewSet
@@ -57,9 +59,13 @@ class CustomImagesAPIViewSet(ImagesAPIViewSet):
     ]
 
 
+class CustomPagesAPIViewSet(PagesAPIViewSet):
+    base_serializer_class = DefaultPageSerializer
+
+
 api_router = WagtailAPIRouter("wagtailapi")
 
-api_router.register_endpoint("pages", PagesAPIViewSet)
+api_router.register_endpoint("pages", CustomPagesAPIViewSet)
 api_router.register_endpoint("images", CustomImagesAPIViewSet)
 api_router.register_endpoint("media", MediaAPIViewSet)
 api_router.register_endpoint("page_preview", PagePreviewAPIViewSet)

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -152,6 +152,10 @@ class BasePage(MetadataPageMixin, DataLayerMixin, Page, HeadlessPreviewMixin):
         APIField("full_url"),
         APIField("type_label"),
         APIField("teaser_text"),
+        APIField(
+            "teaser_image",
+            serializer=ImageSerializer("fill-600x400"),
+        ),
     ]
 
     api_fields = [


### PR DESCRIPTION
Detail views such as http://localhost:8000/api/v2/pages/55/ should remain the same as before (https://develop-sr3snxi-rasrzs7pi6sd4.uk-1.platformsh.site/api/v2/pages/55/)

Listing views such as:

- http://localhost:8000/api/v2/pages/?child_of=55
- http://localhost:8000/api/v2/pages/?search=john

...should now contain more information than previously:

- https://develop-sr3snxi-rasrzs7pi6sd4.uk-1.platformsh.site/api/v2/pages/?child_of=55
- https://develop-sr3snxi-rasrzs7pi6sd4.uk-1.platformsh.site/api/v2/pages/?search=john

...but still be able to accept the pre-existing filter parameters:

- http://localhost:8000/api/v2/pages/?child_of=55&offset=2&limit=3
- http://localhost:8000/api/v2/pages/?search=john&limit=3