### PR TITLE
Add redis config for services not on platform.sh

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -437,3 +437,19 @@ FEATURE_FEEDBACK_MECHANISM_ENABLED = strtobool(
 FEATURE_DISABLE_JS_WHATS_ON_LISTING = strtobool(
     os.getenv("FEATURE_DISABLE_JS_WHATS_ON_LISTING", "False")
 )
+
+if redis_url := os.getenv("REDIS_URL"):
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": redis_url,
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            },
+        },
+        "renditions": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": redis_url,
+            "KEY_PREFIX": "renditions",
+        },
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - media:/media
     depends_on:
       - db
+      - redis
     ports:
       - 8000:8080
     command: sh /app/bash/run-dev.sh
@@ -48,6 +49,7 @@ services:
       - FEATURE_BETA_BANNER_ENABLED=False
       - KEEP_ALIVE=30
       - WAGTAILAPI_BASE_URL=http://host.docker.internal:8000
+      - REDIS_URL=redis://:redis@redis:6379
 
   cli:
     container_name: cli
@@ -86,6 +88,13 @@ services:
       - DATABASE_HOST=db
       - DATABASE_NAME=postgres
       - DATABASE_USER=postgres
+
+  redis:
+    container_name: redis
+    image: redis:latest
+    command: /bin/sh -c "redis-server --requirepass redis"
+    ports:
+      - 6379:6379
 
 volumes:
   media:


### PR DESCRIPTION
Set up redis config for services not on platform.sh, ready for AWS

Setup is described here: https://docs.wagtail.org/en/stable/advanced_topics/performance.html