### PR TITLE
Image size tweaks and add headless mixin

### DIFF
--- a/etna/api/tests/expected_results/article.json
+++ b/etna/api/tests/expected_results/article.json
@@ -39,22 +39,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 12,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_iG2hIxi.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_iG2hIxi.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_15rF74p.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_15rF74p.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 12,
         "title": "An image",
@@ -154,8 +138,8 @@
                                     "height": 100
                                 },
                                 "webp": {
-                                    "url": "/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-80.webp",
-                                    "full_url": "https://nationalarchives.gov.uk/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-80.webp",
+                                    "url": "/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-60.webp",
+                                    "full_url": "https://nationalarchives.gov.uk/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-60.webp",
                                     "width": 100,
                                     "height": 100
                                 },
@@ -253,8 +237,8 @@
                                         "height": 100
                                     },
                                     "webp": {
-                                        "url": "/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-80.webp",
-                                        "full_url": "https://nationalarchives.gov.uk/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-80.webp",
+                                        "url": "/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-60.webp",
+                                        "full_url": "https://nationalarchives.gov.uk/media/images/example_0Tm3K5n.max-900x900.format-webp.webpquality-60.webp",
                                         "width": 100,
                                         "height": 100
                                     },

--- a/etna/api/tests/expected_results/article.json
+++ b/etna/api/tests/expected_results/article.json
@@ -33,8 +33,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
             "width": 100,
             "height": 68
         }
@@ -49,8 +49,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_8zcBeAq.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_8zcBeAq.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_8zcBeAq.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_8zcBeAq.webp",
             "width": 100,
             "height": 100
         }
@@ -69,8 +69,8 @@
             "height": 40
         },
         "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_xM6LhM0.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_xM6LhM0.webp",
+            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_xM6LhM0.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_xM6LhM0.webp",
             "width": 100,
             "height": 40
         }
@@ -85,8 +85,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_BEZm7Hv.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_BEZm7Hv.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_BEZm7Hv.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_BEZm7Hv.webp",
             "width": 100,
             "height": 68
         }
@@ -174,8 +174,8 @@
                                     "height": 68
                                 },
                                 "webp": {
-                                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_GupD5Qb.webp",
-                                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_GupD5Qb.webp",
+                                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_GupD5Qb.webp",
+                                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_GupD5Qb.webp",
                                     "width": 100,
                                     "height": 68
                                 },
@@ -299,8 +299,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -327,8 +327,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -353,8 +353,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -377,8 +377,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_yuGViLV.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_yuGViLV.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_yuGViLV.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_yuGViLV.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/article_index.json
+++ b/etna/api/tests/expected_results/article_index.json
@@ -33,8 +33,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_7hLyRgB.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_7hLyRgB.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_7hLyRgB.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_7hLyRgB.webp",
             "width": 100,
             "height": 68
         }
@@ -49,8 +49,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_ppQbvU2.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_ppQbvU2.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_ppQbvU2.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_ppQbvU2.webp",
             "width": 100,
             "height": 100
         }

--- a/etna/api/tests/expected_results/article_index.json
+++ b/etna/api/tests/expected_results/article_index.json
@@ -39,22 +39,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 11,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_NwigGNI.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_NwigGNI.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_HpAlGCn.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_HpAlGCn.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 11,
         "title": "An image",
@@ -91,8 +75,8 @@
                 "height": 68
             },
             "webp": {
-                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                 "width": 100,
                 "height": 68
             }
@@ -123,8 +107,8 @@
                                 "height": 68
                             },
                             "webp": {
-                                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                                 "width": 100,
                                 "height": 68
                             }
@@ -148,8 +132,8 @@
                                 "height": 68
                             },
                             "webp": {
-                                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                                 "width": 100,
                                 "height": 68
                             }

--- a/etna/api/tests/expected_results/arts.json
+++ b/etna/api/tests/expected_results/arts.json
@@ -73,22 +73,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 2,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_KA7WZJi.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_KA7WZJi.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_GIgFPMR.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_GIgFPMR.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 2,
         "title": "An image",

--- a/etna/api/tests/expected_results/arts.json
+++ b/etna/api/tests/expected_results/arts.json
@@ -32,8 +32,8 @@
             "height": 40
         },
         "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_JdNZ8pq.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_JdNZ8pq.webp",
+            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_JdNZ8pq.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_JdNZ8pq.webp",
             "width": 100,
             "height": 40
         }
@@ -48,8 +48,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_m1Symmo.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_m1Symmo.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_m1Symmo.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_m1Symmo.webp",
             "width": 100,
             "height": 68
         }
@@ -67,8 +67,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
             "width": 100,
             "height": 68
         }
@@ -83,8 +83,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_iIlAHIz.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_iIlAHIz.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_iIlAHIz.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_iIlAHIz.webp",
             "width": 100,
             "height": 100
         }
@@ -113,8 +113,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -138,8 +138,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -165,8 +165,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_zRNQgeA.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_zRNQgeA.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_zRNQgeA.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_zRNQgeA.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/author.json
+++ b/etna/api/tests/expected_results/author.json
@@ -33,8 +33,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_ljNBufq.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_ljNBufq.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_ljNBufq.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_ljNBufq.webp",
             "width": 100,
             "height": 68
         }
@@ -49,8 +49,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_g9tHw4i.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_g9tHw4i.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_g9tHw4i.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_g9tHw4i.webp",
             "width": 100,
             "height": 100
         }
@@ -96,8 +96,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_nJ9965Y.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_nJ9965Y.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_nJ9965Y.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_nJ9965Y.webp",
             "width": 100,
             "height": 100
         }
@@ -112,8 +112,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80_WHn2XPR.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80_WHn2XPR.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60_WHn2XPR.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60_WHn2XPR.webp",
             "width": 100,
             "height": 100
         }

--- a/etna/api/tests/expected_results/author.json
+++ b/etna/api/tests/expected_results/author.json
@@ -39,22 +39,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 10,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_UkpcToZ.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_UkpcToZ.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_ZHjzsGF.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_ZHjzsGF.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 10,
         "title": "An image",
@@ -93,8 +77,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/authors.json
+++ b/etna/api/tests/expected_results/authors.json
@@ -33,8 +33,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_28UNLbC.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_28UNLbC.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_28UNLbC.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_28UNLbC.webp",
             "width": 100,
             "height": 68
         }
@@ -49,8 +49,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_52SwDTo.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_52SwDTo.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_52SwDTo.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_52SwDTo.webp",
             "width": 100,
             "height": 100
         }

--- a/etna/api/tests/expected_results/authors.json
+++ b/etna/api/tests/expected_results/authors.json
@@ -39,22 +39,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 8,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_ezPcrol.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_ezPcrol.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_UAsVaAN.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_UAsVaAN.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 8,
         "title": "An image",
@@ -91,8 +75,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -108,8 +92,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 100
                 }
@@ -124,8 +108,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 100
                 }

--- a/etna/api/tests/expected_results/early_modern.json
+++ b/etna/api/tests/expected_results/early_modern.json
@@ -32,8 +32,8 @@
             "height": 40
         },
         "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_VQVfGTV.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_VQVfGTV.webp",
+            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_VQVfGTV.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_VQVfGTV.webp",
             "width": 100,
             "height": 40
         }
@@ -48,8 +48,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_XBKOSWE.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_XBKOSWE.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_XBKOSWE.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_XBKOSWE.webp",
             "width": 100,
             "height": 68
         }
@@ -67,8 +67,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
             "width": 100,
             "height": 68
         }
@@ -83,8 +83,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_NJOgycO.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_NJOgycO.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_NJOgycO.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_NJOgycO.webp",
             "width": 100,
             "height": 100
         }
@@ -112,8 +112,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -137,8 +137,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -164,8 +164,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_zRNQgeA.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_zRNQgeA.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_zRNQgeA.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_zRNQgeA.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/early_modern.json
+++ b/etna/api/tests/expected_results/early_modern.json
@@ -73,22 +73,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 4,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_0pS7i14.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_0pS7i14.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_a3GVmkk.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_a3GVmkk.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 4,
         "title": "An image",

--- a/etna/api/tests/expected_results/focused_article.json
+++ b/etna/api/tests/expected_results/focused_article.json
@@ -95,8 +95,8 @@
     "custom_warning_text": "",
     "is_newly_published": true,
     "tags": [
-        "Medicine",
-        "Witchcraft"
+        "Witchcraft",
+        "Medicine"
     ],
     "body": [],
     "similar_items": [

--- a/etna/api/tests/expected_results/focused_article.json
+++ b/etna/api/tests/expected_results/focused_article.json
@@ -39,22 +39,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 14,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_Z4wdWCW.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_Z4wdWCW.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_Fh5slYL.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_Fh5slYL.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 14,
         "title": "An image",
@@ -213,8 +197,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/focused_article.json
+++ b/etna/api/tests/expected_results/focused_article.json
@@ -33,8 +33,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_moF3lTy.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_moF3lTy.webp",
             "width": 100,
             "height": 68
         }
@@ -49,8 +49,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_5hj4CDl.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_5hj4CDl.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_5hj4CDl.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_5hj4CDl.webp",
             "width": 100,
             "height": 100
         }
@@ -69,8 +69,8 @@
             "height": 40
         },
         "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_mfg9Hat.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_mfg9Hat.webp",
+            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_mfg9Hat.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_mfg9Hat.webp",
             "width": 100,
             "height": 40
         }
@@ -85,8 +85,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_bj9aWVy.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_bj9aWVy.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_bj9aWVy.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_bj9aWVy.webp",
             "width": 100,
             "height": 68
         }
@@ -117,8 +117,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -145,8 +145,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -171,8 +171,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -214,8 +214,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_d2IUyJ1.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_d2IUyJ1.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_d2IUyJ1.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_d2IUyJ1.webp",
                     "width": 100,
                     "height": 100
                 }
@@ -230,8 +230,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80_igefotD.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80_igefotD.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60_igefotD.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60_igefotD.webp",
                     "width": 100,
                     "height": 100
                 }

--- a/etna/api/tests/expected_results/focused_article.json
+++ b/etna/api/tests/expected_results/focused_article.json
@@ -95,8 +95,8 @@
     "custom_warning_text": "",
     "is_newly_published": true,
     "tags": [
-        "Witchcraft",
-        "Medicine"
+        "Medicine",
+        "Witchcraft"
     ],
     "body": [],
     "similar_items": [

--- a/etna/api/tests/expected_results/highlight_gallery.json
+++ b/etna/api/tests/expected_results/highlight_gallery.json
@@ -33,8 +33,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_zRNQgeA.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_zRNQgeA.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_zRNQgeA.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_zRNQgeA.webp",
             "width": 100,
             "height": 68
         }
@@ -49,8 +49,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_4qVjMdZ.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_4qVjMdZ.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_4qVjMdZ.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_4qVjMdZ.webp",
             "width": 100,
             "height": 100
         }
@@ -77,8 +77,8 @@
                 "height": 68
             },
             "webp": {
-                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
-                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
+                "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
+                "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
                 "width": 100,
                 "height": 68
             }
@@ -165,8 +165,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_EW7Ow5o.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_EW7Ow5o.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -191,8 +191,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_hHTWoNv.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_hHTWoNv.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/highlight_gallery.json
+++ b/etna/api/tests/expected_results/highlight_gallery.json
@@ -102,12 +102,6 @@
                     "width": 100,
                     "height": 100
                 },
-                "png": {
-                    "url": "/media/images/example.max-1024x1024.format-png.png",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/example.max-1024x1024.format-png.png",
-                    "width": 100,
-                    "height": 100
-                },
                 "transcript": {
                     "heading": "Transcript",
                     "text": "<p>Transcript</p>"

--- a/etna/api/tests/expected_results/highlight_gallery.json
+++ b/etna/api/tests/expected_results/highlight_gallery.json
@@ -39,22 +39,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 16,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_t8sn6ar.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_t8sn6ar.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_xfOqzM7.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_xfOqzM7.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 16,
         "title": "An image",
@@ -113,8 +97,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/example_E1PUN8.max-1024x1024.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/example_E1PUN8.max-1024x1024.format-webp.webpquality-80.webp",
+                    "url": "/media/images/example_E1PUN8.max-1024x1024.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/example_E1PUN8.max-1024x1024.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 100
                 },
@@ -154,8 +138,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/pages.json
+++ b/etna/api/tests/expected_results/pages.json
@@ -29,8 +29,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -53,8 +53,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -78,8 +78,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -102,8 +102,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -126,8 +126,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -150,8 +150,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -167,8 +167,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 100
                 }
@@ -183,8 +183,8 @@
                     "height": 100
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-128x128.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 100
                 }
@@ -207,8 +207,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -231,8 +231,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }
@@ -256,8 +256,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/api/tests/expected_results/postwar.json
+++ b/etna/api/tests/expected_results/postwar.json
@@ -73,22 +73,6 @@
             "height": 68
         }
     },
-    "teaser_image_large": {
-        "id": 6,
-        "title": "An image",
-        "jpeg": {
-            "url": "/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_C6if4E3.jpg",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-1200x480.format-jpeg.jpegquality-60_C6if4E3.jpg",
-            "width": 100,
-            "height": 40
-        },
-        "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_SD5KpRM.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_SD5KpRM.webp",
-            "width": 100,
-            "height": 40
-        }
-    },
     "teaser_image_square": {
         "id": 6,
         "title": "An image",

--- a/etna/api/tests/expected_results/postwar.json
+++ b/etna/api/tests/expected_results/postwar.json
@@ -32,8 +32,8 @@
             "height": 40
         },
         "webp": {
-            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_oHYAsUO.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-80_oHYAsUO.webp",
+            "url": "/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_oHYAsUO.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/examp.2e16d0ba.fill-1200x480.format-webp.webpquality-60_oHYAsUO.webp",
             "width": 100,
             "height": 40
         }
@@ -48,8 +48,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_ls5YpjY.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_ls5YpjY.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_ls5YpjY.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_ls5YpjY.webp",
             "width": 100,
             "height": 68
         }
@@ -67,8 +67,8 @@
             "height": 68
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_yuGViLV.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_yuGViLV.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_yuGViLV.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_yuGViLV.webp",
             "width": 100,
             "height": 68
         }
@@ -83,8 +83,8 @@
             "height": 100
         },
         "webp": {
-            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_iXmD76N.webp",
-            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-80_iXmD76N.webp",
+            "url": "/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_iXmD76N.webp",
+            "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-512x512.format-webp.webpquality-60_iXmD76N.webp",
             "width": 100,
             "height": 100
         }
@@ -112,8 +112,8 @@
                     "height": 68
                 },
                 "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-80_q1PKELE.webp",
+                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
+                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60_q1PKELE.webp",
                     "width": 100,
                     "height": 68
                 }

--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -776,7 +776,7 @@ class RecordArticlePage(
             APIField("promoted_links"),
             APIField(
                 "intro_image",
-                serializer=ImageSerializer(rendition_size="fill-512x512"),
+                serializer=ImageSerializer(rendition_size="width-400"),
             ),
         ]
         + TopicalPageMixin.api_fields

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -772,9 +772,7 @@ class TopicalPageMixin:
 
 
 class HighlightSerializer(serializers.ModelSerializer):
-    image = HighlightImageSerializer(
-        rendition_size="max-1024x1024", additional_formats=["png"]
-    )
+    image = HighlightImageSerializer(rendition_size="max-1024x1024")
 
     class Meta:
         model = Highlight

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -794,7 +794,7 @@ class HighlightCardSerializer(serializers.Serializer):
 
     rendition_size = "fill-600x400"
     jpeg_quality = 60
-    webp_quality = 80
+    webp_quality = 60
     additional_formats = []
 
     def to_representation(self, value):

--- a/etna/core/blocks/image.py
+++ b/etna/core/blocks/image.py
@@ -32,7 +32,7 @@ class APIImageChooserBlock(ImageChooserBlock):
         help_text=None,
         rendition_size="fill-600x400",
         jpeg_quality=60,
-        webp_quality=80,
+        webp_quality=60,
         **kwargs,
     ):
         self.jpeg_quality = jpeg_quality

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -166,10 +166,6 @@ class BasePage(MetadataPageMixin, DataLayerMixin, Page, HeadlessPreviewMixin):
             serializer=ImageSerializer("fill-600x400"),
         ),
         APIField(
-            "teaser_image_large",
-            serializer=ImageSerializer("fill-1200x480", source="teaser_image"),
-        ),
-        APIField(
             "teaser_image_square",
             serializer=ImageSerializer("fill-512x512", source="teaser_image"),
         ),

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -17,7 +17,7 @@ from wagtail.images import get_image_model_string
 from wagtail.models import Page
 from wagtail.search import index
 
-from wagtail_headless_preview.models import HeadlessMixin
+from wagtail_headless_preview.models import HeadlessPreviewMixin
 from wagtailmetadata.models import MetadataPageMixin
 
 from etna.analytics.mixins import DataLayerMixin
@@ -40,7 +40,7 @@ options.DEFAULT_NAMES = options.DEFAULT_NAMES + ("verbose_name_public",)
 
 @method_decorator(apply_default_vary_headers, name="serve")
 @method_decorator(apply_default_cache_control, name="serve")
-class BasePage(MetadataPageMixin, DataLayerMixin, HeadlessMixin, Page):
+class BasePage(MetadataPageMixin, DataLayerMixin, HeadlessPreviewMixin, Page):
     """
     An abstract base model that is used for all Page models within
     the project. Any common fields, Wagtail overrides or custom

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -17,7 +17,7 @@ from wagtail.images import get_image_model_string
 from wagtail.models import Page
 from wagtail.search import index
 
-from wagtail_headless_preview.models import HeadlessPreviewMixin
+from wagtail_headless_preview.models import HeadlessMixin
 from wagtailmetadata.models import MetadataPageMixin
 
 from etna.analytics.mixins import DataLayerMixin
@@ -40,7 +40,7 @@ options.DEFAULT_NAMES = options.DEFAULT_NAMES + ("verbose_name_public",)
 
 @method_decorator(apply_default_vary_headers, name="serve")
 @method_decorator(apply_default_cache_control, name="serve")
-class BasePage(MetadataPageMixin, DataLayerMixin, Page, HeadlessPreviewMixin):
+class BasePage(MetadataPageMixin, DataLayerMixin, HeadlessMixin, Page):
     """
     An abstract base model that is used for all Page models within
     the project. Any common fields, Wagtail overrides or custom

--- a/etna/core/serializers/images.py
+++ b/etna/core/serializers/images.py
@@ -28,7 +28,7 @@ class ImageSerializer(Serializer):
         self,
         rendition_size="fill-600x400",
         jpeg_quality=60,
-        webp_quality=80,
+        webp_quality=60,
         additional_formats=[],
         *args,
         **kwargs,


### PR DESCRIPTION
- Update intro image size in `RecordArticlePage`
- Change all default `webp_quality` from `80` to `60`
- Add `HeadlessMixin` to `BasePage` and remove `HeadlessPreviewMixin`
- Removed unused `teaser_image_large`