### PR TITLE
API sibling pages

### DIFF
--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -46,7 +46,7 @@ class SiblingOfFilter(BaseFilterBackend):
                 else:
                     raise BadRequestError("sibling_of must be a positive integer")
             except Page.DoesNotExist:
-                raise BadRequestError("parent page doesn't exist")
+                raise BadRequestError("parent_page or grandparent_page page don't exist")
             queryset = queryset.child_of(grandparent_page)
             queryset._filtered_by_grandchild_of = grandparent_page
         return queryset

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -46,7 +46,9 @@ class SiblingOfFilter(BaseFilterBackend):
                 else:
                     raise BadRequestError("sibling_of must be a positive integer")
             except Page.DoesNotExist:
-                raise BadRequestError("parent_page or grandparent_page page don't exist")
+                raise BadRequestError(
+                    "parent_page or grandparent_page page don't exist"
+                )
             queryset = queryset.child_of(grandparent_page)
             queryset._filtered_by_grandchild_of = grandparent_page
         return queryset


### PR DESCRIPTION
Add a query parameter `sibling_of` (e.g. http://localhost:8000/api/v2/pages/?sibling_of=26) to allow querying of pages at the same level.

This will help when we need to add other pages in a section to the sidebar (e.g. the right column of https://www.nationalarchives.gov.uk/about/our-role/what-we-do/ - "Also in Our role")