### PR TITLE
CHORE: Remove `version` from docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   web:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   db:


### PR DESCRIPTION
When running `fab build` etc on my new laptop, Docker informed me that the use of `version` is no longer needed. Tested on my old laptop and it also ran fine, so it seems like `version` is redundant on both new and old versions of Docker.

This PR removes `version` from both `docker-compose.yml` files in the project.