### PR TITLE
Add setting for WAGTAILAPI_LIMIT_MAX

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -460,3 +460,5 @@ if redis_url := os.getenv("REDIS_URL"):
             "KEY_PREFIX": "renditions",
         },
     }
+
+WAGTAILAPI_LIMIT_MAX = int(os.getenv("WAGTAILAPI_LIMIT_MAX", "0")) or None


### PR DESCRIPTION
Allow the frontend to query more child pages in a single request for things like the sitemap.

At the moment, a maximum of 20 pages can be returned at once.

E.g. http://localhost:8000/api/v2/pages/?limit=100