### PR TITLE
EDEV-36: RecordSerializer

### DIFF
--- a/etna/articles/models.py
+++ b/etna/articles/models.py
@@ -45,6 +45,7 @@ from etna.core.serializers import (
 from etna.core.utils import skos_id_from_text
 from etna.people.models import AuthorPageMixin
 from etna.records.fields import RecordField
+from etna.records.serializers import RecordSerializer
 
 from .blocks import ArticlePageStreamBlock
 
@@ -755,7 +756,7 @@ class RecordArticlePage(
             APIField("type_label"),
             APIField("date_text"),
             APIField("about", serializer=RichTextSerializer()),
-            APIField("record"),
+            APIField("record", serializer=RecordSerializer()),
             APIField("gallery_heading"),
             APIField("gallery_items", serializer=GallerySerializer(many=True)),
             APIField("image_library_link"),

--- a/etna/images/models.py
+++ b/etna/images/models.py
@@ -10,6 +10,7 @@ from wagtail.search import index
 
 from etna.core.serializers import RichTextSerializer
 from etna.records.fields import RecordField
+from etna.records.serializers import RecordSerializer
 
 DEFAULT_SENSITIVE_IMAGE_WARNING = (
     "This image contains content which some people may find offensive or distressing."
@@ -144,7 +145,7 @@ class CustomImage(ClusterableModel, AbstractImage):
         APIField("translation_heading"),
         APIField("translation", serializer=RichTextSerializer()),
         APIField("record_dates"),
-        APIField("record"),
+        APIField("record", serializer=RecordSerializer()),
     ]
 
     @property

--- a/etna/records/blocks.py
+++ b/etna/records/blocks.py
@@ -105,6 +105,13 @@ class RecordChooserBlock(blocks.ChooserBlock):
         """This overrides the extract_references function from ChooserBlock to prevent
         Wagtail's reference index from rebuilding this block"""
         return []
+    
+    def get_api_representation(self, value, context=None):
+        return {
+            "title": value.summary_title,
+            "iaid": value.iaid,
+            "reference_number": value.reference_number,
+        }
 
     class Meta:
         icon = "archive"

--- a/etna/records/blocks.py
+++ b/etna/records/blocks.py
@@ -105,7 +105,7 @@ class RecordChooserBlock(blocks.ChooserBlock):
         """This overrides the extract_references function from ChooserBlock to prevent
         Wagtail's reference index from rebuilding this block"""
         return []
-    
+
     def get_api_representation(self, value, context=None):
         return {
             "title": value.summary_title,

--- a/etna/records/serializers.py
+++ b/etna/records/serializers.py
@@ -3,10 +3,8 @@ from rest_framework import serializers
 
 class RecordSerializer(serializers.Serializer):
     def to_representation(self, instance):
-        if instance:
-            return {
-                "title": instance.summary_title,
-                "iaid": instance.iaid,
-                "reference_number": instance.reference_number,
-            }
-        return None
+        return {
+            "title": instance.summary_title,
+            "iaid": instance.iaid,
+            "reference_number": instance.reference_number,
+        }

--- a/etna/records/serializers.py
+++ b/etna/records/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+
+
+class RecordSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        if instance:
+            return {
+                "title": instance.summary_title,
+                "iaid": instance.iaid,
+                "reference_number": instance.reference_number,
+            }
+        return None


### PR DESCRIPTION
Ticket URL: [EDEV-36]

## About these changes

This adds a `RecordSerializer` which serializes `RecordFields` and adds an API representation for `RecordChooserBlocks`.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
