### PR TITLE
EDEV-126:increase disk space on psh

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -22,7 +22,7 @@ variables:
     POETRY_VERSION: 1.8.1
 
 # The size of the persistent disk of the application (in MB).
-disk: 4096
+disk: 5120
 
 # The relationships of the application with services or other applications.
 #


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/EDEV-126

## About these changes

To Fix: Warning: less than 20% disk space in National Archives - Etna Wagtail / main / app

## How to check these changes

Logon to psh and review persistent disk metric

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
