### PR TITLE
EDEV-126:adjust/increase disk space psh

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -22,7 +22,7 @@ variables:
     POETRY_VERSION: 1.8.1
 
 # The size of the persistent disk of the application (in MB).
-disk: 4096
+disk: 5120
 
 # The relationships of the application with services or other applications.
 #

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -22,7 +22,7 @@ variables:
     POETRY_VERSION: 1.8.1
 
 # The size of the persistent disk of the application (in MB).
-disk: 5120
+disk: 4608
 
 # The relationships of the application with services or other applications.
 #


### PR DESCRIPTION
Ticket URL: https://national-archives.atlassian.net/browse/EDEV-126

## About these changes

To Fix: 
1.Warning: less than 20% disk space in National Archives - Etna Wagtail / main / app
2. E: Error: Resources exceeding plan limit; disk: 5632.00MB > 5120.00MB; try removing a service, or add more storage to your plan

`4608+512(db) = 5120`

## How to check these changes

Where possible, provide guidance to help your reviewer

## Before assigning to reviewer, please make sure you have

- [ ] Checked things thoroughly before handing over to reviewer
- [ ] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [ ] Ensured that PR includes only commits relevant to the ticket
- [ ] Waited for all CI jobs to pass before requesting a review
- [ ] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
