### PR TITLE
Blog API: `author_view`

### DIFF
--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -329,27 +329,30 @@ class BlogPostsAPIViewSet(CustomPagesAPIViewSet):
             for year in sorted(years)
         ]
         return Response(years_count)
-    
+
     def author_view(self, request):
         queryset = self.get_queryset()
         self.check_query_parameters(queryset)
         queryset = self.filter_queryset(queryset)
         authors = set(queryset.values_list("author_tags__author"))
-        print("AUTHORS", authors)
+        serializer = DefaultPageSerializer()
         authors_count = []
         for author in authors:
             if author[0] is not None:
-                print("AUTHOR", author)
-                author_item = queryset.filter(author_tags__author=author).first().author_tags.filter(author=author).first().author
-                print("AUTHOR ITEM", author_item)
+                author_item = (
+                    queryset.filter(author_tags__author=author)
+                    .first()
+                    .author_tags.filter(author=author)
+                    .first()
+                    .author
+                )
                 authors_count.append(
                     {
-                        "author": author_item.title,
+                        "author": serializer.to_representation(author_item),
                         "posts": queryset.filter(author_tags__author=author).count(),
                     }
                 )
         return Response(authors_count)
-
 
     @classmethod
     def get_urlpatterns(cls):
@@ -359,7 +362,7 @@ class BlogPostsAPIViewSet(CustomPagesAPIViewSet):
         return [
             path("", cls.as_view({"get": "listing_view"}), name="listing"),
             path("count/", cls.as_view({"get": "count_view"}), name="count"),
-            path("author/", cls.as_view({"get": "author_view"}), name="author"),
+            path("authors/", cls.as_view({"get": "author_view"}), name="authors"),
         ]
 
 

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -352,7 +352,7 @@ class BlogPostsAPIViewSet(CustomPagesAPIViewSet):
                         "posts": queryset.filter(author_tags__author=author).count(),
                     }
                 )
-        return Response(authors_count)
+        return Response(sorted(authors_count, key=lambda x: x["posts"], reverse=True))
 
     @classmethod
     def get_urlpatterns(cls):

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -329,6 +329,27 @@ class BlogPostsAPIViewSet(CustomPagesAPIViewSet):
             for year in sorted(years)
         ]
         return Response(years_count)
+    
+    def author_view(self, request):
+        queryset = self.get_queryset()
+        self.check_query_parameters(queryset)
+        queryset = self.filter_queryset(queryset)
+        authors = set(queryset.values_list("author_tags__author"))
+        print("AUTHORS", authors)
+        authors_count = []
+        for author in authors:
+            if author[0] is not None:
+                print("AUTHOR", author)
+                author_item = queryset.filter(author_tags__author=author).first().author_tags.filter(author=author).first().author
+                print("AUTHOR ITEM", author_item)
+                authors_count.append(
+                    {
+                        "author": author_item.title,
+                        "posts": queryset.filter(author_tags__author=author).count(),
+                    }
+                )
+        return Response(authors_count)
+
 
     @classmethod
     def get_urlpatterns(cls):
@@ -338,6 +359,7 @@ class BlogPostsAPIViewSet(CustomPagesAPIViewSet):
         return [
             path("", cls.as_view({"get": "listing_view"}), name="listing"),
             path("count/", cls.as_view({"get": "count_view"}), name="count"),
+            path("author/", cls.as_view({"get": "author_view"}), name="author"),
         ]
 
 


### PR DESCRIPTION
## About these changes

This adds an `author_view` endpoint, which allows us to get a list of authors (and their details) and how many blog posts they are marked as an author on.
![image](https://github.com/user-attachments/assets/aa776ba3-5ba0-4389-b8b6-53f57ce57863)

## How to check these changes

Go to http://localhost:8000/api/v2/blog_posts/authors/ and see the data

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
