### PR TITLE
Replace relative imports for imports outside of the immediate module

### DIFF
--- a/etna/alerts/tests.py
+++ b/etna/alerts/tests.py
@@ -2,10 +2,11 @@ from django.test import TestCase
 
 from wagtail.models import Site
 
-from ..alerts.models import Alert
-from ..alerts.templatetags import alert_tags
-from ..collections.models import ExplorerIndexPage, TopicExplorerPage
-from ..home.models import HomePage
+from etna.collections.models import ExplorerIndexPage, TopicExplorerPage
+from etna.home.models import HomePage
+
+from .models import Alert
+from .templatetags import alert_tags
 
 
 def rich_text_msg(level):

--- a/etna/articles/blocks.py
+++ b/etna/articles/blocks.py
@@ -12,9 +12,8 @@ from etna.core.blocks import (
     SectionDepthAwareStructBlock,
     SubHeadingBlock,
 )
-
-from ..media.blocks import MediaBlock
-from ..records.blocks import RecordLinksBlock
+from etna.media.blocks import MediaBlock
+from etna.records.blocks import RecordLinksBlock
 
 
 class SectionContentBlock(blocks.StreamBlock):

--- a/etna/blog/blocks.py
+++ b/etna/blog/blocks.py
@@ -16,8 +16,7 @@ from etna.core.blocks import (
     SubHeadingBlock,
     YouTubeBlock,
 )
-
-from ..media.blocks import MediaBlock
+from etna.media.blocks import MediaBlock
 
 
 class SectionContentBlock(blocks.StreamBlock):

--- a/etna/ciim/tests/test_models.py
+++ b/etna/ciim/tests/test_models.py
@@ -3,8 +3,9 @@ from django.test import SimpleTestCase, override_settings
 
 import responses
 
-from ...records.api import get_records_client
-from ...records.models import Record
+from etna.records.api import get_records_client
+from etna.records.models import Record
+
 from ..exceptions import ClientAPIError, DoesNotExist, MultipleObjectsReturned
 from .factories import create_record, create_search_response
 

--- a/etna/collections/models.py
+++ b/etna/collections/models.py
@@ -22,19 +22,19 @@ from wagtail.search import index
 
 from rest_framework import serializers
 
-from etna.core.serializers import (
-    DefaultPageSerializer,
-    HighlightImageSerializer,
-    ImageSerializer,
-)
-
-from ..core.models import (
+from etna.core.models import (
     BasePage,
     BasePageWithRequiredIntro,
     ContentWarningMixin,
     RequiredHeroImageMixin,
 )
-from ..core.utils import skos_id_from_text
+from etna.core.serializers import (
+    DefaultPageSerializer,
+    HighlightImageSerializer,
+    ImageSerializer,
+)
+from etna.core.utils import skos_id_from_text
+
 from .blocks import (
     ExplorerIndexPageStreamBlock,
     FeaturedArticlesBlock,

--- a/etna/collections/tests/test_views.py
+++ b/etna/collections/tests/test_views.py
@@ -6,9 +6,8 @@ from wagtail.test.utils import WagtailPageTestCase
 
 import responses
 
+from etna.ciim.tests.factories import create_record, create_response
 from etna.core.test_utils import prevent_request_warnings
-
-from ...ciim.tests.factories import create_record, create_response
 
 
 class TestRecordChooseView(WagtailPageTestCase):

--- a/etna/core/tests/test_decorators.py
+++ b/etna/core/tests/test_decorators.py
@@ -6,7 +6,7 @@ from wagtail.test.utils import WagtailTestUtils
 
 import responses
 
-from ...ciim.tests.factories import create_record, create_response
+from etna.ciim.tests.factories import create_record, create_response
 
 CONDITIONALLY_PROTECTED_URLS = (
     reverse_lazy("search-catalogue"),

--- a/etna/generic_pages/blocks.py
+++ b/etna/generic_pages/blocks.py
@@ -27,9 +27,8 @@ from etna.core.blocks import (
     WarningTextBlock,
     YouTubeBlock,
 )
-
-from ..media.blocks import MediaBlock
-from ..records.blocks import RecordLinksBlock
+from etna.media.blocks import MediaBlock
+from etna.records.blocks import RecordLinksBlock
 
 
 class SectionContentBlock(blocks.StreamBlock):

--- a/etna/people/tests/test_models.py
+++ b/etna/people/tests/test_models.py
@@ -2,8 +2,9 @@ from django.test import TestCase
 
 from wagtail.models import Site
 
-from ...articles.models import FocusedArticlePage
-from ...images.models import CustomImage
+from etna.articles.models import FocusedArticlePage
+from etna.images.models import CustomImage
+
 from ..models import AuthorTag, PeopleIndexPage, PersonPage
 
 

--- a/etna/records/blocks.py
+++ b/etna/records/blocks.py
@@ -6,9 +6,9 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.api import APIField
 
+from etna.ciim.exceptions import ClientAPIError
 from etna.core.blocks.image import APIImageChooserBlock
 
-from ..ciim.exceptions import ClientAPIError
 from .api import records_client
 
 

--- a/etna/records/models.py
+++ b/etna/records/models.py
@@ -14,14 +14,14 @@ from django.utils.safestring import mark_safe
 
 from pyquery import PyQuery as pq
 
-from ..analytics.mixins import DataLayerMixin
-from ..ciim.constants import (
+from etna.analytics.mixins import DataLayerMixin
+from etna.ciim.constants import (
     ARCHIVE_NRA_RECORDS_COLLECTION,
     ARCHIVE_RECORD_CREATORS_COLLECTION,
     TNA_URLS,
 )
-from ..ciim.models import APIModel
-from ..ciim.utils import (
+from etna.ciim.models import APIModel
+from etna.ciim.utils import (
     NOT_PROVIDED,
     ValueExtractionError,
     extract,
@@ -30,13 +30,14 @@ from ..ciim.utils import (
     format_link,
     strip_html,
 )
-from ..records.classes import (
+from etna.records.classes import (
     AccessionsInfo,
     ArchiveCollections,
     CollectionInfo,
     ContactInfo,
     FurtherInfo,
 )
+
 from .converters import IAIDConverter
 
 logger = logging.getLogger(__name__)

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -1,7 +1,8 @@
 from django import template
 from django.conf import settings
 
-from ...ciim.constants import TNA_URLS, LevelKeys, NonTNALevelKeys
+from etna.ciim.constants import TNA_URLS, LevelKeys, NonTNALevelKeys
+
 from ..field_labels import FIELD_LABELS
 from ..models import Record
 

--- a/etna/records/tests/test_blocks.py
+++ b/etna/records/tests/test_blocks.py
@@ -9,10 +9,9 @@ from wagtail.test.utils.form_data import nested_form_data, rich_text, streamfiel
 
 import responses
 
+from etna.articles.models import ArticleIndexPage, ArticlePage
+from etna.ciim.tests.factories import create_record, create_response
 from etna.images.models import CustomImage
-
-from ...articles.models import ArticleIndexPage, ArticlePage
-from ...ciim.tests.factories import create_record, create_response
 
 TEST_RECORD_DATA = {
     "iaid": "C123456",

--- a/etna/records/tests/test_models.py
+++ b/etna/records/tests/test_models.py
@@ -10,8 +10,9 @@ from django.utils.safestring import SafeString
 
 import responses
 
-from ...ciim.tests.factories import create_media, create_record, create_response
-from ...ciim.utils import ValueExtractionError
+from etna.ciim.tests.factories import create_media, create_record, create_response
+from etna.ciim.utils import ValueExtractionError
+
 from ..api import get_records_client
 from ..models import Image, Record
 

--- a/etna/records/tests/test_views.py
+++ b/etna/records/tests/test_views.py
@@ -13,10 +13,9 @@ from wagtail.test.utils import WagtailTestUtils
 
 import responses
 
+from etna.ciim.tests.factories import create_media, create_record, create_response
 from etna.core.test_utils import prevent_request_warnings
 from etna.records.views.records import SEARCH_URL_RETAIN_DELTA
-
-from ...ciim.tests.factories import create_media, create_record, create_response
 
 User = get_user_model()
 

--- a/etna/records/transforms.py
+++ b/etna/records/transforms.py
@@ -1,4 +1,4 @@
-from ..ciim.utils import pluck
+from etna.ciim.utils import pluck
 
 
 def transform_image_result(result):

--- a/etna/records/views/choosers.py
+++ b/etna/records/views/choosers.py
@@ -4,9 +4,10 @@ from django.urls import re_path
 
 from generic_chooser.views import BaseChosenView, ChooserMixin, ChooserViewSet
 
-from ...ciim.client import Stream
-from ...ciim.exceptions import ClientAPIError
-from ...ciim.paginator import APIPaginator
+from etna.ciim.client import Stream
+from etna.ciim.exceptions import ClientAPIError
+from etna.ciim.paginator import APIPaginator
+
 from ..api import records_client
 from ..models import Record
 

--- a/etna/records/views/images.py
+++ b/etna/records/views/images.py
@@ -3,8 +3,9 @@ from django.http import FileResponse
 from django.shortcuts import Http404, render
 from django.views.decorators.cache import cache_control
 
-from ...ciim.exceptions import ClientAPIError, DoesNotExist
-from ...ciim.utils import convert_sort_key_to_index
+from etna.ciim.exceptions import ClientAPIError, DoesNotExist
+from etna.ciim.utils import convert_sort_key_to_index
+
 from ..api import records_client
 from ..models import Image
 

--- a/etna/records/views/records.py
+++ b/etna/records/views/records.py
@@ -6,9 +6,10 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 
-from ...ciim.constants import TNA_URLS
-from ...ciim.exceptions import DoesNotExist
-from ...ciim.paginator import APIPaginator
+from etna.ciim.constants import TNA_URLS
+from etna.ciim.exceptions import DoesNotExist
+from etna.ciim.paginator import APIPaginator
+
 from ..api import records_client
 
 SEARCH_URL_RETAIN_DELTA = timezone.timedelta(hours=48)

--- a/etna/search/forms.py
+++ b/etna/search/forms.py
@@ -6,18 +6,17 @@ from django.utils.functional import cached_property
 
 from wagtail.models import get_page_models
 
-from etna.core.fields import END_OF_MONTH, DateInputField
-from etna.core.models import BasePage
-
-from ..ciim.client import SortBy, SortOrder
-from ..ciim.constants import (
+from etna.ciim.client import SortBy, SortOrder
+from etna.ciim.constants import (
     CATALOGUE_BUCKETS,
     COLLECTION_CHOICES,
     LEVEL_CHOICES,
     TYPE_CHOICES,
     WEBSITE_BUCKETS,
 )
-from ..collections.models import TimePeriodExplorerPage, TopicExplorerPage
+from etna.collections.models import TimePeriodExplorerPage, TopicExplorerPage
+from etna.core.fields import END_OF_MONTH, DateInputField
+from etna.core.models import BasePage
 
 
 class SearchFilterCheckboxList(forms.widgets.CheckboxSelectMultiple):

--- a/etna/search/tests/test_views.py
+++ b/etna/search/tests/test_views.py
@@ -11,13 +11,13 @@ from wagtail.test.utils import WagtailTestUtils
 
 import responses
 
+from etna.articles.factories import ArticlePageFactory
+from etna.articles.models import ArticleIndexPage, ArticlePage
 from etna.ciim.constants import DEFAULT_AGGREGATIONS, Aggregation, Bucket, BucketList
+from etna.ciim.tests.factories import create_response, create_search_response
 from etna.core.test_utils import prevent_request_warnings
+from etna.home.models import HomePage
 
-from ...articles.factories import ArticlePageFactory
-from ...articles.models import ArticleIndexPage, ArticlePage
-from ...ciim.tests.factories import create_response, create_search_response
-from ...home.models import HomePage
 from ..forms import CatalogueSearchForm
 from ..views import CatalogueSearchView
 

--- a/etna/search/views.py
+++ b/etna/search/views.py
@@ -20,10 +20,10 @@ from wagtail.models import Page
 from wagtail.query import PageQuerySet
 from wagtail.search.backends.database.postgres.postgres import PostgresSearchResults
 
-from ..analytics.mixins import SearchDataLayerMixin
-from ..articles.models import ArticleIndexPage, ArticlePage
-from ..ciim.client import Aggregation, SortBy, SortOrder, Stream, Template
-from ..ciim.constants import (
+from etna.analytics.mixins import SearchDataLayerMixin
+from etna.articles.models import ArticleIndexPage, ArticlePage
+from etna.ciim.client import Aggregation, SortBy, SortOrder, Stream, Template
+from etna.ciim.constants import (
     CATALOGUE_BUCKETS,
     CLOSURE_CLOSED_STATUS,
     FEATURED_BUCKETS,
@@ -34,9 +34,9 @@ from ..ciim.constants import (
     Display,
     SearchTabs,
 )
-from ..ciim.paginator import APIPaginator
-from ..ciim.utils import underscore_to_camelcase
-from ..collections.models import (
+from etna.ciim.paginator import APIPaginator
+from etna.ciim.utils import underscore_to_camelcase
+from etna.collections.models import (
     ExplorerIndexPage,
     PageTimePeriod,
     PageTopic,
@@ -45,8 +45,9 @@ from ..collections.models import (
     TopicExplorerIndexPage,
     TopicExplorerPage,
 )
-from ..home.models import HomePage
-from ..records.api import records_client
+from etna.home.models import HomePage
+from etna.records.api import records_client
+
 from .forms import (
     CatalogueSearchForm,
     FeaturedSearchForm,


### PR DESCRIPTION
Following a discussion on the developer catch-up, we decided it would be good practice to only use relative imports within the immediate module, e.g.

in etna.articles.blocks.py, this is fine:
`from .models import ArticlePage`

but we shouldn't use them like this:
`from ..media.blocks import MediaBlock`

and should instead be writing:
`from etna.media.blocks import MediaBlock`

It adds unnecessary additional cognitive load. The two apps are not immediately related to one another - `etna.media` can exist without `etna.articles` (in theory). So there is a chance that the path may change. It also makes it easier to trace where you are importing things from, and makes it clear to a developer trying to understand your code.

### [**_"Explicit is better than implicit."_**](https://peps.python.org/pep-0020/#the-zen-of-python)