### PR TITLE
Add last published to pages endpoint and simplify depth field

### DIFF
--- a/etna/api/tests/expected_results/article.json
+++ b/etna/api/tests/expected_results/article.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-01T00:00:00Z",
         "url": "/article_index/article/",
+        "depth": 4,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 12,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 4
+        "twitter_og_image": null
     },
     "title": "article",
     "global_alert": null,
@@ -331,6 +331,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": true
         }
     ],
@@ -358,7 +359,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         }
     ],
     "time_periods": [
@@ -384,7 +386,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         },
         {
             "id": POSTWAR_ID,
@@ -408,7 +411,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         }
     ]
 }

--- a/etna/api/tests/expected_results/article_index.json
+++ b/etna/api/tests/expected_results/article_index.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-01T00:00:00Z",
         "url": "/article_index/",
+        "depth": 3,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 11,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 3
+        "twitter_og_image": null
     },
     "title": "article_index",
     "global_alert": null,
@@ -92,6 +92,7 @@
                 "height": 68
             }
         },
+        "last_published_at": "2000-01-01T00:00:00Z",
         "is_newly_published": false
     },
     "featured_pages": [
@@ -124,6 +125,7 @@
                                 "height": 68
                             }
                         },
+                        "last_published_at": "2000-01-01T00:00:00Z",
                         "is_newly_published": false
                     },
                     {
@@ -149,6 +151,7 @@
                                 "height": 68
                             }
                         },
+                        "last_published_at": "2000-01-01T00:00:00Z",
                         "is_newly_published": true
                     }
                 ]

--- a/etna/api/tests/expected_results/article_index.json
+++ b/etna/api/tests/expected_results/article_index.json
@@ -151,7 +151,7 @@
                                 "height": 68
                             }
                         },
-                        "last_published_at": "2000-01-01T00:00:00Z",
+                        "last_published_at": "2000-01-02T00:00:00Z",
                         "is_newly_published": true
                     }
                 ]

--- a/etna/api/tests/expected_results/arts.json
+++ b/etna/api/tests/expected_results/arts.json
@@ -139,7 +139,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-01T00:00:00Z",
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": true
         },
         {
@@ -165,7 +165,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-03T00:00:00Z",
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": false
         }
     ],
@@ -193,7 +193,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-02T00:00:00Z",
+            "last_published_at": "2000-01-03T00:00:00Z",
             "highlight_image_count": 1
         }
     ]

--- a/etna/api/tests/expected_results/arts.json
+++ b/etna/api/tests/expected_results/arts.json
@@ -139,7 +139,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-02T00:00:00Z",
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": true
         },
         {
@@ -165,7 +165,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-02T00:00:00Z",
+            "last_published_at": "2000-01-03T00:00:00Z",
             "is_newly_published": false
         }
     ],

--- a/etna/api/tests/expected_results/arts.json
+++ b/etna/api/tests/expected_results/arts.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-01T00:00:00Z",
         "url": "/arts/",
+        "depth": 3,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 2,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 3
+        "twitter_og_image": null
     },
     "title": "arts",
     "hero_image_caption": "<p>Hero image caption</p>",
@@ -139,6 +139,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": true
         },
         {
@@ -164,6 +165,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": false
         }
     ],
@@ -191,6 +193,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "highlight_image_count": 1
         }
     ]

--- a/etna/api/tests/expected_results/author.json
+++ b/etna/api/tests/expected_results/author.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-01T00:00:00Z",
         "url": "/people/author/",
+        "depth": 4,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 10,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 4
+        "twitter_og_image": null
     },
     "title": "author",
     "global_alert": {
@@ -141,6 +141,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": true
         }
     ],

--- a/etna/api/tests/expected_results/early_modern.json
+++ b/etna/api/tests/expected_results/early_modern.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-01T00:00:00Z",
         "url": "/early_modern/",
+        "depth": 3,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 4,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 3
+        "twitter_og_image": null
     },
     "title": "early_modern",
     "hero_image_caption": "<p>Hero image caption</p>",
@@ -138,6 +138,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": true
         },
         {
@@ -163,6 +164,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": false
         }
     ],
@@ -190,6 +192,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-02T00:00:00Z",
             "highlight_image_count": 1
         }
     ],

--- a/etna/api/tests/expected_results/early_modern.json
+++ b/etna/api/tests/expected_results/early_modern.json
@@ -164,7 +164,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-02T00:00:00Z",
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": false
         }
     ],
@@ -192,7 +192,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-02T00:00:00Z",
+            "last_published_at": "2000-01-03T00:00:00Z",
             "highlight_image_count": 1
         }
     ],

--- a/etna/api/tests/expected_results/focused_article.json
+++ b/etna/api/tests/expected_results/focused_article.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-02T00:00:00Z",
         "url": "/article_index/focused_article/",
+        "depth": 4,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 14,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 4
+        "twitter_og_image": null
     },
     "title": "focused_article",
     "global_alert": null,
@@ -144,6 +144,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": false
         }
     ],
@@ -171,7 +172,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         }
     ],
     "time_periods": [
@@ -197,7 +199,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         }
     ],
     "authors": [
@@ -224,6 +227,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "role": "Test Author",
             "image": {
                 "id": 9,

--- a/etna/api/tests/expected_results/highlight_gallery.json
+++ b/etna/api/tests/expected_results/highlight_gallery.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-03T00:00:00Z",
         "url": "/arts/highlight_gallery/",
+        "depth": 4,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 16,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 4
+        "twitter_og_image": null
     },
     "title": "highlight_gallery",
     "global_alert": null,
@@ -94,6 +94,7 @@
                 "height": 68
             }
         },
+        "last_published_at": "2000-01-01T00:00:00Z",
         "is_newly_published": false
     },
     "highlights": [
@@ -175,7 +176,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         }
     ],
     "time_periods": [
@@ -201,7 +203,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         }
     ]
 }

--- a/etna/api/tests/expected_results/pages.json
+++ b/etna/api/tests/expected_results/pages.json
@@ -61,7 +61,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-01T00:00:00Z",
+            "last_published_at": "2000-01-03T00:00:00Z",
             "highlight_image_count": 1
         },
         {
@@ -137,7 +137,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-01T00:00:00Z"
+            "last_published_at": null
         },
         {
             "id": AUTHOR_ID,
@@ -280,7 +280,7 @@
                     "height": 68
                 }
             },
-            "last_published_at": "2000-01-01T00:00:00Z",
+            "last_published_at": "2000-01-02T00:00:00Z",
             "is_newly_published": true
         }
     ]

--- a/etna/api/tests/expected_results/pages.json
+++ b/etna/api/tests/expected_results/pages.json
@@ -10,7 +10,8 @@
             "full_url": "http://localhost/",
             "type_label": null,
             "teaser_text": "",
-            "teaser_image": null
+            "teaser_image": null,
+            "last_published_at": null
         },
         {
             "id": ARTS_ID,
@@ -34,7 +35,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         },
         {
             "id": HIGHLIGHT_GALLERY_ID,
@@ -59,6 +61,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "highlight_image_count": 1
         },
         {
@@ -83,7 +86,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         },
         {
             "id": POSTWAR_ID,
@@ -107,7 +111,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         },
         {
             "id": AUTHOR_INDEX_ID,
@@ -131,7 +136,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         },
         {
             "id": AUTHOR_ID,
@@ -156,6 +162,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "role": "Test Author",
             "image": {
                 "id": 9,
@@ -221,7 +228,8 @@
                     "width": 100,
                     "height": 68
                 }
-            }
+            },
+            "last_published_at": "2000-01-01T00:00:00Z"
         },
         {
             "id": ARTICLE_ID,
@@ -246,6 +254,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": false
         },
         {
@@ -271,6 +280,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": true
         }
     ]

--- a/etna/api/tests/expected_results/people.json
+++ b/etna/api/tests/expected_results/people.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": null,
         "url": "/people/",
+        "depth": 3,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 8,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 3
+        "twitter_og_image": null
     },
     "title": "people",
     "global_alert": {
@@ -98,6 +98,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "role": "Test Author",
             "image": {
                 "id": 9,

--- a/etna/api/tests/expected_results/postwar.json
+++ b/etna/api/tests/expected_results/postwar.json
@@ -22,6 +22,7 @@
         "privacy": "public",
         "last_published_at": "2000-01-01T00:00:00Z",
         "url": "/postwar/",
+        "depth": 3,
         "teaser_text": "Teaser text",
         "teaser_image": {
             "id": 6,
@@ -58,8 +59,7 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null,
-        "depth": 3
+        "twitter_og_image": null
     },
     "title": "postwar",
     "hero_image_caption": "<p>Hero image caption</p>",
@@ -138,6 +138,7 @@
                     "height": 68
                 }
             },
+            "last_published_at": "2000-01-01T00:00:00Z",
             "is_newly_published": false
         }
     ],

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -161,12 +161,8 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
         "privacy",
         "last_published_at",
         "url",
+        "depth",
     ]
-
-    # Add in depth to the list of fields that can be ordered by and filtered to
-    @classmethod
-    def get_meta_fields_names(cls, model):
-        return super().get_meta_fields_names(model) + ["depth"]
 
     def find_object(self, queryset, request):
         site = Site.find_for_request(request)

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -149,6 +149,7 @@ class BasePage(AlertMixin, SocialMixin, DataLayerMixin, HeadlessPreviewMixin, Pa
             "teaser_image",
             serializer=ImageSerializer("fill-600x400"),
         ),
+        APIField("last_published_at"),
     ]
 
     api_fields = AlertMixin.api_fields + [


### PR DESCRIPTION
1. Add `last_published_at` to http://localhost:8000/api/v2/pages/
2. Simplify adding `depth` to API fields still allows ordering by depth: http://localhost:8000/api/v2/pages/?ancestor_of=412&order=depth