### PR TITLE
Restrict document extensions

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -308,7 +308,18 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 WAGTAILDOCS_DOCUMENT_MODEL = "core.CustomDocument"
-WAGTAILDOCS_EXTENSIONS = ["pdf", "xls", "xlsx", "doc", "docx", "xls", "xlsx", "stl", "txt", "csv"]
+WAGTAILDOCS_EXTENSIONS = [
+    "pdf",
+    "xls",
+    "xlsx",
+    "doc",
+    "docx",
+    "xls",
+    "xlsx",
+    "stl",
+    "txt",
+    "csv",
+]
 
 WAGTAILIMAGES_IMAGE_MODEL = "images.CustomImage"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -308,7 +308,7 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 WAGTAILDOCS_DOCUMENT_MODEL = "core.CustomDocument"
-WAGTAILDOCS_EXTENSIONS = ["pdf", "xls", "xlsx", "doc", "docx"]
+WAGTAILDOCS_EXTENSIONS = ["pdf", "xls", "xlsx", "doc", "docx", "xls", "xlsx", "stl", "txt", "csv"]
 
 WAGTAILIMAGES_IMAGE_MODEL = "images.CustomImage"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -308,6 +308,7 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 WAGTAILDOCS_DOCUMENT_MODEL = "core.CustomDocument"
+WAGTAILDOCS_EXTENSIONS = ["pdf", "xls", "xlsx", "doc", "docx"]
 
 WAGTAILIMAGES_IMAGE_MODEL = "images.CustomImage"
 


### PR DESCRIPTION
This stops people being able to upload HTML files (among others) that contain malicious code