### PR TITLE
Return None if record does not exist or multiple objects returned

### DIFF
--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -301,11 +301,14 @@ class ClientAPI:
         # Convert the Python dict to a ResultList
         result_list = self.resultlist_from_response(response_data)
 
-        if not result_list:
-            raise DoesNotExist
-        if len(result_list) > 1:
-            raise MultipleObjectsReturned
-        return result_list.hits[0]
+        try:
+            if not result_list:
+                raise DoesNotExist
+            if len(result_list) > 1:
+                raise MultipleObjectsReturned
+            return result_list.hits[0]
+        except (DoesNotExist, MultipleObjectsReturned):
+            return None
 
     def search(
         self,

--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -301,14 +301,11 @@ class ClientAPI:
         # Convert the Python dict to a ResultList
         result_list = self.resultlist_from_response(response_data)
 
-        try:
-            if not result_list:
-                raise DoesNotExist
-            if len(result_list) > 1:
-                raise MultipleObjectsReturned
-            return result_list.hits[0]
-        except (DoesNotExist, MultipleObjectsReturned):
-            return None
+        if not result_list:
+            raise DoesNotExist
+        if len(result_list) > 1:
+            raise MultipleObjectsReturned
+        return result_list.hits[0]
 
     def search(
         self,

--- a/etna/records/fields.py
+++ b/etna/records/fields.py
@@ -7,6 +7,8 @@ from django.utils.functional import SimpleLazyObject
 
 from requests import HTTPError
 
+from etna.ciim.exceptions import DoesNotExist
+
 from .api import records_client
 from .models import Record
 from .widgets import RecordChooser
@@ -24,7 +26,10 @@ class LazyRecord(SimpleLazyObject):
         self.__dict__["iaid"] = iaid
 
         def _fetch_record():
-            return records_client.fetch(iaid=iaid)
+            try:
+                return records_client.fetch(iaid=iaid)
+            except DoesNotExist:
+                return None
 
         super().__init__(_fetch_record)
 


### PR DESCRIPTION
Temporary fix for errors being raised if a record does not exist in CIIM. This will need some work to gracefully handle errors in the future, in case a record is taken down from CIIM, or CIIM goes down in the future.