### PR TITLE
If record does not exist, return ""

### DIFF
--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -37,7 +37,7 @@ def record_url(
     """
     if not record:
         return ""
-    
+
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 

--- a/etna/records/templatetags/records_tags.py
+++ b/etna/records/templatetags/records_tags.py
@@ -35,6 +35,9 @@ def record_url(
 
     form_group: use with results from search queries, value determines tna, nonTna results
     """
+    if not record:
+        return ""
+    
     if is_editorial and settings.FEATURE_RECORD_LINKS_GO_TO_DISCOVERY and record.iaid:
         return TNA_URLS.get("discovery_rec_default_fmt").format(iaid=record.iaid)
 


### PR DESCRIPTION
We're having issues on pages such as https://beta.nationalarchives.gov.uk/explore-the-collection/stories/margaret-bondfield/ because the page is attempting to get the record `iaid` value - however due to missing data from CIIM, we're getting a `NoneType` error. This fix will temporarily return "" if there is no record data. This will be fixed in the new search app, and when the CIIM data returns.