### PR TITLE
Set BlogPostPage chips to the parent blog title

### DIFF
--- a/etna/blog/models.py
+++ b/etna/blog/models.py
@@ -80,12 +80,12 @@ class BlogPostPage(
         Overrides the type_label method from BasePage, to return the correct
         type label for the blog post page.
         """
-        if parent := cls.get_parent():
-            print(parent.get_parent().specific_class)
-            if parent.get_parent().specific_class == BlogPage:
-                return parent.get_parent().title
-            return parent.title
-        return "Blog post"
+        parent = cls.get_parent()
+        if not parent:
+            return "Blog post"
+        while parent.get_parent().specific_class == BlogPage:
+            parent = parent.get_parent()
+        return parent.title
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels

--- a/etna/blog/models.py
+++ b/etna/blog/models.py
@@ -1,3 +1,4 @@
+from django.utils.functional import cached_property
 from wagtail.admin.panels import FieldPanel
 from wagtail.api import APIField
 from wagtail.fields import StreamField
@@ -72,6 +73,19 @@ class BlogPostPage(
     body = StreamField(
         BlogPostPageStreamBlock(),
     )
+
+    @cached_property
+    def type_label(cls) -> str:
+        """
+        Overrides the type_label method from BasePage, to return the correct
+        type label for the blog post page.
+        """
+        if parent := cls.get_parent():
+            print(parent.get_parent().specific_class)
+            if parent.get_parent().specific_class == BlogPage:
+                return parent.get_parent().title
+            return parent.title
+        return "Blog post"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels


### PR DESCRIPTION
## About these changes

Adds an override for `type_label` on `BlogPostPage` to show which blog the post is under.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
