### PR TITLE
AliasOfSerializer

### DIFF
--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -24,6 +24,7 @@ from etna.core.cache_control import (
     apply_default_vary_headers,
 )
 from etna.core.serializers import (
+    AliasOfSerializer,
     ImageSerializer,
     MourningSerializer,
     RichTextSerializer,
@@ -162,6 +163,7 @@ class BasePage(AlertMixin, SocialMixin, DataLayerMixin, HeadlessPreviewMixin, Pa
             "teaser_image",
             serializer=ImageSerializer("fill-600x400"),
         ),
+        APIField("alias_of", serializer=AliasOfSerializer()),
     ] + SocialMixin.api_meta_fields
 
 

--- a/etna/core/serializers/__init__.py
+++ b/etna/core/serializers/__init__.py
@@ -1,10 +1,11 @@
 from .date import DateTimeSerializer
 from .images import DetailedImageSerializer, HighlightImageSerializer, ImageSerializer
-from .pages import DefaultPageSerializer, SimplePageSerializer
+from .pages import AliasOfSerializer, DefaultPageSerializer, SimplePageSerializer
 from .richtext import RichTextSerializer
 from .tags import MourningSerializer, TaggableSerializer
 
 __all__ = [
+    "AliasOfSerializer",
     "DateTimeSerializer",
     "DefaultPageSerializer",
     "SimplePageSerializer",

--- a/etna/core/serializers/pages.py
+++ b/etna/core/serializers/pages.py
@@ -83,3 +83,16 @@ class SimplePageSerializer(serializers.Serializer):
             "url": instance.url,
             "full_url": instance.full_url,
         }
+
+
+class AliasOfSerializer(serializers.Serializer):
+    """
+    A serializer used to override the default representation of an alias page,
+    to include information that can decide is necessary for the front-end.
+    """
+
+    def to_representation(self, instance):
+        return {
+            "id": instance.id,
+            "url": instance.url,
+        }


### PR DESCRIPTION
## About these changes

Adds an `AliasOfSerializer` to serialise `alias_of` values on the detail view of all pages. This is because by default, we get
![image](https://github.com/user-attachments/assets/abb37332-4a0b-4597-b4f5-65e38b1fac2b)
which isn't massively useful for the frontend. Now we get
![image](https://github.com/user-attachments/assets/a0c6a25f-34a5-454b-b328-76314d5151e0)
which we can update to include different values. But as it stands, these are the most useful values to us.

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
