### PR TITLE
Update `is_author` to include blogs

### DIFF
--- a/etna/api/tests/expected_results/author.json
+++ b/etna/api/tests/expected_results/author.json
@@ -117,33 +117,5 @@
     },
     "summary": "<p>Summary text</p>",
     "research_summary": [],
-    "authored_focused_articles": [
-        {
-            "id": FOCUSED_ID,
-            "title": "focused_article",
-            "url": "/article_index/focused_article/",
-            "full_url": "http://localhost/article_index/focused_article/",
-            "type_label": "Focus on",
-            "teaser_text": "Teaser text",
-            "teaser_image": {
-                "id": 14,
-                "title": "An image",
-                "jpeg": {
-                    "url": "/media/images/example.2e16d0ba.fill-600x400.format-jpeg.jpegquality-60.bgcolor-fff.jpg",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/example.2e16d0ba.fill-600x400.format-jpeg.jpegquality-60.bgcolor-fff.jpg",
-                    "width": 100,
-                    "height": 68
-                },
-                "webp": {
-                    "url": "/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.bgcolor-fff.webp",
-                    "full_url": "https://nationalarchives.gov.uk/media/images/exampl.2e16d0ba.fill-600x400.format-webp.webpquality-60.bgcolor-fff.webp",
-                    "width": 100,
-                    "height": 68
-                }
-            },
-            "last_published_at": "2000-01-02T00:00:00Z",
-            "is_newly_published": false
-        }
-    ],
     "shop_items": []
 }

--- a/etna/people/models.py
+++ b/etna/people/models.py
@@ -187,8 +187,6 @@ class PersonPage(BasePage):
             .public()
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
-            .select_related("teaser_image")
-            .specific
         )
 
     @cached_property

--- a/etna/people/models.py
+++ b/etna/people/models.py
@@ -172,12 +172,6 @@ class PersonPage(BasePage):
         APIField("summary", serializer=RichTextSerializer()),
         APIField("research_summary"),
         APIField(
-            "authored_focused_articles",
-            serializer=DefaultPageSerializer(
-                required_api_fields=["teaser_image"], many=True
-            ),
-        ),
-        APIField(
             "shop_items",
         ),
     ]
@@ -185,13 +179,16 @@ class PersonPage(BasePage):
     @cached_property
     def authored_focused_articles(self):
         from etna.articles.models import FocusedArticlePage
+        from etna.blog.models import BlogPostPage
 
         return (
-            FocusedArticlePage.objects.live()
+            Page.objects.type(FocusedArticlePage, BlogPostPage)
+            .live()
             .public()
             .filter(pk__in=self.related_page_pks)
             .order_by("-first_published_at")
             .select_related("teaser_image")
+            .specific
         )
 
     @cached_property


### PR DESCRIPTION
## About these changes

Adds `BlogPostPage` to the `authored_focused_articles` (will keep this name for now as to not mess with the current frontend) so that `is_author` status is given if they are credited on a blog (not just focused articles)

## Before assigning to reviewer, please make sure you have

- [x] Checked things thoroughly before handing over to reviewer
- [x] Checked PR title starts with ticket number as per project conventions to help us keep track of changes
- [x] Ensured that PR includes only commits relevant to the ticket
- [x] Waited for all CI jobs to pass before requesting a review
- [x] Added/updated tests and documentation where relevant

## Merging PR guidance

Follow [docs\developer-guide\contributing.md](https://nationalarchives.github.io/ds-wagtail/developer-guide/contributing/)

## Deployment guidance

Follow [docs\infra\environments.md](https://nationalarchives.github.io/ds-wagtail/infra/environments/)
