### PR TITLE
Add Redirects API endpoint and serializer

### DIFF
--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -454,6 +454,7 @@ class RedirectsAPIViewSet(BaseAPIViewSet):
 
     def find_object(self, queryset, request):
         if "path" in request.GET:
+            # Taken from https://github.com/wagtail/wagtail/blob/main/wagtail/contrib/redirects/models.py#L165-L169
             path = request.GET["path"]
             path = path.strip()
             if not path.startswith("/"):

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -454,11 +454,16 @@ class RedirectsAPIViewSet(BaseAPIViewSet):
 
     def find_object(self, queryset, request):
         if "path" in request.GET:
-            return queryset.get(old_path=request.GET["path"])
+            path = request.GET["path"]
+            path = path.strip()
+            if not path.startswith("/"):
+                path = "/" + path
+            if path.endswith("/") and len(path) > 1:
+                path = path[:-1]
+            return queryset.get(old_path=path)
 
 
 api_router = WagtailAPIRouter("wagtailapi")
-
 api_router.register_endpoint("pages", CustomPagesAPIViewSet)
 api_router.register_endpoint("page_preview", PagePreviewAPIViewSet)
 api_router.register_endpoint("images", CustomImagesAPIViewSet)

--- a/etna/core/models/basepage.py
+++ b/etna/core/models/basepage.py
@@ -161,7 +161,7 @@ class BasePage(AlertMixin, SocialMixin, DataLayerMixin, HeadlessPreviewMixin, Pa
     @cached_property
     def type(self):
         return self._meta.label
-    
+
     default_api_fields = [
         APIField("id"),
         APIField("title"),

--- a/etna/core/serializers/redirects.py
+++ b/etna/core/serializers/redirects.py
@@ -5,7 +5,7 @@ class RedirectSerializer(serializers.Serializer):
     def to_representation(self, instance):
         return {
             "id": instance.id,
-            "title": instance.title,
+            "path": instance.title,
             "is_permanent": instance.is_permanent,
             "link": instance.link,
         }

--- a/etna/core/serializers/redirects.py
+++ b/etna/core/serializers/redirects.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class RedirectSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        return {
+            "id": instance.id,
+            "title": instance.title,
+            "is_permanent": instance.is_permanent,
+            "link": instance.link,
+        }


### PR DESCRIPTION
- All redirects: http://localhost:8000/api/v2/redirects/
- Single redirect: http://localhost:8000/api/v2/redirects/20/
- Find a redirect by its path: http://localhost:8000/api/v2/redirects/find/?path=/insight-pages/horatio-nelson -> http://localhost:8000/api/v2/redirects/20/
- Find a redirect by its path with incorrect slashes: http://localhost:8000/api/v2/redirects/find/?path=insight-pages/horatio-nelson/ -> http://localhost:8000/api/v2/redirects/20/

> In local dev, the redirects may go to http://host.docker.internal:8000 - this won't matter to the container