### PR TITLE
Add breadcrumbs metadata to CustomPagesAPIViewSet response

### DIFF
--- a/etna/api/tests/expected_results/article.json
+++ b/etna/api/tests/expected_results/article.json
@@ -59,7 +59,17 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            },
+            {
+                "text": "article_index",
+                "href": "/article_index/"
+            }
+        ]
     },
     "title": "article",
     "short_title": null,

--- a/etna/api/tests/expected_results/article_index.json
+++ b/etna/api/tests/expected_results/article_index.json
@@ -59,7 +59,13 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            }
+        ]
     },
     "title": "article_index",
     "short_title": null,

--- a/etna/api/tests/expected_results/arts.json
+++ b/etna/api/tests/expected_results/arts.json
@@ -59,7 +59,13 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            }
+        ]
     },
     "title": "arts",
     "short_title": null,

--- a/etna/api/tests/expected_results/author.json
+++ b/etna/api/tests/expected_results/author.json
@@ -59,7 +59,17 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            },
+            {
+                "text": "people",
+                "href": "/people/"
+            }
+        ]
     },
     "title": "author",
     "short_title": null,

--- a/etna/api/tests/expected_results/early_modern.json
+++ b/etna/api/tests/expected_results/early_modern.json
@@ -59,7 +59,13 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            }
+        ]
     },
     "title": "early_modern",
     "short_title": null,

--- a/etna/api/tests/expected_results/focused_article.json
+++ b/etna/api/tests/expected_results/focused_article.json
@@ -59,7 +59,17 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            },
+            {
+                "text": "article_index",
+                "href": "/article_index/"
+            }
+        ]
     },
     "title": "focused_article",
     "short_title": null,

--- a/etna/api/tests/expected_results/highlight_gallery.json
+++ b/etna/api/tests/expected_results/highlight_gallery.json
@@ -59,7 +59,17 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            },
+            {
+                "text": "arts",
+                "href": "/arts/"
+            }
+        ]
     },
     "title": "highlight_gallery",
     "short_title": null,

--- a/etna/api/tests/expected_results/people.json
+++ b/etna/api/tests/expected_results/people.json
@@ -59,7 +59,13 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            }
+        ]
     },
     "title": "people",
     "short_title": null,

--- a/etna/api/tests/expected_results/postwar.json
+++ b/etna/api/tests/expected_results/postwar.json
@@ -59,7 +59,13 @@
         "search_image": null,
         "twitter_og_title": null,
         "twitter_og_description": null,
-        "twitter_og_image": null
+        "twitter_og_image": null,
+        "breadcrumbs": [
+            {
+                "text": "Home",
+                "href": "/"
+            }
+        ]
     },
     "title": "postwar",
     "short_title": null,

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -100,6 +100,18 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
         restrictions = instance.get_view_restrictions()
         serializer = self.get_serializer(instance)
         data = serializer.data
+        data["meta"].update(
+            {
+                "breadcrumbs": [
+                    {
+                        "text": ("Home" if page.url == "/" else page.title),
+                        "href": page.url,
+                    }
+                    for page in instance.get_ancestors().order_by("depth")
+                    if page.url
+                ],
+            }
+        )
         if not restrictions:
             return Response(data)
         restricted_data = {
@@ -226,10 +238,6 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
                     if new_path := redirects.get().redirect_page.url:
                         logger.info(f"Redirect detected: {path} ---> {new_path}")
                         path = new_path
-                # elif redirects.get().redirect_link:
-                #     if new_path := redirects.get().redirect_link:
-                #         logger.info(f"Redirect detected: {path} ---> {new_path}")
-                #         path = new_path
 
             path_components = [component for component in path.split("/") if component]
 

--- a/etna/api/urls.py
+++ b/etna/api/urls.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -104,10 +105,16 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
             {
                 "breadcrumbs": [
                     {
-                        "text": ("Home" if page.url == "/" else page.title),
+                        "text": (
+                            "Home"
+                            if page.url == "/"
+                            else page.short_title or page.title
+                        ),
                         "href": page.url,
                     }
-                    for page in instance.get_ancestors().order_by("depth")
+                    for page in instance.get_ancestors()
+                    .order_by("depth")
+                    .specific(defer=True)
                     if page.url
                 ],
             }


### PR DESCRIPTION
This means the frontend won't have to make a follow-up call of something like http://localhost:8000/api/v2/pages/?ancestor_of=192&order=-depth after the initial page request.

<img width="480" alt="image" src="https://github.com/user-attachments/assets/8c605386-c739-4ab5-9a38-916f8510d3dc" />
