### PR TITLE
`/media` and `/images` endpoint updates

### DIFF
--- a/etna/api/urls/images.py
+++ b/etna/api/urls/images.py
@@ -1,7 +1,37 @@
+from wagtail.images.api.v2.serializers import ImageSerializer
 from wagtail.images.api.v2.views import ImagesAPIViewSet
+
+from etna.core.serializers.images import image_generator
+
+
+class ViewSetImageSerializer(ImageSerializer):
+    """
+    Serializer for images in the /images endpoint.
+    """
+
+    rendition_size = "max-900x900"
+    jpeg_quality = 60
+    webp_quality = 60
+    background_colour = "fff"
+    additional_formats = []
+
+    def to_representation(self, value):
+        representation = super().to_representation(value)
+
+        image_data = image_generator(
+            original_image=value,
+            rendition_size=self.rendition_size,
+            jpeg_quality=self.jpeg_quality,
+            webp_quality=self.webp_quality,
+            background_colour=self.background_colour,
+            additional_formats=self.additional_formats,
+        )
+
+        return representation | image_data
 
 
 class CustomImagesAPIViewSet(ImagesAPIViewSet):
+    base_serializer_class = ViewSetImageSerializer
     body_fields = ImagesAPIViewSet.body_fields + [
         "title",
         "file",

--- a/etna/api/urls/media.py
+++ b/etna/api/urls/media.py
@@ -1,6 +1,7 @@
-from wagtailmedia.api.views import MediaAPIViewSet
-from wagtailmedia.api.serializers import MediaItemSerializer
 from wagtail.rich_text import expand_db_html
+from wagtailmedia.api.serializers import MediaItemSerializer
+from wagtailmedia.api.views import MediaAPIViewSet
+
 
 class CustomMediaItemSerializer(MediaItemSerializer):
     def to_representation(self, instance):
@@ -19,6 +20,7 @@ class CustomMediaItemSerializer(MediaItemSerializer):
             "chapters_file": instance.chapters_file_url,
             "chapters_file_full_url": instance.chapters_file_full_url,
         }
+
 
 class CustomMediaAPIViewSet(MediaAPIViewSet):
     base_serializer_class = CustomMediaItemSerializer

--- a/etna/api/urls/media.py
+++ b/etna/api/urls/media.py
@@ -1,7 +1,27 @@
 from wagtailmedia.api.views import MediaAPIViewSet
+from wagtailmedia.api.serializers import MediaItemSerializer
+from wagtail.rich_text import expand_db_html
 
+class CustomMediaItemSerializer(MediaItemSerializer):
+    def to_representation(self, instance):
+        chapters = [
+            {
+                "time": int(chapter.value["time"]),
+                "heading": chapter.value["heading"],
+                "transcript": expand_db_html(chapter.value["transcript"].source),
+            }
+            for chapter in instance.chapters
+        ]
+        return super().to_representation(instance) | {
+            "chapters": sorted(chapters, key=lambda x: x["time"]),
+            "subtitles_file": instance.subtitles_file_url,
+            "subtitles_file_full_url": instance.subtitles_file_full_url,
+            "chapters_file": instance.chapters_file_url,
+            "chapters_file_full_url": instance.chapters_file_full_url,
+        }
 
 class CustomMediaAPIViewSet(MediaAPIViewSet):
+    base_serializer_class = CustomMediaItemSerializer
     body_fields = MediaAPIViewSet.body_fields + [
         "title",
         "file",
@@ -12,6 +32,7 @@ class CustomMediaAPIViewSet(MediaAPIViewSet):
         "duration",
         "subtitles_file",
         "subtitles_file_full_url",
+        "chapters",
         "chapters_file",
         "chapters_file_full_url",
     ]

--- a/etna/core/serializers/images.py
+++ b/etna/core/serializers/images.py
@@ -3,6 +3,60 @@ from rest_framework.serializers import Serializer
 from etna.ciim.client import CIIMClient
 
 
+def image_generator(
+    original_image,
+    rendition_size="fill-600x400",
+    jpeg_quality=60,
+    webp_quality=60,
+    background_colour=None,
+    additional_formats=[],
+):
+    background_colour_rendition = (
+        f"|bgcolor-{background_colour}" if background_colour else ""
+    )
+    jpeg_image = original_image.get_rendition(
+        f"{rendition_size}|format-jpeg|jpegquality-{jpeg_quality}{background_colour_rendition}"
+    )
+    webp_image = original_image.get_rendition(
+        f"{rendition_size}|format-webp|webpquality-{webp_quality}{background_colour_rendition}"
+    )
+
+    additional_images = {}
+
+    if formats := additional_formats:
+        for format in formats:
+            additional_image = original_image.get_rendition(
+                f"{rendition_size}|format-{format}"
+            )
+            if additional_image:
+                additional_image = {
+                    "url": additional_image.url,
+                    "full_url": additional_image.full_url,
+                    "width": additional_image.width,
+                    "height": additional_image.height,
+                }
+                additional_images[format] = additional_image
+
+    if not jpeg_image or not webp_image:
+        return None
+
+    return {
+        "jpeg": {
+            "url": jpeg_image.url,
+            "full_url": jpeg_image.full_url,
+            "width": jpeg_image.width,
+            "height": jpeg_image.height,
+        },
+        "webp": {
+            "url": webp_image.url,
+            "full_url": webp_image.full_url,
+            "width": webp_image.width,
+            "height": webp_image.height,
+        },
+        **(additional_images),
+    }
+
+
 class ImageSerializer(Serializer):
     """
     This ImageSerializer was created to improve the `ImageRenditionField` that
@@ -45,48 +99,22 @@ class ImageSerializer(Serializer):
 
     def to_representation(self, value):
         if value:
-            background_colour_rendition = (
-                f"|bgcolor-{self.background_colour}" if self.background_colour else ""
-            )
-            jpeg_image = value.get_rendition(
-                f"{self.rendition_size}|format-jpeg|jpegquality-{self.jpeg_quality}{background_colour_rendition}"
-            )
-            webp_image = value.get_rendition(
-                f"{self.rendition_size}|format-webp|webpquality-{self.webp_quality}{background_colour_rendition}"
+            image_data = image_generator(
+                original_image=value,
+                rendition_size=self.rendition_size,
+                jpeg_quality=self.jpeg_quality,
+                webp_quality=self.webp_quality,
+                background_colour=self.background_colour,
+                additional_formats=self.additional_formats,
             )
 
-            additional_images = {}
-
-            if formats := self.additional_formats:
-                for format in formats:
-                    additional_image = value.get_rendition(
-                        f"{self.rendition_size}|format-{format}"
-                    )
-                    if additional_image:
-                        additional_image = {
-                            "url": additional_image.url,
-                            "full_url": additional_image.full_url,
-                            "width": additional_image.width,
-                            "height": additional_image.height,
-                        }
-                        additional_images[format] = additional_image
+            if not image_data:
+                return None
 
             return {
                 "id": value.id,
                 "title": value.title,
-                "jpeg": {
-                    "url": jpeg_image.url,
-                    "full_url": jpeg_image.full_url,
-                    "width": jpeg_image.width,
-                    "height": jpeg_image.height,
-                },
-                "webp": {
-                    "url": webp_image.url,
-                    "full_url": webp_image.full_url,
-                    "width": webp_image.width,
-                    "height": webp_image.height,
-                },
-                **(additional_images),
+                **(image_data),
             }
         return None
 


### PR DESCRIPTION
Changed how Media items are being serialized on the `/media` endpoint so that the `chapter` field comes back ordered (and we can now change what comes back, etc)

Changed how CustomImage items are being serialized so that we can return renditions (like we do across the site) in the default representation of `/images` and taken the rendition generation outside of the serializer so we can use it in other places (as seen in this PR)