### PR TITLE
Add DescendantOfPathFilter to enable filtering by page URI

### DIFF
--- a/etna/api/urls/pages.py
+++ b/etna/api/urls/pages.py
@@ -24,14 +24,14 @@ from wagtail.models import Page, PageViewRestriction, Site
 
 from etna.core.serializers.pages import DefaultPageSerializer
 
-from ..filters import AliasFilter, SiteFilter
+from ..filters import AliasFilter, DescendantOfPathFilter, SiteFilter
 
 logger = logging.getLogger(__name__)
 
 
 class CustomPagesAPIViewSet(PagesAPIViewSet):
     known_query_parameters = PagesAPIViewSet.known_query_parameters.union(
-        ["password", "author", "include_aliases"]
+        ["password", "author", "include_aliases", "descendant_of_path"]
     )
 
     # Copied from wagtail.api.v2.views.PagesAPIViewSet
@@ -41,6 +41,7 @@ class CustomPagesAPIViewSet(PagesAPIViewSet):
         ChildOfFilter,
         AncestorOfFilter,
         DescendantOfFilter,
+        DescendantOfPathFilter,
         OrderingFilter,
         TranslationOfFilter,
         LocaleFilter,


### PR DESCRIPTION
Allows searching part of the site:

- http://localhost:8000/api/v2/pages/?search=victoria
- http://localhost:8000/api/v2/pages/?search=victoria&descendant_of_path=/
- http://localhost:8000/api/v2/pages/?search=victoria&descendant_of_path=/explore-the-collection/
- http://localhost:8000/api/v2/pages/?search=victoria&descendant_of_path=/explore-the-collection/stories/

Used to enable a search page on Explore the collection (https://develop.tna.dblclk.dev/explore-the-collection/search/)