### PR TITLE
Add WAGTAILAPI_IMAGES_BASE_URL setting and full_url property to CustomImageRendition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ cp .env.example .env
 
 # Set .env values for:
 #   - ROSETTA_API_URL
-#   - PLATFORMSH_CLI_TOKEN
 
 # Build and start the containers
 docker compose up -d

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -19,6 +19,7 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 WAGTAILADMIN_BASE_URL = os.getenv("WAGTAILADMIN_BASE_URL", "")
+WAGTAILAPI_IMAGES_BASE_URL = os.getenv("WAGTAILAPI_IMAGES_BASE_URL", "")
 WAGTAILAPI_BASE_URL = os.getenv("WAGTAILAPI_BASE_URL", WAGTAILADMIN_BASE_URL)
 WAGTAIL_HEADLESS_PREVIEW = {
     "CLIENT_URLS": {

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -5,6 +5,7 @@ from .base import *  # noqa: F401
 SECRET_KEY = "abc123"
 
 WAGTAILADMIN_BASE_URL = "https://www.nationalarchives.gov.uk"
+WAGTAILAPI_IMAGES_BASE_URL = "https://www.nationalarchives.gov.uk"
 
 ALLOWED_HOSTS = ["*"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - DJANGO_SUPERUSER_EMAIL=admin@tna.dev
       - WAGTAILADMIN_BASE_URL=http://localhost:8000
       - WAGTAILAPI_BASE_URL=http://host.docker.internal:8000
-      - WAGTAILAPI_IMAGES_BASE_URL=http://localhost
+      - WAGTAILAPI_IMAGES_BASE_URL=https://localhost
       - WAGTAIL_HEADLESS_PREVIEW_URL=http://localhost:65535/preview/
       - REDIS_URL=redis://redis:6379/0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - DJANGO_SUPERUSER_EMAIL=admin@tna.dev
       - WAGTAILADMIN_BASE_URL=http://localhost:8000
       - WAGTAILAPI_BASE_URL=http://host.docker.internal:8000
+      - WAGTAILAPI_IMAGES_BASE_URL=http://localhost
       - WAGTAIL_HEADLESS_PREVIEW_URL=http://localhost:65535/preview/
       - REDIS_URL=redis://redis:6379/0
 

--- a/etna/images/models.py
+++ b/etna/images/models.py
@@ -182,5 +182,18 @@ class CustomImageRendition(AbstractRendition):
         CustomImage, on_delete=models.CASCADE, related_name="renditions"
     )
 
+    @property
+    def full_url(self):
+        url = self.url
+        if url.startswith("/"):
+            if (
+                hasattr(settings, "WAGTAILAPI_IMAGES_BASE_URL")
+                and settings.WAGTAILAPI_IMAGES_BASE_URL
+            ):
+                url = settings.WAGTAILAPI_IMAGES_BASE_URL + url
+            elif hasattr(settings, "WAGTAILADMIN_BASE_URL"):
+                url = settings.WAGTAILADMIN_BASE_URL + url
+        return url
+
     class Meta:
         unique_together = (("image", "filter_spec", "focal_point_key"),)


### PR DESCRIPTION
Setting `WAGTAILAPI_IMAGES_BASE_URL` allows us to control the `full_url` of image renditions in the API.

https://github.com/wagtail/wagtail/issues/13140

This stops the API on wagtail.nationalarchives.gov.uk producing full URLs that contain the Wagtail subdomain.