### PR TITLE
Refactor CIIMClient constructor to use superclass initialisation and add default filter parameter

### DIFF
--- a/etna/ciim/client.py
+++ b/etna/ciim/client.py
@@ -18,9 +18,9 @@ class CIIMClient(JSONAPIClient):
     Client for interacting with the CIIM API.
     """
 
-    def __init__(self, api_url: str = f"{settings.ROSETTA_API_URL}", params: dict = {}):
-        self.api_url: str = api_url
-        self.params: dict = params
+    def __init__(self, api_url: str = settings.ROSETTA_API_URL, params: dict = {}):
+        super().__init__(api_url, params=params)
+        self.add_parameter("filter", "@datatype.base:record")
 
     def get(self, path: str = "/", headers: dict = None) -> dict:
         try:


### PR DESCRIPTION
Rosetta was updated causing https://rosetta-prod.k-int.com/rosetta/data/search?q=* to return a different data schema, missing out some properties (e.g. IAID).

This adds a `filter` parameter in to the API requests (https://rosetta-prod.k-int.com/rosetta/data/search?q=*&filter=@datatype.base:record) in order to produce the expected result.