### PR TITLE
Use `get_renditions` instead of individual `get_rendition` calls

### DIFF
--- a/app/api/urls/images.py
+++ b/app/api/urls/images.py
@@ -15,7 +15,6 @@ class ViewSetImageSerializer(ImageSerializer):
     jpeg_quality = 60
     webp_quality = 70
     background_colour = "fff"
-    additional_formats = []
 
     def to_representation(self, value):
         representation = super().to_representation(value)
@@ -27,7 +26,6 @@ class ViewSetImageSerializer(ImageSerializer):
             jpeg_quality=self.jpeg_quality,
             webp_quality=self.webp_quality,
             background_colour=self.background_colour,
-            additional_formats=self.additional_formats,
         )
 
         return representation | image_data


### PR DESCRIPTION
This PR updates the `image_generator` function so that we can create all of our renditions for an image in one call.

This also removes `additional_formats` in favour of just `formats` which allows us to dynamically generate different formats - or exclude jpeg/webp, which were (and still are) the default formats.