### PR TITLE
Exclude `featured_page` from event listings

### DIFF
--- a/app/whatson/models/listings.py
+++ b/app/whatson/models/listings.py
@@ -218,6 +218,7 @@ class WhatsOnCategoryPage(BasePageWithRequiredIntro):
                 "end_date__gte": timezone.now(),
             },
             order_by="start_date",
+            exclude={"pk": self.featured_page_id},
         )
 
     @cached_property
@@ -469,6 +470,7 @@ class EventsListingPage(BasePageWithRequiredIntro):
             page_types=[EventPage],
             filters={"end_date__gte": timezone.now()},
             order_by="start_date",
+            exclude={"pk": self.featured_page_id},
         )
 
     @cached_property


### PR DESCRIPTION
Editors noticed that on certain pages the featured event shows in the listing. This removes that!😄 
<img width="641" height="796" alt="image" src="https://github.com/user-attachments/assets/b5a2522b-cc68-44cd-958f-87cd7da69e3b" />
