### PR TITLE
Remove editable listings from the landing page, replace with cached properties

### DIFF
--- a/app/education/models/landing.py
+++ b/app/education/models/landing.py
@@ -17,6 +17,7 @@ from app.core.models import (
 from app.core.serializers import DefaultPageSerializer
 
 from ..serializers import LinkedPageSerializer
+from .listings import EducationSessionsListingPage, TeachingResourcesListingPage
 from .resources import TeachingResourcePage
 from .sessions import EducationSessionPage
 
@@ -40,6 +41,26 @@ class EducationPage(BasePageWithRequiredIntro):
     def latest_education_sessions(self) -> list:
         return list(
             EducationSessionPage.objects.live().public().order_by("-start_date")[:3]
+        )
+
+    @cached_property
+    def teaching_resources_listing(self):
+        return (
+            self.get_children()
+            .type(TeachingResourcesListingPage)
+            .live()
+            .public()
+            .first()
+        )
+
+    @cached_property
+    def education_sessions_listing(self):
+        return (
+            self.get_children()
+            .type(EducationSessionsListingPage)
+            .live()
+            .public()
+            .first()
         )
 
     parent_page_types = [
@@ -136,7 +157,6 @@ class EducationPage(BasePageWithRequiredIntro):
     content_panels = BasePageWithRequiredIntro.content_panels + [
         MultiFieldPanel(
             [
-                PageChooserPanel("teaching_resources_listing_page"),
                 FieldPanel("teaching_resources_teaser_override"),
                 MultiFieldPanel(
                     [
@@ -149,7 +169,6 @@ class EducationPage(BasePageWithRequiredIntro):
         ),
         MultiFieldPanel(
             [
-                PageChooserPanel("education_sessions_listing_page"),
                 FieldPanel("education_sessions_teaser_override"),
                 MultiFieldPanel(
                     [
@@ -168,11 +187,11 @@ class EducationPage(BasePageWithRequiredIntro):
     ]
 
     api_fields = BasePageWithRequiredIntro.api_fields + [
-        APIField("teaching_resources_listing_page", serializer=DefaultPageSerializer()),
+        APIField("teaching_resources_listing", serializer=DefaultPageSerializer()),
         APIField("teaching_resources_teaser_override"),
         APIField("featured_teaching_resource", serializer=DefaultPageSerializer()),
         APIField("featured_teaching_resource_teaser_override"),
-        APIField("education_sessions_listing_page", serializer=DefaultPageSerializer()),
+        APIField("education_sessions_listing", serializer=DefaultPageSerializer()),
         APIField("education_sessions_teaser_override"),
         APIField("featured_education_session", serializer=DefaultPageSerializer()),
         APIField("featured_education_session_teaser_override"),


### PR DESCRIPTION
- slight name change, don't love but is still understandable, to avoid migration later (otherwise can do as part of other PR)
- exposed in the API
- tested locally

Associated changes (removal of old fields that would require migrations) are here: https://github.com/nationalarchives/ds-wagtail/pull/1978/changes/c5df68567527f4e74f412238675b74816948e9d2