### PR TITLE
Remove gettext_lazy

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication, TokenAuthentication
 
@@ -22,10 +21,10 @@ class CustomTokenAuthentication(TokenAuthentication):
         try:
             token = model.objects.get(key=key)
         except model.DoesNotExist:
-            raise exceptions.AuthenticationFailed(_("Invalid token."))
+            raise exceptions.AuthenticationFailed(("Invalid token."))
 
         if not token.active:
-            raise exceptions.PermissionDenied(_("Token inactive or deleted."))
+            raise exceptions.PermissionDenied(("Token inactive or deleted."))
 
         # Return a DummyUser instance in place of the user object, as we're not assigning tokens to user accounts
         return (DummyUser(), token)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -21,10 +21,10 @@ class CustomTokenAuthentication(TokenAuthentication):
         try:
             token = model.objects.get(key=key)
         except model.DoesNotExist:
-            raise exceptions.AuthenticationFailed(("Invalid token."))
+            raise exceptions.AuthenticationFailed("Invalid token.")
 
         if not token.active:
-            raise exceptions.PermissionDenied(("Token inactive or deleted."))
+            raise exceptions.PermissionDenied("Token inactive or deleted.")
 
         # Return a DummyUser instance in place of the user object, as we're not assigning tokens to user accounts
         return (DummyUser(), token)

--- a/app/articles/models.py
+++ b/app/articles/models.py
@@ -125,9 +125,7 @@ class ArticleIndexPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=(
-            "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
-        ),
+        help_text="Select a page to display in the featured area. This can be an Article, Focused Article or Record Article.",
         verbose_name="featured article",
     )
 
@@ -578,9 +576,7 @@ class RecordArticlePage(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=(
-            "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
-        ),
+        help_text="Select a page to display in the featured area. This can be an Article, Focused Article or Record Article.",
         verbose_name="featured article",
     )
 

--- a/app/articles/models.py
+++ b/app/articles/models.py
@@ -128,7 +128,7 @@ class ArticleIndexPage(BasePageWithRequiredIntro):
         help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=("featured article"),
+        verbose_name="featured article",
     )
 
     featured_pages = StreamField(
@@ -526,21 +526,21 @@ class RecordArticlePage(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=("Square, rotated image to display in the page introduction"),
-        verbose_name=("intro image"),
+        help_text="Square, rotated image to display in the page introduction",
+        verbose_name="intro image",
     )
 
-    record = RecordField(verbose_name=("record"), db_index=True)
+    record = RecordField(verbose_name="record", db_index=True)
     record.wagtail_reference_index_ignore = True
 
     date_text = models.CharField(
-        verbose_name=("date text"),
+        verbose_name="date text",
         max_length=100,
-        help_text=("Date(s) related to the record (max. character length: 100)"),
+        help_text="Date(s) related to the record (max. character length: 100)",
     )
 
     about = RichTextField(
-        verbose_name=("why this record matters"),
+        verbose_name="why this record matters",
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
     )
 
@@ -557,11 +557,11 @@ class RecordArticlePage(
     )
 
     gallery_heading = models.CharField(
-        verbose_name=("gallery heading"),
+        verbose_name="gallery heading",
         max_length=250,
         blank=True,
         null=True,
-        help_text=("Optional heading for the gallery"),
+        help_text="Optional heading for the gallery",
     )
 
     featured_highlight_gallery = models.ForeignKey(
@@ -569,7 +569,7 @@ class RecordArticlePage(
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
-        verbose_name=("featured highlight gallery"),
+        verbose_name="featured highlight gallery",
     )
 
     featured_article = models.ForeignKey(
@@ -581,7 +581,7 @@ class RecordArticlePage(
         help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=("featured article"),
+        verbose_name="featured article",
     )
 
     class Meta:

--- a/app/articles/models.py
+++ b/app/articles/models.py
@@ -3,7 +3,6 @@ from typing import Union
 from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers
@@ -126,10 +125,10 @@ class ArticleIndexPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_(
+        help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=_("featured article"),
+        verbose_name=("featured article"),
     )
 
     featured_pages = StreamField(
@@ -147,7 +146,7 @@ class ArticleIndexPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("article index page")
+        verbose_name = "article index page"
 
     content_panels = BasePageWithRequiredIntro.content_panels + [
         PageChooserPanel(
@@ -186,9 +185,9 @@ class ArticlePage(
     body = StreamField(ArticlePageStreamBlock, blank=True, null=True)
 
     class Meta:
-        verbose_name = _("article")
-        verbose_name_plural = _("articles")
-        verbose_name_public = _("the story of")
+        verbose_name = "article"
+        verbose_name_plural = "articles"
+        verbose_name_public = "the story of"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels
@@ -336,9 +335,9 @@ class FocusedArticlePage(
     body = StreamField(ArticlePageStreamBlock, blank=True, null=True)
 
     class Meta:
-        verbose_name = _("focused article")
-        verbose_name_plural = _("focused articles")
-        verbose_name_public = _("focus on")
+        verbose_name = "focused article"
+        verbose_name_plural = "focused articles"
+        verbose_name_public = "focus on"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels
@@ -488,8 +487,8 @@ class PageGalleryImage(Orderable):
     )
 
     class Meta(Orderable.Meta):
-        verbose_name = _("gallery image")
-        verbose_name_plural = _("gallery images")
+        verbose_name = "gallery image"
+        verbose_name_plural = "gallery images"
 
     panels = [
         FieldPanel("image"),
@@ -527,21 +526,21 @@ class RecordArticlePage(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_("Square, rotated image to display in the page introduction"),
-        verbose_name=_("intro image"),
+        help_text=("Square, rotated image to display in the page introduction"),
+        verbose_name=("intro image"),
     )
 
-    record = RecordField(verbose_name=_("record"), db_index=True)
+    record = RecordField(verbose_name=("record"), db_index=True)
     record.wagtail_reference_index_ignore = True
 
     date_text = models.CharField(
-        verbose_name=_("date text"),
+        verbose_name=("date text"),
         max_length=100,
-        help_text=_("Date(s) related to the record (max. character length: 100)"),
+        help_text=("Date(s) related to the record (max. character length: 100)"),
     )
 
     about = RichTextField(
-        verbose_name=_("why this record matters"),
+        verbose_name=("why this record matters"),
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
     )
 
@@ -558,11 +557,11 @@ class RecordArticlePage(
     )
 
     gallery_heading = models.CharField(
-        verbose_name=_("gallery heading"),
+        verbose_name=("gallery heading"),
         max_length=250,
         blank=True,
         null=True,
-        help_text=_("Optional heading for the gallery"),
+        help_text=("Optional heading for the gallery"),
     )
 
     featured_highlight_gallery = models.ForeignKey(
@@ -570,7 +569,7 @@ class RecordArticlePage(
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
-        verbose_name=_("featured highlight gallery"),
+        verbose_name=("featured highlight gallery"),
     )
 
     featured_article = models.ForeignKey(
@@ -579,16 +578,16 @@ class RecordArticlePage(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_(
+        help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=_("featured article"),
+        verbose_name=("featured article"),
     )
 
     class Meta:
-        verbose_name = _("record article")
-        verbose_name_plural = _("record articles")
-        verbose_name_public = _("record revealed")
+        verbose_name = "record article"
+        verbose_name_plural = "record articles"
+        verbose_name_public = "record revealed"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels

--- a/app/ciim/blocks.py
+++ b/app/ciim/blocks.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.api import APIField
 from wagtail.blocks import CharBlock
@@ -29,11 +28,11 @@ class RecordChooserBlock(CharBlock):
 
 
 class RecordLinkBlock(blocks.StructBlock):
-    record = RecordChooserBlock(label=_("Record"))
-    descriptive_title = blocks.CharBlock(label=_("Descriptive title"), max_length=255)
-    record_dates = blocks.CharBlock(label=_("Date(s)"), max_length=100)
+    record = RecordChooserBlock(label=("Record"))
+    descriptive_title = blocks.CharBlock(label=("Descriptive title"), max_length=255)
+    record_dates = blocks.CharBlock(label=("Date(s)"), max_length=100)
     thumbnail_image = APIImageChooserBlock(
-        label=_("Thumbnail image (optional)"), required=False
+        label=("Thumbnail image (optional)"), required=False
     )
 
     class Meta:
@@ -48,7 +47,7 @@ class RecordLinkBlock(blocks.StructBlock):
 
 
 class RecordLinksBlock(blocks.StructBlock):
-    items = blocks.ListBlock(RecordLinkBlock, label=_("Items"))
+    items = blocks.ListBlock(RecordLinkBlock, label=("Items"))
 
     class Meta:
         icon = "box-archive"

--- a/app/ciim/blocks.py
+++ b/app/ciim/blocks.py
@@ -28,11 +28,11 @@ class RecordChooserBlock(CharBlock):
 
 
 class RecordLinkBlock(blocks.StructBlock):
-    record = RecordChooserBlock(label=("Record"))
-    descriptive_title = blocks.CharBlock(label=("Descriptive title"), max_length=255)
-    record_dates = blocks.CharBlock(label=("Date(s)"), max_length=100)
+    record = RecordChooserBlock(label="Record")
+    descriptive_title = blocks.CharBlock(label="Descriptive title", max_length=255)
+    record_dates = blocks.CharBlock(label="Date(s)", max_length=100)
     thumbnail_image = APIImageChooserBlock(
-        label=("Thumbnail image (optional)"), required=False
+        label="Thumbnail image (optional)", required=False
     )
 
     class Meta:
@@ -47,7 +47,7 @@ class RecordLinkBlock(blocks.StructBlock):
 
 
 class RecordLinksBlock(blocks.StructBlock):
-    items = blocks.ListBlock(RecordLinkBlock, label=("Items"))
+    items = blocks.ListBlock(RecordLinkBlock, label="Items")
 
     class Meta:
         icon = "box-archive"

--- a/app/collections/models.py
+++ b/app/collections/models.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers
 from wagtail.admin.panels import (
@@ -51,38 +50,38 @@ class Highlight(Orderable):
         get_image_model_string(),
         null=True,
         on_delete=models.SET_NULL,
-        verbose_name=_("image"),
+        verbose_name=("image"),
     )
 
     title = models.CharField(
         max_length=255,
-        verbose_name=_("title"),
-        help_text=_(
+        verbose_name=("title"),
+        help_text=(
             "The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page."
         ),
     )
 
     record = RecordField(
-        verbose_name=_("related record"),
+        verbose_name=("related record"),
         db_index=True,
         blank=False,
         null=False,
-        help_text=_(
+        help_text=(
             "If the image relates to a specific record, select that record here."
         ),
     )
     record.wagtail_reference_index_ignore = True
 
     record_dates = models.CharField(
-        verbose_name=_("record date(s)"),
+        verbose_name=("record date(s)"),
         max_length=100,
         blank=False,
         null=False,
-        help_text=_("Date(s) related to the selected record (max length: 100 chars)."),
+        help_text=("Date(s) related to the selected record (max length: 100 chars)."),
     )
 
     description = RichTextField(
-        verbose_name=_("description"),
+        verbose_name=("description"),
         help_text=(
             "This text will appear in highlights galleries. A 100-300 word "
             "description of the story of the record and why it is significant."
@@ -115,13 +114,13 @@ class ExplorerIndexPageSelection(Orderable):
         "wagtailcore.Page",
         on_delete=models.CASCADE,
         related_name="explorer_index_page_selected_pages",
-        help_text=_("Select a page to display in the Explorer Index Page."),
+        help_text=("Select a page to display in the Explorer Index Page."),
     )
 
     title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_(
+        help_text=(
             "Optional title for the selected page. If left blank, the page title will be used."
         ),
     )
@@ -129,7 +128,7 @@ class ExplorerIndexPageSelection(Orderable):
     teaser_text = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_(
+        help_text=(
             "Optional teaser text for the selected page. If left blank, the page's teaser text will be displayed."
         ),
     )
@@ -140,7 +139,7 @@ class ExplorerIndexPageSelection(Orderable):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_(
+        help_text=(
             "Optional image to display in the teaser for the selected page. If left blank, the page's teaser image will be displayed."
         ),
     )
@@ -148,7 +147,7 @@ class ExplorerIndexPageSelection(Orderable):
     cta_label = models.CharField(
         max_length=50,
         blank=True,
-        help_text=_(
+        help_text=(
             "Optional label for the call to action button. If left blank, 'Read more' will be used."
         ),
         verbose_name="CTA label",
@@ -163,7 +162,7 @@ class ExplorerIndexPageSelection(Orderable):
                 FieldPanel("teaser_image"),
                 FieldPanel("cta_label"),
             ],
-            heading=_("Page link overrides"),
+            heading=("Page link overrides"),
         ),
     ]
 
@@ -207,13 +206,13 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         max_length=100,
         blank=True,
         default="Stories from the collection",
-        help_text=_("The title to display for the articles section."),
+        help_text=("The title to display for the articles section."),
     )
 
     stories_introduction = models.CharField(
         max_length=200,
         blank=True,
-        help_text=_("The introduction to display for the articles section."),
+        help_text=("The introduction to display for the articles section."),
     )
 
     stories_hero_image = models.ForeignKey(
@@ -222,8 +221,8 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("stories hero image"),
-        help_text=_(
+        verbose_name=("stories hero image"),
+        help_text=(
             "The stories section hero image to display on the Explorer Index Page."
         ),
     )
@@ -235,7 +234,7 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
     explorer_index_page_selections_title = models.CharField(
         max_length=100,
         blank=True,
-        help_text=_("The title to display for the Explorer Index Page selections."),
+        help_text=("The title to display for the Explorer Index Page selections."),
     )
 
     @cached_property
@@ -260,14 +259,14 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
                     FieldPanel("stories_title"),
                     FieldPanel("stories_introduction"),
                 ],
-                heading=_("Stories section"),
+                heading=("Stories section"),
             ),
             FieldPanel("explorer_index_page_selections_title"),
             InlinePanel(
                 "explorer_index_page_selections",
-                label=_("Selected pages for Explorer Index Page"),
+                label=("Selected pages for Explorer Index Page"),
                 max_num=2,
-                help_text=_("Select pages to display on the Explorer Index Page."),
+                help_text=("Select pages to display on the Explorer Index Page."),
             ),
         ]
     )
@@ -379,9 +378,9 @@ class TopicExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
     """
 
     class Meta:
-        verbose_name = _("topic page")
-        verbose_name_plural = _("topic pages")
-        verbose_name_public = _("explore the collection")
+        verbose_name = "topic page"
+        verbose_name_plural = "topic pages"
+        verbose_name_public = "explore the collection"
 
     featured_article = models.ForeignKey(
         "wagtailcore.Page",
@@ -389,10 +388,10 @@ class TopicExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_(
+        help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=_("featured article"),
+        verbose_name=("featured article"),
     )
 
     skos_id = models.CharField(
@@ -601,9 +600,9 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
     """
 
     class Meta:
-        verbose_name = _("time period page")
-        verbose_name_plural = _("time period pages")
-        verbose_name_public = _("explore the collection")
+        verbose_name = "time period page"
+        verbose_name_plural = "time period pages"
+        verbose_name_public = "explore the collection"
 
     featured_article = models.ForeignKey(
         "wagtailcore.Page",
@@ -611,10 +610,10 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_(
+        help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=_("featured article"),
+        verbose_name=("featured article"),
     )
 
     start_year = models.IntegerField(blank=False)
@@ -738,7 +737,7 @@ class PageTopic(Orderable):
     page = ParentalKey(Page, on_delete=models.CASCADE, related_name="page_topics")
     topic = models.ForeignKey(
         TopicExplorerPage,
-        verbose_name=_("topic"),
+        verbose_name=("topic"),
         related_name="topic_pages",
         on_delete=models.CASCADE,
     )
@@ -760,7 +759,7 @@ class PageTimePeriod(Orderable):
     page = ParentalKey(Page, on_delete=models.CASCADE, related_name="page_time_periods")
     time_period = models.ForeignKey(
         TimePeriodExplorerPage,
-        verbose_name=_("time period"),
+        verbose_name=("time period"),
         related_name="time_period_pages",
         on_delete=models.CASCADE,
     )
@@ -793,8 +792,8 @@ class TopicalPageMixin:
     def get_time_periods_inlinepanel(cls, max_num: int | None = 4) -> InlinePanel:
         return InlinePanel(
             "page_time_periods",
-            heading=_("Related time periods"),
-            help_text=_(
+            heading=("Related time periods"),
+            help_text=(
                 "If the page relates to more than one time period, please add these in order of relevance from most to least"
             ),
             max_num=max_num,
@@ -804,8 +803,8 @@ class TopicalPageMixin:
     def get_topics_inlinepanel(cls, max_num: int | None = 4) -> InlinePanel:
         return InlinePanel(
             "page_topics",
-            heading=_("Related topics"),
-            help_text=_(
+            heading=("Related topics"),
+            help_text=(
                 "If the page relates to more than one topic, please add these in order of relevance from most to least."
             ),
             max_num=max_num,
@@ -888,10 +887,10 @@ class HighlightGalleryPage(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_(
+        help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=_("featured article"),
+        verbose_name=("featured article"),
     )
 
     api_fields = (
@@ -909,9 +908,9 @@ class HighlightGalleryPage(
     )
 
     class Meta:
-        verbose_name = _("highlight gallery page")
-        verbose_name_plural = _("highlight gallery pages")
-        verbose_name_public = _("in pictures")
+        verbose_name = "highlight gallery page"
+        verbose_name_plural = "highlight gallery pages"
+        verbose_name_public = "in pictures"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels
@@ -919,8 +918,8 @@ class HighlightGalleryPage(
         + [
             InlinePanel(
                 "page_highlights",
-                heading=_("Highlights"),
-                label=_("Item"),
+                heading=("Highlights"),
+                label=("Item"),
                 max_num=15,
             ),
             PageChooserPanel(

--- a/app/collections/models.py
+++ b/app/collections/models.py
@@ -56,9 +56,7 @@ class Highlight(Orderable):
     title = models.CharField(
         max_length=255,
         verbose_name="title",
-        help_text=(
-            "The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page."
-        ),
+        help_text="The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page.",
     )
 
     record = RecordField(
@@ -66,9 +64,7 @@ class Highlight(Orderable):
         db_index=True,
         blank=False,
         null=False,
-        help_text=(
-            "If the image relates to a specific record, select that record here."
-        ),
+        help_text="If the image relates to a specific record, select that record here.",
     )
     record.wagtail_reference_index_ignore = True
 
@@ -82,10 +78,8 @@ class Highlight(Orderable):
 
     description = RichTextField(
         verbose_name="description",
-        help_text=(
-            "This text will appear in highlights galleries. A 100-300 word "
-            "description of the story of the record and why it is significant."
-        ),
+        help_text="This text will appear in highlights galleries. A 100-300 word "
+        "description of the story of the record and why it is significant.",
         blank=False,
         null=False,
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
@@ -120,17 +114,13 @@ class ExplorerIndexPageSelection(Orderable):
     title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=(
-            "Optional title for the selected page. If left blank, the page title will be used."
-        ),
+        help_text="Optional title for the selected page. If left blank, the page title will be used.",
     )
 
     teaser_text = models.CharField(
         max_length=255,
         blank=True,
-        help_text=(
-            "Optional teaser text for the selected page. If left blank, the page's teaser text will be displayed."
-        ),
+        help_text="Optional teaser text for the selected page. If left blank, the page's teaser text will be displayed.",
     )
 
     teaser_image = models.ForeignKey(
@@ -139,17 +129,13 @@ class ExplorerIndexPageSelection(Orderable):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=(
-            "Optional image to display in the teaser for the selected page. If left blank, the page's teaser image will be displayed."
-        ),
+        help_text="Optional image to display in the teaser for the selected page. If left blank, the page's teaser image will be displayed.",
     )
 
     cta_label = models.CharField(
         max_length=50,
         blank=True,
-        help_text=(
-            "Optional label for the call to action button. If left blank, 'Read more' will be used."
-        ),
+        help_text="Optional label for the call to action button. If left blank, 'Read more' will be used.",
         verbose_name="CTA label",
     )
 
@@ -222,9 +208,7 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         on_delete=models.SET_NULL,
         related_name="+",
         verbose_name="stories hero image",
-        help_text=(
-            "The stories section hero image to display on the Explorer Index Page."
-        ),
+        help_text="The stories section hero image to display on the Explorer Index Page.",
     )
 
     stories_hero_image_caption = RichTextField(
@@ -388,9 +372,7 @@ class TopicExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=(
-            "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
-        ),
+        help_text="Select a page to display in the featured area. This can be an Article, Focused Article or Record Article.",
         verbose_name="featured article",
     )
 
@@ -610,9 +592,7 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=(
-            "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
-        ),
+        help_text="Select a page to display in the featured area. This can be an Article, Focused Article or Record Article.",
         verbose_name="featured article",
     )
 
@@ -793,9 +773,7 @@ class TopicalPageMixin:
         return InlinePanel(
             "page_time_periods",
             heading="Related time periods",
-            help_text=(
-                "If the page relates to more than one time period, please add these in order of relevance from most to least"
-            ),
+            help_text="If the page relates to more than one time period, please add these in order of relevance from most to least",
             max_num=max_num,
         )
 
@@ -804,9 +782,7 @@ class TopicalPageMixin:
         return InlinePanel(
             "page_topics",
             heading="Related topics",
-            help_text=(
-                "If the page relates to more than one topic, please add these in order of relevance from most to least."
-            ),
+            help_text="If the page relates to more than one topic, please add these in order of relevance from most to least.",
             max_num=max_num,
         )
 
@@ -887,9 +863,7 @@ class HighlightGalleryPage(
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=(
-            "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
-        ),
+        help_text="Select a page to display in the featured area. This can be an Article, Focused Article or Record Article.",
         verbose_name="featured article",
     )
 

--- a/app/collections/models.py
+++ b/app/collections/models.py
@@ -50,19 +50,19 @@ class Highlight(Orderable):
         get_image_model_string(),
         null=True,
         on_delete=models.SET_NULL,
-        verbose_name=("image"),
+        verbose_name="image",
     )
 
     title = models.CharField(
         max_length=255,
-        verbose_name=("title"),
+        verbose_name="title",
         help_text=(
             "The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page."
         ),
     )
 
     record = RecordField(
-        verbose_name=("related record"),
+        verbose_name="related record",
         db_index=True,
         blank=False,
         null=False,
@@ -73,15 +73,15 @@ class Highlight(Orderable):
     record.wagtail_reference_index_ignore = True
 
     record_dates = models.CharField(
-        verbose_name=("record date(s)"),
+        verbose_name="record date(s)",
         max_length=100,
         blank=False,
         null=False,
-        help_text=("Date(s) related to the selected record (max length: 100 chars)."),
+        help_text="Date(s) related to the selected record (max length: 100 chars).",
     )
 
     description = RichTextField(
-        verbose_name=("description"),
+        verbose_name="description",
         help_text=(
             "This text will appear in highlights galleries. A 100-300 word "
             "description of the story of the record and why it is significant."
@@ -114,7 +114,7 @@ class ExplorerIndexPageSelection(Orderable):
         "wagtailcore.Page",
         on_delete=models.CASCADE,
         related_name="explorer_index_page_selected_pages",
-        help_text=("Select a page to display in the Explorer Index Page."),
+        help_text="Select a page to display in the Explorer Index Page.",
     )
 
     title = models.CharField(
@@ -162,7 +162,7 @@ class ExplorerIndexPageSelection(Orderable):
                 FieldPanel("teaser_image"),
                 FieldPanel("cta_label"),
             ],
-            heading=("Page link overrides"),
+            heading="Page link overrides",
         ),
     ]
 
@@ -206,13 +206,13 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         max_length=100,
         blank=True,
         default="Stories from the collection",
-        help_text=("The title to display for the articles section."),
+        help_text="The title to display for the articles section.",
     )
 
     stories_introduction = models.CharField(
         max_length=200,
         blank=True,
-        help_text=("The introduction to display for the articles section."),
+        help_text="The introduction to display for the articles section.",
     )
 
     stories_hero_image = models.ForeignKey(
@@ -221,7 +221,7 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("stories hero image"),
+        verbose_name="stories hero image",
         help_text=(
             "The stories section hero image to display on the Explorer Index Page."
         ),
@@ -234,7 +234,7 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
     explorer_index_page_selections_title = models.CharField(
         max_length=100,
         blank=True,
-        help_text=("The title to display for the Explorer Index Page selections."),
+        help_text="The title to display for the Explorer Index Page selections.",
     )
 
     @cached_property
@@ -259,14 +259,14 @@ class ExplorerIndexPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
                     FieldPanel("stories_title"),
                     FieldPanel("stories_introduction"),
                 ],
-                heading=("Stories section"),
+                heading="Stories section",
             ),
             FieldPanel("explorer_index_page_selections_title"),
             InlinePanel(
                 "explorer_index_page_selections",
-                label=("Selected pages for Explorer Index Page"),
+                label="Selected pages for Explorer Index Page",
                 max_num=2,
-                help_text=("Select pages to display on the Explorer Index Page."),
+                help_text="Select pages to display on the Explorer Index Page.",
             ),
         ]
     )
@@ -391,7 +391,7 @@ class TopicExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=("featured article"),
+        verbose_name="featured article",
     )
 
     skos_id = models.CharField(
@@ -613,7 +613,7 @@ class TimePeriodExplorerPage(RequiredHeroImageMixin, BasePageWithRequiredIntro):
         help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=("featured article"),
+        verbose_name="featured article",
     )
 
     start_year = models.IntegerField(blank=False)
@@ -737,7 +737,7 @@ class PageTopic(Orderable):
     page = ParentalKey(Page, on_delete=models.CASCADE, related_name="page_topics")
     topic = models.ForeignKey(
         TopicExplorerPage,
-        verbose_name=("topic"),
+        verbose_name="topic",
         related_name="topic_pages",
         on_delete=models.CASCADE,
     )
@@ -759,7 +759,7 @@ class PageTimePeriod(Orderable):
     page = ParentalKey(Page, on_delete=models.CASCADE, related_name="page_time_periods")
     time_period = models.ForeignKey(
         TimePeriodExplorerPage,
-        verbose_name=("time period"),
+        verbose_name="time period",
         related_name="time_period_pages",
         on_delete=models.CASCADE,
     )
@@ -792,7 +792,7 @@ class TopicalPageMixin:
     def get_time_periods_inlinepanel(cls, max_num: int | None = 4) -> InlinePanel:
         return InlinePanel(
             "page_time_periods",
-            heading=("Related time periods"),
+            heading="Related time periods",
             help_text=(
                 "If the page relates to more than one time period, please add these in order of relevance from most to least"
             ),
@@ -803,7 +803,7 @@ class TopicalPageMixin:
     def get_topics_inlinepanel(cls, max_num: int | None = 4) -> InlinePanel:
         return InlinePanel(
             "page_topics",
-            heading=("Related topics"),
+            heading="Related topics",
             help_text=(
                 "If the page relates to more than one topic, please add these in order of relevance from most to least."
             ),
@@ -890,7 +890,7 @@ class HighlightGalleryPage(
         help_text=(
             "Select a page to display in the featured area. This can be an Article, Focused Article or Record Article."
         ),
-        verbose_name=("featured article"),
+        verbose_name="featured article",
     )
 
     api_fields = (
@@ -918,8 +918,8 @@ class HighlightGalleryPage(
         + [
             InlinePanel(
                 "page_highlights",
-                heading=("Highlights"),
-                label=("Item"),
+                heading="Highlights",
+                label="Item",
                 max_num=15,
             ),
             PageChooserPanel(

--- a/app/core/blocks/cta.py
+++ b/app/core/blocks/cta.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 
 from .page_chooser import APIPageChooserBlock
@@ -10,10 +9,10 @@ from .paragraph import APIRichTextBlock
 class LargeCardLinksBlock(blocks.StructBlock):
     heading = blocks.CharBlock(max_length=100, required=False)
     page_1 = APIPageChooserBlock(
-        label=_("Link one target"), required_api_fields=["teaser_image"]
+        label=("Link one target"), required_api_fields=["teaser_image"]
     )
     page_2 = APIPageChooserBlock(
-        label=_("Link two target"), required_api_fields=["teaser_image"]
+        label=("Link two target"), required_api_fields=["teaser_image"]
     )
 
     class Meta:

--- a/app/core/blocks/cta.py
+++ b/app/core/blocks/cta.py
@@ -9,10 +9,10 @@ from .paragraph import APIRichTextBlock
 class LargeCardLinksBlock(blocks.StructBlock):
     heading = blocks.CharBlock(max_length=100, required=False)
     page_1 = APIPageChooserBlock(
-        label=("Link one target"), required_api_fields=["teaser_image"]
+        label="Link one target", required_api_fields=["teaser_image"]
     )
     page_2 = APIPageChooserBlock(
-        label=("Link two target"), required_api_fields=["teaser_image"]
+        label="Link two target", required_api_fields=["teaser_image"]
     )
 
     class Meta:

--- a/app/core/blocks/image.py
+++ b/app/core/blocks/image.py
@@ -57,10 +57,8 @@ class ContentImageBlock(blocks.StructBlock):
     image = APIImageChooserBlock(rendition_size="max-900x900", required=True)
     caption = APIRichTextBlock(
         features=["bold", "italic", "link"],
-        help_text=(
-            "If provided, displays directly below the image. Can be used to specify sources, transcripts or "
-            "other useful metadata."
-        ),
+        help_text="If provided, displays directly below the image. Can be used to specify sources, transcripts or "
+        "other useful metadata.",
         label="Caption (optional)",
         required=False,
     )

--- a/app/core/models/basepage.py
+++ b/app/core/models/basepage.py
@@ -76,9 +76,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
 
     short_title = models.CharField(
         verbose_name="short title",
-        help_text=(
-            "A shorter title for use in breadcrumbs and other navigational elements, where applicable."
-        ),
+        help_text="A shorter title for use in breadcrumbs and other navigational elements, where applicable.",
         max_length=45,
         blank=True,
         null=True,
@@ -86,9 +84,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
 
     teaser_text = models.TextField(
         verbose_name="teaser text",
-        help_text=(
-            "A short, enticing description of this page. This will appear in promos and under thumbnails around the site."
-        ),
+        help_text="A short, enticing description of this page. This will appear in promos and under thumbnails around the site.",
         max_length=160,
     )
 
@@ -107,9 +103,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
         [
             FieldPanel(
                 "slug",
-                help_text=(
-                    "The name of the page as it will appear at the end of the URL"
-                ),
+                help_text="The name of the page as it will appear at the end of the URL",
                 widget=SlugInput,
             ),
             HelpPanel(
@@ -276,9 +270,7 @@ class BasePageWithIntro(BasePage):
 
     intro = RichTextField(
         verbose_name="introductory text",
-        help_text=(
-            "1-2 sentences introducing the subject of the page, and explaining why a user should read on."
-        ),
+        help_text="1-2 sentences introducing the subject of the page, and explaining why a user should read on.",
         features=settings.INLINE_RICH_TEXT_FEATURES,
         max_length=300,
         null=True,
@@ -307,9 +299,7 @@ class BasePageWithRequiredIntro(BasePageWithIntro):
 
     intro = RichTextField(
         verbose_name="introductory text",
-        help_text=(
-            "1-2 sentences introducing the subject of the page, and explaining why a user should read on."
-        ),
+        help_text="1-2 sentences introducing the subject of the page, and explaining why a user should read on.",
         features=settings.INLINE_RICH_TEXT_FEATURES,
         max_length=300,
     )

--- a/app/core/models/basepage.py
+++ b/app/core/models/basepage.py
@@ -111,7 +111,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
                 content="The full URL to this page. This is generated automatically based on the page's position in the page tree.",
             ),
         ],
-        ("For search engines"),
+        heading="For search engines",
     )
     _short_title_panel = FieldPanel("short_title")
     _teaser_panel = MultiFieldPanel(

--- a/app/core/models/basepage.py
+++ b/app/core/models/basepage.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.db.models import options
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, HelpPanel, MultiFieldPanel
 from wagtail.admin.widgets.slug import SlugInput
 from wagtail.api import APIField
@@ -76,8 +75,8 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
     """
 
     short_title = models.CharField(
-        verbose_name=_("short title"),
-        help_text=_(
+        verbose_name=("short title"),
+        help_text=(
             "A shorter title for use in breadcrumbs and other navigational elements, where applicable."
         ),
         max_length=45,
@@ -86,8 +85,8 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
     )
 
     teaser_text = models.TextField(
-        verbose_name=_("teaser text"),
-        help_text=_(
+        verbose_name=("teaser text"),
+        help_text=(
             "A short, enticing description of this page. This will appear in promos and under thumbnails around the site."
         ),
         max_length=160,
@@ -99,7 +98,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=_("Image that will appear on thumbnails and promos around the site."),
+        help_text=("Image that will appear on thumbnails and promos around the site."),
     )
 
     show_publish_date_in_search_results = False
@@ -108,7 +107,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
         [
             FieldPanel(
                 "slug",
-                help_text=_(
+                help_text=(
                     "The name of the page as it will appear at the end of the URL"
                 ),
                 widget=SlugInput,
@@ -118,7 +117,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
                 content="The full URL to this page. This is generated automatically based on the page's position in the page tree.",
             ),
         ],
-        _("For search engines"),
+        ("For search engines"),
     )
     _short_title_panel = FieldPanel("short_title")
     _teaser_panel = MultiFieldPanel(
@@ -276,8 +275,8 @@ class BasePageWithIntro(BasePage):
     """
 
     intro = RichTextField(
-        verbose_name=_("introductory text"),
-        help_text=_(
+        verbose_name=("introductory text"),
+        help_text=(
             "1-2 sentences introducing the subject of the page, and explaining why a user should read on."
         ),
         features=settings.INLINE_RICH_TEXT_FEATURES,
@@ -307,8 +306,8 @@ class BasePageWithRequiredIntro(BasePageWithIntro):
     """
 
     intro = RichTextField(
-        verbose_name=_("introductory text"),
-        help_text=_(
+        verbose_name=("introductory text"),
+        help_text=(
             "1-2 sentences introducing the subject of the page, and explaining why a user should read on."
         ),
         features=settings.INLINE_RICH_TEXT_FEATURES,

--- a/app/core/models/basepage.py
+++ b/app/core/models/basepage.py
@@ -75,7 +75,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
     """
 
     short_title = models.CharField(
-        verbose_name=("short title"),
+        verbose_name="short title",
         help_text=(
             "A shorter title for use in breadcrumbs and other navigational elements, where applicable."
         ),
@@ -85,7 +85,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
     )
 
     teaser_text = models.TextField(
-        verbose_name=("teaser text"),
+        verbose_name="teaser text",
         help_text=(
             "A short, enticing description of this page. This will appear in promos and under thumbnails around the site."
         ),
@@ -98,7 +98,7 @@ class BasePage(AlertMixin, SocialMixin, CustomHeadlessPreviewMixin, Page):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        help_text=("Image that will appear on thumbnails and promos around the site."),
+        help_text="Image that will appear on thumbnails and promos around the site.",
     )
 
     show_publish_date_in_search_results = False
@@ -275,7 +275,7 @@ class BasePageWithIntro(BasePage):
     """
 
     intro = RichTextField(
-        verbose_name=("introductory text"),
+        verbose_name="introductory text",
         help_text=(
             "1-2 sentences introducing the subject of the page, and explaining why a user should read on."
         ),
@@ -306,7 +306,7 @@ class BasePageWithRequiredIntro(BasePageWithIntro):
     """
 
     intro = RichTextField(
-        verbose_name=("introductory text"),
+        verbose_name="introductory text",
         help_text=(
             "1-2 sentences introducing the subject of the page, and explaining why a user should read on."
         ),

--- a/app/core/models/documents.py
+++ b/app/core/models/documents.py
@@ -8,7 +8,7 @@ from wagtail.documents.models import AbstractDocument, Document
 class CustomDocument(AbstractDocument):
     title = models.CharField(
         max_length=255,
-        verbose_name=("title"),
+        verbose_name="title",
         help_text="The name of the document as it will appear on the webpage. Please format this in sentence case with spaces between the words. e.g. Preservation policy part one.",
     )
     extent = models.CharField(

--- a/app/core/models/documents.py
+++ b/app/core/models/documents.py
@@ -2,14 +2,13 @@ import re
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from wagtail.documents.models import AbstractDocument, Document
 
 
 class CustomDocument(AbstractDocument):
     title = models.CharField(
         max_length=255,
-        verbose_name=_("title"),
+        verbose_name=("title"),
         help_text="The name of the document as it will appear on the webpage. Please format this in sentence case with spaces between the words. e.g. Preservation policy part one.",
     )
     extent = models.CharField(

--- a/app/core/models/location.py
+++ b/app/core/models/location.py
@@ -20,18 +20,18 @@ class Location(models.Model):
     A model representing a location (physical or online).
     """
 
-    space_name = models.CharField(max_length=255, verbose_name=("Space name"))
+    space_name = models.CharField(max_length=255, verbose_name="Space name")
 
     at_tna = models.BooleanField(
         default=False,
-        verbose_name=("at The National Archives"),
-        help_text=("Check if this venue is at The National Archives."),
+        verbose_name="at The National Archives",
+        help_text="Check if this venue is at The National Archives.",
     )
 
     online = models.BooleanField(
         default=False,
-        verbose_name=("online venue"),
-        help_text=("Check if this is an online venue."),
+        verbose_name="online venue",
+        help_text="Check if this is an online venue.",
     )
 
     # Address fields
@@ -39,32 +39,32 @@ class Location(models.Model):
         max_length=255,
         blank=True,
         null=True,
-        verbose_name=("first line of address"),
-        help_text=("First line of address for the location, if applicable."),
+        verbose_name="first line of address",
+        help_text="First line of address for the location, if applicable.",
     )
 
     address_line_2 = models.CharField(
         max_length=255,
         blank=True,
         null=True,
-        verbose_name=("second line of address"),
-        help_text=("Second line of address for the location, if applicable."),
+        verbose_name="second line of address",
+        help_text="Second line of address for the location, if applicable.",
     )
 
     postcode = models.CharField(
         max_length=20,
         blank=True,
         null=True,
-        verbose_name=("postcode"),
-        help_text=("Postcode for the location, if applicable."),
+        verbose_name="postcode",
+        help_text="Postcode for the location, if applicable.",
     )
 
     online_detail = models.CharField(
         max_length=255,
         blank=True,
         null=True,
-        verbose_name=("online detail"),
-        help_text=("Additional detail for online venues, if applicable."),
+        verbose_name="online detail",
+        help_text="Additional detail for online venues, if applicable.",
     )
 
     image = models.ForeignKey(
@@ -73,14 +73,14 @@ class Location(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("Image"),
-        help_text=("An image representing the location, if applicable."),
+        verbose_name="Image",
+        help_text="An image representing the location, if applicable.",
     )
 
     details_title = models.CharField(
         max_length=100,
         blank=True,
-        help_text=("Leave blank to default to 'Plan your visit'."),
+        help_text="Leave blank to default to 'Plan your visit'.",
     )
 
     details = StreamField(
@@ -92,16 +92,16 @@ class Location(models.Model):
     venue_link = models.URLField(
         blank=True,
         null=True,
-        verbose_name=("Venue link"),
-        help_text=("A link to the venue's website or visit us page."),
+        verbose_name="Venue link",
+        help_text="A link to the venue's website or visit us page.",
     )
 
     venue_link_text = models.CharField(
         max_length=50,
         blank=True,
         null=True,
-        verbose_name=("Venue link text"),
-        help_text=("Text to display for the venue link, if applicable."),
+        verbose_name="Venue link text",
+        help_text="Text to display for the venue link, if applicable.",
     )
 
     panels = [
@@ -111,8 +111,8 @@ class Location(models.Model):
                 FieldPanel("online"),
                 FieldPanel("online_detail"),
             ],
-            heading=("Online Venue Details"),
-            help_text=("Fill in these details for online venues only."),
+            heading="Online Venue Details",
+            help_text="Fill in these details for online venues only.",
         ),
         MultiFieldPanel(
             [
@@ -121,8 +121,8 @@ class Location(models.Model):
                 FieldPanel("address_line_2"),
                 FieldPanel("postcode"),
             ],
-            heading=("Physical address"),
-            help_text=("Fill in these details for physical venues only."),
+            heading="Physical address",
+            help_text="Fill in these details for physical venues only.",
         ),
         MultiFieldPanel(
             [
@@ -131,7 +131,7 @@ class Location(models.Model):
                 FieldPanel("venue_link"),
                 FieldPanel("venue_link_text"),
             ],
-            heading=("Key details"),
+            heading="Key details",
         ),
     ]
 

--- a/app/core/models/location.py
+++ b/app/core/models/location.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from wagtail import blocks
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel, TitleFieldPanel
@@ -21,18 +20,18 @@ class Location(models.Model):
     A model representing a location (physical or online).
     """
 
-    space_name = models.CharField(max_length=255, verbose_name=_("Space name"))
+    space_name = models.CharField(max_length=255, verbose_name=("Space name"))
 
     at_tna = models.BooleanField(
         default=False,
-        verbose_name=_("at The National Archives"),
-        help_text=_("Check if this venue is at The National Archives."),
+        verbose_name=("at The National Archives"),
+        help_text=("Check if this venue is at The National Archives."),
     )
 
     online = models.BooleanField(
         default=False,
-        verbose_name=_("online venue"),
-        help_text=_("Check if this is an online venue."),
+        verbose_name=("online venue"),
+        help_text=("Check if this is an online venue."),
     )
 
     # Address fields
@@ -40,32 +39,32 @@ class Location(models.Model):
         max_length=255,
         blank=True,
         null=True,
-        verbose_name=_("first line of address"),
-        help_text=_("First line of address for the location, if applicable."),
+        verbose_name=("first line of address"),
+        help_text=("First line of address for the location, if applicable."),
     )
 
     address_line_2 = models.CharField(
         max_length=255,
         blank=True,
         null=True,
-        verbose_name=_("second line of address"),
-        help_text=_("Second line of address for the location, if applicable."),
+        verbose_name=("second line of address"),
+        help_text=("Second line of address for the location, if applicable."),
     )
 
     postcode = models.CharField(
         max_length=20,
         blank=True,
         null=True,
-        verbose_name=_("postcode"),
-        help_text=_("Postcode for the location, if applicable."),
+        verbose_name=("postcode"),
+        help_text=("Postcode for the location, if applicable."),
     )
 
     online_detail = models.CharField(
         max_length=255,
         blank=True,
         null=True,
-        verbose_name=_("online detail"),
-        help_text=_("Additional detail for online venues, if applicable."),
+        verbose_name=("online detail"),
+        help_text=("Additional detail for online venues, if applicable."),
     )
 
     image = models.ForeignKey(
@@ -74,14 +73,14 @@ class Location(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("Image"),
-        help_text=_("An image representing the location, if applicable."),
+        verbose_name=("Image"),
+        help_text=("An image representing the location, if applicable."),
     )
 
     details_title = models.CharField(
         max_length=100,
         blank=True,
-        help_text=_("Leave blank to default to 'Plan your visit'."),
+        help_text=("Leave blank to default to 'Plan your visit'."),
     )
 
     details = StreamField(
@@ -93,16 +92,16 @@ class Location(models.Model):
     venue_link = models.URLField(
         blank=True,
         null=True,
-        verbose_name=_("Venue link"),
-        help_text=_("A link to the venue's website or visit us page."),
+        verbose_name=("Venue link"),
+        help_text=("A link to the venue's website or visit us page."),
     )
 
     venue_link_text = models.CharField(
         max_length=50,
         blank=True,
         null=True,
-        verbose_name=_("Venue link text"),
-        help_text=_("Text to display for the venue link, if applicable."),
+        verbose_name=("Venue link text"),
+        help_text=("Text to display for the venue link, if applicable."),
     )
 
     panels = [
@@ -112,8 +111,8 @@ class Location(models.Model):
                 FieldPanel("online"),
                 FieldPanel("online_detail"),
             ],
-            heading=_("Online Venue Details"),
-            help_text=_("Fill in these details for online venues only."),
+            heading=("Online Venue Details"),
+            help_text=("Fill in these details for online venues only."),
         ),
         MultiFieldPanel(
             [
@@ -122,8 +121,8 @@ class Location(models.Model):
                 FieldPanel("address_line_2"),
                 FieldPanel("postcode"),
             ],
-            heading=_("Physical address"),
-            help_text=_("Fill in these details for physical venues only."),
+            heading=("Physical address"),
+            help_text=("Fill in these details for physical venues only."),
         ),
         MultiFieldPanel(
             [
@@ -132,7 +131,7 @@ class Location(models.Model):
                 FieldPanel("venue_link"),
                 FieldPanel("venue_link_text"),
             ],
-            heading=_("Key details"),
+            heading=("Key details"),
         ),
     ]
 
@@ -202,8 +201,8 @@ class Location(models.Model):
         return f"{self.space_name}"
 
     class Meta:
-        verbose_name = _("Location")
-        verbose_name_plural = _("Locations")
+        verbose_name = "Location"
+        verbose_name_plural = "Locations"
 
 
 class LocationSerializer(serializers.Serializer):

--- a/app/core/models/mixins.py
+++ b/app/core/models/mixins.py
@@ -6,7 +6,6 @@ from django.http import HttpRequest
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.api import APIField
 from wagtail.fields import RichTextField
@@ -158,8 +157,8 @@ class AccentColourMixin(models.Model):
     accent_colour = models.CharField(
         max_length=20,
         default=BrandColourChoices.NONE,
-        verbose_name=_("page accent colour"),
-        help_text=_("The accent colour of the page where relevant."),
+        verbose_name=("page accent colour"),
+        help_text=("The accent colour of the page where relevant."),
         choices=BrandColourChoices.choices,
     )
 
@@ -181,8 +180,8 @@ class HeroLayoutMixin(models.Model):
     hero_layout = models.CharField(
         max_length=20,
         default=HeroLayoutChoices.DEFAULT,
-        verbose_name=_("hero layout"),
-        help_text=_("The layout of the hero component."),
+        verbose_name=("hero layout"),
+        help_text=("The layout of the hero component."),
         choices=HeroLayoutChoices.choices,
     )
 
@@ -204,8 +203,8 @@ class HeroStyleMixin(models.Model):
     hero_style = models.CharField(
         max_length=20,
         default=HeroColourChoices.NONE,
-        verbose_name=_("hero component colour"),
-        help_text=_("The accent colour of the hero component."),
+        verbose_name=("hero component colour"),
+        help_text=("The accent colour of the hero component."),
         choices=HeroColourChoices.choices,
     )
 
@@ -276,24 +275,24 @@ class SocialMixin(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("OpenGraph image"),
-        help_text=_(
+        verbose_name=("OpenGraph image"),
+        help_text=(
             "Image that will appear when this page is shared on social media. This will default to the teaser image if left blank."
         ),
     )
 
     twitter_og_title = models.CharField(
-        verbose_name=_("Twitter OpenGraph title"),
+        verbose_name=("Twitter OpenGraph title"),
         max_length=255,
         blank=True,
         null=True,
-        help_text=_("If left blank, the OpenGraph title will be used."),
+        help_text=("If left blank, the OpenGraph title will be used."),
     )
     twitter_og_description = models.TextField(
-        verbose_name=_("Twitter OpenGraph description"),
+        verbose_name=("Twitter OpenGraph description"),
         blank=True,
         null=True,
-        help_text=_("If left blank, the OpenGraph description will be used."),
+        help_text=("If left blank, the OpenGraph description will be used."),
     )
     twitter_og_image = models.ForeignKey(
         get_image_model_string(),
@@ -301,8 +300,8 @@ class SocialMixin(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("Twitter OpenGraph image"),
-        help_text=_("If left blank, the OpenGraph image will be used."),
+        verbose_name=("Twitter OpenGraph image"),
+        help_text=("If left blank, the OpenGraph image will be used."),
     )
 
     class Meta:
@@ -313,13 +312,13 @@ class SocialMixin(models.Model):
             [
                 FieldPanel(
                     "seo_title",
-                    help_text=_(
+                    help_text=(
                         "The name of the page displayed on search engine results as the clickable headline and when shared on social media."
                     ),
                 ),
                 FieldPanel(
                     "search_description",
-                    help_text=_(
+                    help_text=(
                         "The descriptive text displayed underneath a headline in search engine results and when shared on social media."
                     ),
                 ),

--- a/app/core/models/mixins.py
+++ b/app/core/models/mixins.py
@@ -46,7 +46,7 @@ class ContentWarningMixin(models.Model):
         verbose_name="custom content warning text (optional)",
         features=["link"],
         blank=True,
-        help_text=("If specified, will be used for the content warning."),
+        help_text="If specified, will be used for the content warning.",
     )
 
     content_panels = [
@@ -157,8 +157,8 @@ class AccentColourMixin(models.Model):
     accent_colour = models.CharField(
         max_length=20,
         default=BrandColourChoices.NONE,
-        verbose_name=("page accent colour"),
-        help_text=("The accent colour of the page where relevant."),
+        verbose_name="page accent colour",
+        help_text="The accent colour of the page where relevant.",
         choices=BrandColourChoices.choices,
     )
 
@@ -180,8 +180,8 @@ class HeroLayoutMixin(models.Model):
     hero_layout = models.CharField(
         max_length=20,
         default=HeroLayoutChoices.DEFAULT,
-        verbose_name=("hero layout"),
-        help_text=("The layout of the hero component."),
+        verbose_name="hero layout",
+        help_text="The layout of the hero component.",
         choices=HeroLayoutChoices.choices,
     )
 
@@ -203,8 +203,8 @@ class HeroStyleMixin(models.Model):
     hero_style = models.CharField(
         max_length=20,
         default=HeroColourChoices.NONE,
-        verbose_name=("hero component colour"),
-        help_text=("The accent colour of the hero component."),
+        verbose_name="hero component colour",
+        help_text="The accent colour of the hero component.",
         choices=HeroColourChoices.choices,
     )
 
@@ -275,24 +275,24 @@ class SocialMixin(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("OpenGraph image"),
+        verbose_name="OpenGraph image",
         help_text=(
             "Image that will appear when this page is shared on social media. This will default to the teaser image if left blank."
         ),
     )
 
     twitter_og_title = models.CharField(
-        verbose_name=("Twitter OpenGraph title"),
+        verbose_name="Twitter OpenGraph title",
         max_length=255,
         blank=True,
         null=True,
-        help_text=("If left blank, the OpenGraph title will be used."),
+        help_text="If left blank, the OpenGraph title will be used.",
     )
     twitter_og_description = models.TextField(
-        verbose_name=("Twitter OpenGraph description"),
+        verbose_name="Twitter OpenGraph description",
         blank=True,
         null=True,
-        help_text=("If left blank, the OpenGraph description will be used."),
+        help_text="If left blank, the OpenGraph description will be used.",
     )
     twitter_og_image = models.ForeignKey(
         get_image_model_string(),
@@ -300,8 +300,8 @@ class SocialMixin(models.Model):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("Twitter OpenGraph image"),
-        help_text=("If left blank, the OpenGraph image will be used."),
+        verbose_name="Twitter OpenGraph image",
+        help_text="If left blank, the OpenGraph image will be used.",
     )
 
     class Meta:

--- a/app/core/models/mixins.py
+++ b/app/core/models/mixins.py
@@ -111,9 +111,7 @@ class HeroImageMixin(models.Model):
         verbose_name="hero image caption (optional)",
         features=["bold", "italic", "link"],
         blank=True,
-        help_text=(
-            "An optional caption for hero images. This could be used for image sources or for other useful metadata."
-        ),
+        help_text="An optional caption for hero images. This could be used for image sources or for other useful metadata.",
     )
 
     class Meta:
@@ -276,9 +274,7 @@ class SocialMixin(models.Model):
         on_delete=models.SET_NULL,
         related_name="+",
         verbose_name="OpenGraph image",
-        help_text=(
-            "Image that will appear when this page is shared on social media. This will default to the teaser image if left blank."
-        ),
+        help_text="Image that will appear when this page is shared on social media. This will default to the teaser image if left blank.",
     )
 
     twitter_og_title = models.CharField(
@@ -312,15 +308,11 @@ class SocialMixin(models.Model):
             [
                 FieldPanel(
                     "seo_title",
-                    help_text=(
-                        "The name of the page displayed on search engine results as the clickable headline and when shared on social media."
-                    ),
+                    help_text="The name of the page displayed on search engine results as the clickable headline and when shared on social media.",
                 ),
                 FieldPanel(
                     "search_description",
-                    help_text=(
-                        "The descriptive text displayed underneath a headline in search engine results and when shared on social media."
-                    ),
+                    help_text="The descriptive text displayed underneath a headline in search engine results and when shared on social media.",
                 ),
                 FieldPanel("search_image"),
             ],

--- a/app/core/styling.py
+++ b/app/core/styling.py
@@ -7,13 +7,13 @@ class BrandColourChoices(models.TextChoices):
     on various components on the site.
     """
 
-    NONE = "none", ("None")
-    BLACK = "black", ("Black")
-    PINK = "pink", ("Pink")
-    ORANGE = "orange", ("Orange")
-    YELLOW = "yellow", ("Yellow")
-    GREEN = "green", ("Green")
-    BLUE = "blue", ("Blue")
+    NONE = "none", "None"
+    BLACK = "black", "Black"
+    PINK = "pink", "Pink"
+    ORANGE = "orange", "Orange"
+    YELLOW = "yellow", "Yellow"
+    GREEN = "green", "Green"
+    BLUE = "blue", "Blue"
 
 
 class HeroColourChoices(models.TextChoices):
@@ -22,10 +22,10 @@ class HeroColourChoices(models.TextChoices):
     on the hero component.
     """
 
-    NONE = "none", ("None")
-    CONTRAST = "contrast", ("Contrast")
-    TINT = "tint", ("Tint")
-    ACCENT = "accent", ("Accent")
+    NONE = "none", "None"
+    CONTRAST = "contrast", "Contrast"
+    TINT = "tint", "Tint"
+    ACCENT = "accent", "Accent"
 
 
 class HeroLayoutChoices(models.TextChoices):
@@ -34,6 +34,6 @@ class HeroLayoutChoices(models.TextChoices):
     on the hero component.
     """
 
-    DEFAULT = "default", ("Default")
-    SHIFT = "shift", ("Shifted")
-    SPLIT = "split", ("Split")
+    DEFAULT = "default", "Default"
+    SHIFT = "shift", "Shifted"
+    SPLIT = "split", "Split"

--- a/app/core/styling.py
+++ b/app/core/styling.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 
 
 class BrandColourChoices(models.TextChoices):
@@ -8,13 +7,13 @@ class BrandColourChoices(models.TextChoices):
     on various components on the site.
     """
 
-    NONE = "none", _("None")
-    BLACK = "black", _("Black")
-    PINK = "pink", _("Pink")
-    ORANGE = "orange", _("Orange")
-    YELLOW = "yellow", _("Yellow")
-    GREEN = "green", _("Green")
-    BLUE = "blue", _("Blue")
+    NONE = "none", ("None")
+    BLACK = "black", ("Black")
+    PINK = "pink", ("Pink")
+    ORANGE = "orange", ("Orange")
+    YELLOW = "yellow", ("Yellow")
+    GREEN = "green", ("Green")
+    BLUE = "blue", ("Blue")
 
 
 class HeroColourChoices(models.TextChoices):
@@ -23,10 +22,10 @@ class HeroColourChoices(models.TextChoices):
     on the hero component.
     """
 
-    NONE = "none", _("None")
-    CONTRAST = "contrast", _("Contrast")
-    TINT = "tint", _("Tint")
-    ACCENT = "accent", _("Accent")
+    NONE = "none", ("None")
+    CONTRAST = "contrast", ("Contrast")
+    TINT = "tint", ("Tint")
+    ACCENT = "accent", ("Accent")
 
 
 class HeroLayoutChoices(models.TextChoices):
@@ -35,6 +34,6 @@ class HeroLayoutChoices(models.TextChoices):
     on the hero component.
     """
 
-    DEFAULT = "default", _("Default")
-    SHIFT = "shift", _("Shifted")
-    SPLIT = "split", _("Split")
+    DEFAULT = "default", ("Default")
+    SHIFT = "shift", ("Shifted")
+    SPLIT = "split", ("Split")

--- a/app/education/models/details.py
+++ b/app/education/models/details.py
@@ -13,27 +13,27 @@ class KeyStage(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=("name"),
+        verbose_name="name",
         unique=True,
     )
 
     stage = models.PositiveSmallIntegerField(
-        verbose_name=("stage"),
-        help_text=("Numeric key stage value, e.g. 2, 3, 4."),
+        verbose_name="stage",
+        help_text="Numeric key stage value, e.g. 2, 3, 4.",
         null=True,
         blank=True,
     )
 
     age_range = models.CharField(
         max_length=64,
-        verbose_name=("age range"),
-        help_text=("Age range text, e.g. 5-7 or 7-11."),
+        verbose_name="age range",
+        help_text="Age range text, e.g. 5-7 or 7-11.",
         blank=True,
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=("slug"),
+        verbose_name="slug",
         unique=True,
     )
 
@@ -68,34 +68,34 @@ class TimePeriod(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=("name"),
+        verbose_name="name",
         unique=True,
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=("slug"),
+        verbose_name="slug",
         unique=True,
     )
 
     year_from = models.PositiveIntegerField(
-        verbose_name=("year from"),
+        verbose_name="year from",
         null=True,
         blank=True,
-        help_text=("Starting year, e.g. 1485"),
+        help_text="Starting year, e.g. 1485",
     )
 
     year_to = models.PositiveIntegerField(
-        verbose_name=("year to"),
+        verbose_name="year to",
         null=True,
         blank=True,
-        help_text=("Ending year, e.g. 1750"),
+        help_text="Ending year, e.g. 1750",
     )
 
     available_for_resources = models.BooleanField(
         default=True,
-        verbose_name=("available for resources"),
-        help_text=("Whether this time period can be tagged on teaching resources."),
+        verbose_name="available for resources",
+        help_text="Whether this time period can be tagged on teaching resources.",
     )
 
     @cached_property
@@ -131,13 +131,13 @@ class Theme(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=("name"),
+        verbose_name="name",
         unique=True,
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=("slug"),
+        verbose_name="slug",
         unique=True,
     )
 
@@ -157,7 +157,7 @@ class BaseKeyStageTag(TagDuplicateCheckMixin, Orderable):
         "education.KeyStage",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("key stage"),
+        verbose_name="key stage",
     )
 
     panels = [
@@ -176,7 +176,7 @@ class BaseTimePeriodTag(TagDuplicateCheckMixin, Orderable):
         "education.TimePeriod",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("time period"),
+        verbose_name="time period",
     )
 
     panels = [
@@ -195,7 +195,7 @@ class BaseThemeTag(TagDuplicateCheckMixin, Orderable):
         "education.Theme",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("theme"),
+        verbose_name="theme",
     )
 
     panels = [

--- a/app/education/models/details.py
+++ b/app/education/models/details.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel
 from wagtail.models import Orderable
 
@@ -14,33 +13,33 @@ class KeyStage(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=_("name"),
+        verbose_name=("name"),
         unique=True,
     )
 
     stage = models.PositiveSmallIntegerField(
-        verbose_name=_("stage"),
-        help_text=_("Numeric key stage value, e.g. 2, 3, 4."),
+        verbose_name=("stage"),
+        help_text=("Numeric key stage value, e.g. 2, 3, 4."),
         null=True,
         blank=True,
     )
 
     age_range = models.CharField(
         max_length=64,
-        verbose_name=_("age range"),
-        help_text=_("Age range text, e.g. 5-7 or 7-11."),
+        verbose_name=("age range"),
+        help_text=("Age range text, e.g. 5-7 or 7-11."),
         blank=True,
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=_("slug"),
+        verbose_name=("slug"),
         unique=True,
     )
 
     class Meta:
-        verbose_name = _("Key stage")
-        verbose_name_plural = _("Key stages")
+        verbose_name = "Key stage"
+        verbose_name_plural = "Key stages"
 
     @property
     def display_name(self):
@@ -69,34 +68,34 @@ class TimePeriod(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=_("name"),
+        verbose_name=("name"),
         unique=True,
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=_("slug"),
+        verbose_name=("slug"),
         unique=True,
     )
 
     year_from = models.PositiveIntegerField(
-        verbose_name=_("year from"),
+        verbose_name=("year from"),
         null=True,
         blank=True,
-        help_text=_("Starting year, e.g. 1485"),
+        help_text=("Starting year, e.g. 1485"),
     )
 
     year_to = models.PositiveIntegerField(
-        verbose_name=_("year to"),
+        verbose_name=("year to"),
         null=True,
         blank=True,
-        help_text=_("Ending year, e.g. 1750"),
+        help_text=("Ending year, e.g. 1750"),
     )
 
     available_for_resources = models.BooleanField(
         default=True,
-        verbose_name=_("available for resources"),
-        help_text=_("Whether this time period can be tagged on teaching resources."),
+        verbose_name=("available for resources"),
+        help_text=("Whether this time period can be tagged on teaching resources."),
     )
 
     @cached_property
@@ -120,8 +119,8 @@ class TimePeriod(models.Model):
         return self.name
 
     class Meta:
-        verbose_name = _("Time period")
-        verbose_name_plural = _("Time periods")
+        verbose_name = "Time period"
+        verbose_name_plural = "Time periods"
 
     def __str__(self):
         return self.display_name
@@ -132,19 +131,19 @@ class Theme(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=_("name"),
+        verbose_name=("name"),
         unique=True,
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=_("slug"),
+        verbose_name=("slug"),
         unique=True,
     )
 
     class Meta:
-        verbose_name = _("Theme")
-        verbose_name_plural = _("Themes")
+        verbose_name = "Theme"
+        verbose_name_plural = "Themes"
 
     def __str__(self):
         return self.name
@@ -152,13 +151,13 @@ class Theme(models.Model):
 
 class BaseKeyStageTag(TagDuplicateCheckMixin, Orderable):
     FK_FIELD_NAME = "key_stage"
-    FIELD_LABEL = _("key stage")
+    FIELD_LABEL = "key stage"
 
     key_stage = models.ForeignKey(
         "education.KeyStage",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("key stage"),
+        verbose_name=("key stage"),
     )
 
     panels = [
@@ -171,13 +170,13 @@ class BaseKeyStageTag(TagDuplicateCheckMixin, Orderable):
 
 class BaseTimePeriodTag(TagDuplicateCheckMixin, Orderable):
     FK_FIELD_NAME = "time_period"
-    FIELD_LABEL = _("time period")
+    FIELD_LABEL = "time period"
 
     time_period = models.ForeignKey(
         "education.TimePeriod",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("time period"),
+        verbose_name=("time period"),
     )
 
     panels = [
@@ -190,13 +189,13 @@ class BaseTimePeriodTag(TagDuplicateCheckMixin, Orderable):
 
 class BaseThemeTag(TagDuplicateCheckMixin, Orderable):
     FK_FIELD_NAME = "theme"
-    FIELD_LABEL = _("theme")
+    FIELD_LABEL = "theme"
 
     theme = models.ForeignKey(
         "education.Theme",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("theme"),
+        verbose_name=("theme"),
     )
 
     panels = [

--- a/app/education/models/landing.py
+++ b/app/education/models/landing.py
@@ -80,14 +80,14 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("teaching resource listing page"),
+        verbose_name="teaching resource listing page",
         help_text=(
             "The teaching resource listing page to display on the Education landing page."
         ),
     )
 
     teaching_resources_teaser_override = models.CharField(
-        verbose_name=("teaching resources teaser text"),
+        verbose_name="teaching resources teaser text",
         help_text=(
             "Short text under Explore teaching resources title to entice users to click through"
         ),
@@ -101,15 +101,15 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured teaching resource"),
+        verbose_name="featured teaching resource",
         help_text=(
             "Option to add a highlighted teaching resource, particularly for history months etc"
         ),
     )
 
     featured_teaching_resource_teaser_override = models.CharField(
-        verbose_name=("Featured teaching resource teaser text override"),
-        help_text=("Override text for the featured teaching resource"),
+        verbose_name="Featured teaching resource teaser text override",
+        help_text="Override text for the featured teaching resource",
         blank=True,
         max_length=160,
     )
@@ -121,14 +121,14 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("education sessions listing page"),
+        verbose_name="education sessions listing page",
         help_text=(
             "The education sessions listing page to display on the Education landing page."
         ),
     )
 
     education_sessions_teaser_override = models.CharField(
-        verbose_name=("education sessions teaser text"),
+        verbose_name="education sessions teaser text",
         help_text=(
             "Short text under Explore education sessions title to entice users to click through"
         ),
@@ -142,13 +142,13 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured education session"),
-        help_text=("Page picker to highlight a featured education session"),
+        verbose_name="featured education session",
+        help_text="Page picker to highlight a featured education session",
     )
 
     featured_education_session_teaser_override = models.CharField(
-        verbose_name=("Featured education session teaser text override"),
-        help_text=("Override text for the featured education session"),
+        verbose_name="Featured education session teaser text override",
+        help_text="Override text for the featured education session",
         blank=True,
         max_length=160,
     )
@@ -164,7 +164,7 @@ class EducationPage(BasePageWithRequiredIntro):
                     ],
                 ),
             ],
-            heading=("Teaching resources"),
+            heading="Teaching resources",
         ),
         MultiFieldPanel(
             [
@@ -176,12 +176,12 @@ class EducationPage(BasePageWithRequiredIntro):
                     ],
                 ),
             ],
-            heading=("Education sessions"),
+            heading="Education sessions",
         ),
         InlinePanel(
             "education_read_more_links",
-            heading=("Read more"),
-            help_text=("Navigation to other sections within Education"),
+            heading="Read more",
+            help_text="Navigation to other sections within Education",
         ),
     ]
 
@@ -223,7 +223,7 @@ class EducationReadMoreLink(Orderable):
         "wagtailcore.Page",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("selected page"),
+        verbose_name="selected page",
     )
 
     panels = [

--- a/app/education/models/landing.py
+++ b/app/education/models/landing.py
@@ -81,16 +81,12 @@ class EducationPage(BasePageWithRequiredIntro):
         on_delete=models.SET_NULL,
         related_name="+",
         verbose_name="teaching resource listing page",
-        help_text=(
-            "The teaching resource listing page to display on the Education landing page."
-        ),
+        help_text="The teaching resource listing page to display on the Education landing page.",
     )
 
     teaching_resources_teaser_override = models.CharField(
         verbose_name="teaching resources teaser text",
-        help_text=(
-            "Short text under Explore teaching resources title to entice users to click through"
-        ),
+        help_text="Short text under Explore teaching resources title to entice users to click through",
         blank=True,
         max_length=160,
     )
@@ -102,9 +98,7 @@ class EducationPage(BasePageWithRequiredIntro):
         on_delete=models.SET_NULL,
         related_name="+",
         verbose_name="featured teaching resource",
-        help_text=(
-            "Option to add a highlighted teaching resource, particularly for history months etc"
-        ),
+        help_text="Option to add a highlighted teaching resource, particularly for history months etc",
     )
 
     featured_teaching_resource_teaser_override = models.CharField(
@@ -122,16 +116,12 @@ class EducationPage(BasePageWithRequiredIntro):
         on_delete=models.SET_NULL,
         related_name="+",
         verbose_name="education sessions listing page",
-        help_text=(
-            "The education sessions listing page to display on the Education landing page."
-        ),
+        help_text="The education sessions listing page to display on the Education landing page.",
     )
 
     education_sessions_teaser_override = models.CharField(
         verbose_name="education sessions teaser text",
-        help_text=(
-            "Short text under Explore education sessions title to entice users to click through"
-        ),
+        help_text="Short text under Explore education sessions title to entice users to click through",
         blank=True,
         max_length=160,
     )

--- a/app/education/models/landing.py
+++ b/app/education/models/landing.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import (
     FieldPanel,
@@ -81,15 +80,15 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("teaching resource listing page"),
-        help_text=_(
+        verbose_name=("teaching resource listing page"),
+        help_text=(
             "The teaching resource listing page to display on the Education landing page."
         ),
     )
 
     teaching_resources_teaser_override = models.CharField(
-        verbose_name=_("teaching resources teaser text"),
-        help_text=_(
+        verbose_name=("teaching resources teaser text"),
+        help_text=(
             "Short text under Explore teaching resources title to entice users to click through"
         ),
         blank=True,
@@ -102,15 +101,15 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured teaching resource"),
-        help_text=_(
+        verbose_name=("featured teaching resource"),
+        help_text=(
             "Option to add a highlighted teaching resource, particularly for history months etc"
         ),
     )
 
     featured_teaching_resource_teaser_override = models.CharField(
-        verbose_name=_("Featured teaching resource teaser text override"),
-        help_text=_("Override text for the featured teaching resource"),
+        verbose_name=("Featured teaching resource teaser text override"),
+        help_text=("Override text for the featured teaching resource"),
         blank=True,
         max_length=160,
     )
@@ -122,15 +121,15 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("education sessions listing page"),
-        help_text=_(
+        verbose_name=("education sessions listing page"),
+        help_text=(
             "The education sessions listing page to display on the Education landing page."
         ),
     )
 
     education_sessions_teaser_override = models.CharField(
-        verbose_name=_("education sessions teaser text"),
-        help_text=_(
+        verbose_name=("education sessions teaser text"),
+        help_text=(
             "Short text under Explore education sessions title to entice users to click through"
         ),
         blank=True,
@@ -143,13 +142,13 @@ class EducationPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured education session"),
-        help_text=_("Page picker to highlight a featured education session"),
+        verbose_name=("featured education session"),
+        help_text=("Page picker to highlight a featured education session"),
     )
 
     featured_education_session_teaser_override = models.CharField(
-        verbose_name=_("Featured education session teaser text override"),
-        help_text=_("Override text for the featured education session"),
+        verbose_name=("Featured education session teaser text override"),
+        help_text=("Override text for the featured education session"),
         blank=True,
         max_length=160,
     )
@@ -165,7 +164,7 @@ class EducationPage(BasePageWithRequiredIntro):
                     ],
                 ),
             ],
-            heading=_("Teaching resources"),
+            heading=("Teaching resources"),
         ),
         MultiFieldPanel(
             [
@@ -177,12 +176,12 @@ class EducationPage(BasePageWithRequiredIntro):
                     ],
                 ),
             ],
-            heading=_("Education sessions"),
+            heading=("Education sessions"),
         ),
         InlinePanel(
             "education_read_more_links",
-            heading=_("Read more"),
-            help_text=_("Navigation to other sections within Education"),
+            heading=("Read more"),
+            help_text=("Navigation to other sections within Education"),
         ),
     ]
 
@@ -208,7 +207,7 @@ class EducationPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Education landing page")
+        verbose_name = "Education landing page"
 
 
 class EducationReadMoreLink(Orderable):
@@ -224,7 +223,7 @@ class EducationReadMoreLink(Orderable):
         "wagtailcore.Page",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("selected page"),
+        verbose_name=("selected page"),
     )
 
     panels = [
@@ -235,5 +234,5 @@ class EducationReadMoreLink(Orderable):
     ]
 
     class Meta:
-        verbose_name = _("read more link")
+        verbose_name = "read more link"
         ordering = ["sort_order"]

--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import (
     FieldPanel,
     MultiFieldPanel,
@@ -34,15 +33,15 @@ class TeachingResourcesListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured teaching resource"),
-        help_text=_(
+        verbose_name=("featured teaching resource"),
+        help_text=(
             "Option to add a highlighted teaching resource, particularly for history months etc"
         ),
     )
 
     featured_teaching_resource_teaser_override = models.CharField(
-        verbose_name=_("Featured teaching resource teaser text override"),
-        help_text=_("Override text for the featured teaching resource"),
+        verbose_name=("Featured teaching resource teaser text override"),
+        help_text=("Override text for the featured teaching resource"),
         blank=True,
         max_length=160,
     )
@@ -53,7 +52,7 @@ class TeachingResourcesListingPage(BasePageWithRequiredIntro):
                 PageChooserPanel("featured_teaching_resource"),
                 FieldPanel("featured_teaching_resource_teaser_override"),
             ],
-            heading=_("Featured teaching resource"),
+            heading=("Featured teaching resource"),
         ),
     ]
 
@@ -63,7 +62,7 @@ class TeachingResourcesListingPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Teaching Resources listing page")
+        verbose_name = "Teaching Resources listing page"
 
 
 class EducationSessionsListingPage(BasePageWithRequiredIntro):
@@ -87,13 +86,13 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured education session"),
-        help_text=_("Page picker to highlight a featured education session"),
+        verbose_name=("featured education session"),
+        help_text=("Page picker to highlight a featured education session"),
     )
 
     featured_education_session_teaser_override = models.CharField(
-        verbose_name=_("Featured education session teaser text override"),
-        help_text=_("Override text for the featured education session"),
+        verbose_name=("Featured education session teaser text override"),
+        help_text=("Override text for the featured education session"),
         blank=True,
         max_length=160,
     )
@@ -104,7 +103,7 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
                 PageChooserPanel("featured_education_session"),
                 FieldPanel("featured_education_session_teaser_override"),
             ],
-            heading=_("Featured education session"),
+            heading=("Featured education session"),
         ),
     ]
 
@@ -114,4 +113,4 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Education Sessions listing page")
+        verbose_name = "Education Sessions listing page"

--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -34,9 +34,7 @@ class TeachingResourcesListingPage(BasePageWithRequiredIntro):
         on_delete=models.SET_NULL,
         related_name="+",
         verbose_name="featured teaching resource",
-        help_text=(
-            "Option to add a highlighted teaching resource, particularly for history months etc"
-        ),
+        help_text="Option to add a highlighted teaching resource, particularly for history months etc",
     )
 
     featured_teaching_resource_teaser_override = models.CharField(

--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -33,15 +33,15 @@ class TeachingResourcesListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured teaching resource"),
+        verbose_name="featured teaching resource",
         help_text=(
             "Option to add a highlighted teaching resource, particularly for history months etc"
         ),
     )
 
     featured_teaching_resource_teaser_override = models.CharField(
-        verbose_name=("Featured teaching resource teaser text override"),
-        help_text=("Override text for the featured teaching resource"),
+        verbose_name="Featured teaching resource teaser text override",
+        help_text="Override text for the featured teaching resource",
         blank=True,
         max_length=160,
     )
@@ -52,7 +52,7 @@ class TeachingResourcesListingPage(BasePageWithRequiredIntro):
                 PageChooserPanel("featured_teaching_resource"),
                 FieldPanel("featured_teaching_resource_teaser_override"),
             ],
-            heading=("Featured teaching resource"),
+            heading="Featured teaching resource",
         ),
     ]
 
@@ -86,13 +86,13 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured education session"),
-        help_text=("Page picker to highlight a featured education session"),
+        verbose_name="featured education session",
+        help_text="Page picker to highlight a featured education session",
     )
 
     featured_education_session_teaser_override = models.CharField(
-        verbose_name=("Featured education session teaser text override"),
-        help_text=("Override text for the featured education session"),
+        verbose_name="Featured education session teaser text override",
+        help_text="Override text for the featured education session",
         blank=True,
         max_length=160,
     )
@@ -103,7 +103,7 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
                 PageChooserPanel("featured_education_session"),
                 FieldPanel("featured_education_session_teaser_override"),
             ],
-            heading=("Featured education session"),
+            heading="Featured education session",
         ),
     ]
 

--- a/app/education/models/mixins.py
+++ b/app/education/models/mixins.py
@@ -41,18 +41,18 @@ class EducationTaxonomyMixin:
         return [
             InlinePanel(
                 "education_keystage_tags",
-                label=("Key stage tag"),
-                heading=("Key stages"),
+                label="Key stage tag",
+                heading="Key stages",
             ),
             InlinePanel(
                 "education_time_period_tags",
-                label=("Time period tag"),
-                heading=("Time periods"),
+                label="Time period tag",
+                heading="Time periods",
             ),
             InlinePanel(
                 "education_theme_tags",
-                label=("Theme tag"),
-                heading=("Themes"),
+                label="Theme tag",
+                heading="Themes",
             ),
         ]
 

--- a/app/education/models/mixins.py
+++ b/app/education/models/mixins.py
@@ -1,5 +1,4 @@
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import InlinePanel
 
 
@@ -42,18 +41,18 @@ class EducationTaxonomyMixin:
         return [
             InlinePanel(
                 "education_keystage_tags",
-                label=_("Key stage tag"),
-                heading=_("Key stages"),
+                label=("Key stage tag"),
+                heading=("Key stages"),
             ),
             InlinePanel(
                 "education_time_period_tags",
-                label=_("Time period tag"),
-                heading=_("Time periods"),
+                label=("Time period tag"),
+                heading=("Time periods"),
             ),
             InlinePanel(
                 "education_theme_tags",
-                label=_("Theme tag"),
-                heading=_("Themes"),
+                label=("Theme tag"),
+                heading=("Themes"),
             ),
         ]
 

--- a/app/education/models/resources.py
+++ b/app/education/models/resources.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import (
     FieldPanel,
@@ -62,7 +61,7 @@ class TeachingResourcePageTimePeriodTag(BaseTimePeriodTag):
         "education.TimePeriod",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("time period"),
+        verbose_name=("time period"),
         limit_choices_to={"available_for_resources": True},
     )
 
@@ -83,16 +82,16 @@ class Source(Orderable):
     )
 
     title = models.CharField(
-        verbose_name=_("source title"),
-        help_text=_("A unique, descriptive title for the source."),
+        verbose_name=("source title"),
+        help_text=("A unique, descriptive title for the source."),
         blank=True,
         max_length=160,
     )
 
     media = StreamField(
         SourceMediaBlock(),
-        verbose_name=_("source media"),
-        help_text=_(
+        verbose_name=("source media"),
+        help_text=(
             "Choose one media type for this source. A caption can be added for each."
         ),
         blank=True,
@@ -101,16 +100,16 @@ class Source(Orderable):
 
     featured_link = StreamField(
         SourceFeaturedLinkBlock(),
-        verbose_name=_("source media featured link"),
-        help_text=_("Choose internal or external link for this source"),
+        verbose_name=("source media featured link"),
+        help_text=("Choose internal or external link for this source"),
         blank=True,
         max_num=1,
     )
 
     description = RichTextField(
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
-        verbose_name=_("source description"),
-        help_text=_(
+        verbose_name=("source description"),
+        help_text=(
             "An optional free text field to add in a fuller description of the source."
         ),
         blank=True,
@@ -145,14 +144,14 @@ class CurriculumConnection(Orderable):
         "education.KeyStage",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("Key stage"),
-        help_text=_("The key stage for this curriculum connection."),
+        verbose_name=("Key stage"),
+        help_text=("The key stage for this curriculum connection."),
     )
 
     description = RichTextField(
         features=["bold", "italic", "link", "ul"],
-        verbose_name=_("curriculum connection description"),
-        help_text=_("Add the curriculum connection description."),
+        verbose_name=("curriculum connection description"),
+        help_text=("Add the curriculum connection description."),
         blank=True,
         null=True,
     )
@@ -181,14 +180,14 @@ class TeachingResourcePage(
     ]
 
     enquiry_question = models.CharField(
-        verbose_name=_("enquiry question"),
+        verbose_name=("enquiry question"),
         blank=True,
         max_length=160,
     )
 
     sources_title = models.CharField(
-        verbose_name=_("sources title"),
-        help_text=_(
+        verbose_name=("sources title"),
+        help_text=(
             "Title of the main section of the page. In most cases ‘Investigate the sources’"
         ),
         blank=True,
@@ -197,16 +196,16 @@ class TeachingResourcePage(
 
     sources_introduction = RichTextField(
         features=["bold", "italic", "link"],
-        verbose_name=_("sources introduction"),
-        help_text=_("Optional text field to provide an introduction to the sources."),
+        verbose_name=("sources introduction"),
+        help_text=("Optional text field to provide an introduction to the sources."),
         blank=True,
         null=True,
     )
 
     teachers_notes = RichTextField(
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
-        verbose_name=_("teachers notes"),
-        help_text=_(
+        verbose_name=("teachers notes"),
+        help_text=(
             "A general overview of what the resource contains and how it can be used."
         ),
         blank=True,
@@ -223,8 +222,8 @@ class TeachingResourcePage(
             ("featured_page", FeaturedPageBlock()),
             ("featured_external_link", FeaturedExternalLinkBlock()),
         ],
-        verbose_name=_("extension activities"),
-        help_text=_(
+        verbose_name=("extension activities"),
+        help_text=(
             "Optional section where editors can add extra activities for teachers to try with their pupils."
         ),
         blank=True,
@@ -239,16 +238,16 @@ class TeachingResourcePage(
             ),
             ("sub_heading", SubHeadingBlock()),
         ],
-        verbose_name=_("background information"),
-        help_text=_("Section providing historical context to the teaching resource."),
+        verbose_name=("background information"),
+        help_text=("Section providing historical context to the teaching resource."),
         blank=True,
         null=True,
     )
 
     further_information_title = models.CharField(
         max_length=255,
-        verbose_name=_("further information title"),
-        help_text=_("Title of the further information section."),
+        verbose_name=("further information title"),
+        help_text=("Title of the further information section."),
         blank=True,
         null=True,
     )
@@ -263,8 +262,8 @@ class TeachingResourcePage(
             ("featured_external_link", FeaturedExternalLinkBlock()),
             ("featured_page", FeaturedPageBlock()),
         ],
-        verbose_name=_("further information"),
-        help_text=_("Section providing links to other useful information."),
+        verbose_name=("further information"),
+        help_text=("Section providing links to other useful information."),
         blank=True,
         null=True,
     )
@@ -281,18 +280,18 @@ class TeachingResourcePage(
                     FieldPanel("sources_introduction"),
                     InlinePanel(
                         "sources",
-                        label=_("Source"),
-                        heading=_("Sources"),
+                        label=("Source"),
+                        heading=("Sources"),
                         min_num=1,
                     ),
                 ],
-                heading=_("Sources"),
+                heading=("Sources"),
             ),
             FieldPanel("teachers_notes"),
             InlinePanel(
                 "curriculum_connections",
-                label=_("Curriculum connection"),
-                heading=_("Connections to the curriculum"),
+                label=("Curriculum connection"),
+                heading=("Connections to the curriculum"),
                 min_num=1,
             ),
             FieldPanel("extension_activities"),
@@ -302,7 +301,7 @@ class TeachingResourcePage(
                     FieldPanel("further_information_title"),
                     FieldPanel("further_information"),
                 ],
-                heading=_("Further information"),
+                heading=("Further information"),
             ),
         ]
     )

--- a/app/education/models/resources.py
+++ b/app/education/models/resources.py
@@ -61,7 +61,7 @@ class TeachingResourcePageTimePeriodTag(BaseTimePeriodTag):
         "education.TimePeriod",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("time period"),
+        verbose_name="time period",
         limit_choices_to={"available_for_resources": True},
     )
 
@@ -82,15 +82,15 @@ class Source(Orderable):
     )
 
     title = models.CharField(
-        verbose_name=("source title"),
-        help_text=("A unique, descriptive title for the source."),
+        verbose_name="source title",
+        help_text="A unique, descriptive title for the source.",
         blank=True,
         max_length=160,
     )
 
     media = StreamField(
         SourceMediaBlock(),
-        verbose_name=("source media"),
+        verbose_name="source media",
         help_text=(
             "Choose one media type for this source. A caption can be added for each."
         ),
@@ -100,15 +100,15 @@ class Source(Orderable):
 
     featured_link = StreamField(
         SourceFeaturedLinkBlock(),
-        verbose_name=("source media featured link"),
-        help_text=("Choose internal or external link for this source"),
+        verbose_name="source media featured link",
+        help_text="Choose internal or external link for this source",
         blank=True,
         max_num=1,
     )
 
     description = RichTextField(
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
-        verbose_name=("source description"),
+        verbose_name="source description",
         help_text=(
             "An optional free text field to add in a fuller description of the source."
         ),
@@ -118,8 +118,8 @@ class Source(Orderable):
 
     question = StreamField(
         SourceQuestionBlock(
-            verbose_name=("source question"),
-            help_text=("A series of questions relating to the source."),
+            verbose_name="source question",
+            help_text="A series of questions relating to the source.",
         ),
         blank=True,
     )
@@ -144,14 +144,14 @@ class CurriculumConnection(Orderable):
         "education.KeyStage",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("Key stage"),
-        help_text=("The key stage for this curriculum connection."),
+        verbose_name="Key stage",
+        help_text="The key stage for this curriculum connection.",
     )
 
     description = RichTextField(
         features=["bold", "italic", "link", "ul"],
-        verbose_name=("curriculum connection description"),
-        help_text=("Add the curriculum connection description."),
+        verbose_name="curriculum connection description",
+        help_text="Add the curriculum connection description.",
         blank=True,
         null=True,
     )
@@ -180,13 +180,13 @@ class TeachingResourcePage(
     ]
 
     enquiry_question = models.CharField(
-        verbose_name=("enquiry question"),
+        verbose_name="enquiry question",
         blank=True,
         max_length=160,
     )
 
     sources_title = models.CharField(
-        verbose_name=("sources title"),
+        verbose_name="sources title",
         help_text=(
             "Title of the main section of the page. In most cases ‘Investigate the sources’"
         ),
@@ -196,15 +196,15 @@ class TeachingResourcePage(
 
     sources_introduction = RichTextField(
         features=["bold", "italic", "link"],
-        verbose_name=("sources introduction"),
-        help_text=("Optional text field to provide an introduction to the sources."),
+        verbose_name="sources introduction",
+        help_text="Optional text field to provide an introduction to the sources.",
         blank=True,
         null=True,
     )
 
     teachers_notes = RichTextField(
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
-        verbose_name=("teachers notes"),
+        verbose_name="teachers notes",
         help_text=(
             "A general overview of what the resource contains and how it can be used."
         ),
@@ -222,7 +222,7 @@ class TeachingResourcePage(
             ("featured_page", FeaturedPageBlock()),
             ("featured_external_link", FeaturedExternalLinkBlock()),
         ],
-        verbose_name=("extension activities"),
+        verbose_name="extension activities",
         help_text=(
             "Optional section where editors can add extra activities for teachers to try with their pupils."
         ),
@@ -238,16 +238,16 @@ class TeachingResourcePage(
             ),
             ("sub_heading", SubHeadingBlock()),
         ],
-        verbose_name=("background information"),
-        help_text=("Section providing historical context to the teaching resource."),
+        verbose_name="background information",
+        help_text="Section providing historical context to the teaching resource.",
         blank=True,
         null=True,
     )
 
     further_information_title = models.CharField(
         max_length=255,
-        verbose_name=("further information title"),
-        help_text=("Title of the further information section."),
+        verbose_name="further information title",
+        help_text="Title of the further information section.",
         blank=True,
         null=True,
     )
@@ -262,8 +262,8 @@ class TeachingResourcePage(
             ("featured_external_link", FeaturedExternalLinkBlock()),
             ("featured_page", FeaturedPageBlock()),
         ],
-        verbose_name=("further information"),
-        help_text=("Section providing links to other useful information."),
+        verbose_name="further information",
+        help_text="Section providing links to other useful information.",
         blank=True,
         null=True,
     )
@@ -280,18 +280,18 @@ class TeachingResourcePage(
                     FieldPanel("sources_introduction"),
                     InlinePanel(
                         "sources",
-                        label=("Source"),
-                        heading=("Sources"),
+                        label="Source",
+                        heading="Sources",
                         min_num=1,
                     ),
                 ],
-                heading=("Sources"),
+                heading="Sources",
             ),
             FieldPanel("teachers_notes"),
             InlinePanel(
                 "curriculum_connections",
-                label=("Curriculum connection"),
-                heading=("Connections to the curriculum"),
+                label="Curriculum connection",
+                heading="Connections to the curriculum",
                 min_num=1,
             ),
             FieldPanel("extension_activities"),
@@ -301,7 +301,7 @@ class TeachingResourcePage(
                     FieldPanel("further_information_title"),
                     FieldPanel("further_information"),
                 ],
-                heading=("Further information"),
+                heading="Further information",
             ),
         ]
     )

--- a/app/education/models/resources.py
+++ b/app/education/models/resources.py
@@ -91,9 +91,7 @@ class Source(Orderable):
     media = StreamField(
         SourceMediaBlock(),
         verbose_name="source media",
-        help_text=(
-            "Choose one media type for this source. A caption can be added for each."
-        ),
+        help_text="Choose one media type for this source. A caption can be added for each.",
         blank=True,
         null=True,
     )
@@ -109,9 +107,7 @@ class Source(Orderable):
     description = RichTextField(
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
         verbose_name="source description",
-        help_text=(
-            "An optional free text field to add in a fuller description of the source."
-        ),
+        help_text="An optional free text field to add in a fuller description of the source.",
         blank=True,
         null=True,
     )
@@ -187,9 +183,7 @@ class TeachingResourcePage(
 
     sources_title = models.CharField(
         verbose_name="sources title",
-        help_text=(
-            "Title of the main section of the page. In most cases ‘Investigate the sources’"
-        ),
+        help_text="Title of the main section of the page. In most cases ‘Investigate the sources’",
         blank=True,
         max_length=160,
     )
@@ -205,9 +199,7 @@ class TeachingResourcePage(
     teachers_notes = RichTextField(
         features=settings.RESTRICTED_RICH_TEXT_FEATURES,
         verbose_name="teachers notes",
-        help_text=(
-            "A general overview of what the resource contains and how it can be used."
-        ),
+        help_text="A general overview of what the resource contains and how it can be used.",
         blank=True,
         null=True,
     )
@@ -223,9 +215,7 @@ class TeachingResourcePage(
             ("featured_external_link", FeaturedExternalLinkBlock()),
         ],
         verbose_name="extension activities",
-        help_text=(
-            "Optional section where editors can add extra activities for teachers to try with their pupils."
-        ),
+        help_text="Optional section where editors can add extra activities for teachers to try with their pupils.",
         blank=True,
         null=True,
     )

--- a/app/education/models/sessions.py
+++ b/app/education/models/sessions.py
@@ -65,10 +65,10 @@ class EducationSessionPageThemeTag(BaseThemeTag):
 
 class SessionLocation(Orderable):
     class LocationType(models.TextChoices):
-        ONLINE = "online", ("Online")
-        NATIONAL_ARCHIVES = "national_archives", ("At The National Archives")
-        YOUR_SCHOOL = "your_school", ("At your school")
-        CUSTOM = "custom", ("Custom venue")
+        ONLINE = "online", "Online"
+        NATIONAL_ARCHIVES = "national_archives", "At The National Archives"
+        YOUR_SCHOOL = "your_school", "At your school"
+        CUSTOM = "custom", "Custom venue"
 
     class Regions(models.TextChoices):
         SOUTH_EAST = "south_east", "South East and London"
@@ -312,14 +312,12 @@ class EducationSessionPage(
         if self.price is not None and not self.price_detail:
             raise ValidationError(
                 {
-                    "price_detail": (
-                        "Price detail is required when a session price is specified."
-                    )
+                    "price_detail": "Price detail is required when a session price is specified."
                 }
             )
         if self.price is None and self.price_detail:
             raise ValidationError(
-                {"price": ("Price is required when price detail is specified.")}
+                {"price": "Price is required when price detail is specified."}
             )
         if (
             self.start_date is not None
@@ -327,7 +325,7 @@ class EducationSessionPage(
             and self.start_date >= self.end_date
         ):
             raise ValidationError(
-                {"end_date": ("End date must be later than start date.")}
+                {"end_date": "End date must be later than start date."}
             )
 
     content_panels = (

--- a/app/education/models/sessions.py
+++ b/app/education/models/sessions.py
@@ -86,13 +86,13 @@ class SessionLocation(Orderable):
     location_type = models.CharField(
         max_length=32,
         choices=LocationType.choices,
-        verbose_name=("location type"),
-        help_text=("Choose a standard location or Custom venue."),
+        verbose_name="location type",
+        help_text="Choose a standard location or Custom venue.",
         null=True,
     )
 
     duration = models.CharField(
-        verbose_name=("duration"),
+        verbose_name="duration",
         help_text=(
             "A clear description of the session duration for this location, e.g. 1 hour, 1 to 2 hours."
         ),
@@ -104,7 +104,7 @@ class SessionLocation(Orderable):
     region = models.CharField(
         max_length=32,
         choices=Regions.choices,
-        verbose_name=("region"),
+        verbose_name="region",
         help_text=(
             "The region where the session is offered. Required for schools and custom venues."
         ),
@@ -116,32 +116,32 @@ class SessionLocation(Orderable):
         blank=True,
         null=True,
         max_length=255,
-        verbose_name=("Venue name"),
-        help_text=("Required only when location type is Custom venue."),
+        verbose_name="Venue name",
+        help_text="Required only when location type is Custom venue.",
     )
 
     address_line_1 = models.CharField(
         blank=True,
         null=True,
         max_length=255,
-        verbose_name=("Address line 1"),
-        help_text=("Required only when location type is Custom venue."),
+        verbose_name="Address line 1",
+        help_text="Required only when location type is Custom venue.",
     )
 
     address_line_2 = models.CharField(
         blank=True,
         null=True,
         max_length=255,
-        verbose_name=("Address line 2"),
-        help_text=("Required only when location type is Custom venue."),
+        verbose_name="Address line 2",
+        help_text="Required only when location type is Custom venue.",
     )
 
     postcode = models.CharField(
         blank=True,
         null=True,
         max_length=20,
-        verbose_name=("Postcode"),
-        help_text=("Required only when location type is Custom venue."),
+        verbose_name="Postcode",
+        help_text="Required only when location type is Custom venue.",
     )
 
     panels = [
@@ -155,7 +155,7 @@ class SessionLocation(Orderable):
                 FieldPanel("address_line_2"),
                 FieldPanel("postcode"),
             ],
-            heading=("Custom venue address details"),
+            heading="Custom venue address details",
         ),
     ]
 
@@ -233,7 +233,7 @@ class RelatedEducationSessions(Orderable):
         "education.EducationSessionPage",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("selected page"),
+        verbose_name="selected page",
     )
 
     class Meta:
@@ -258,7 +258,7 @@ class EducationSessionPage(
     ]
 
     start_date = models.DateField(
-        verbose_name=("start date"),
+        verbose_name="start date",
         null=True,
         blank=True,
         help_text=(
@@ -267,7 +267,7 @@ class EducationSessionPage(
     )
 
     end_date = models.DateField(
-        verbose_name=("end date"),
+        verbose_name="end date",
         null=True,
         blank=True,
         help_text=(
@@ -275,11 +275,11 @@ class EducationSessionPage(
         ),
     )
 
-    price = models.FloatField(null=True, blank=True, verbose_name=("price"))
+    price = models.FloatField(null=True, blank=True, verbose_name="price")
 
     price_detail = models.CharField(
-        verbose_name=("price detail"),
-        help_text=("An explanation of the price. Required if price is filled in."),
+        verbose_name="price detail",
+        help_text="An explanation of the price. Required if price is filled in.",
         blank=True,
         null=True,
         max_length=160,
@@ -288,20 +288,20 @@ class EducationSessionPage(
     booking_link = models.URLField(
         null=True,
         blank=True,
-        help_text=("Link to booking page"),
-        verbose_name=("Booking link"),
+        help_text="Link to booking page",
+        verbose_name="Booking link",
     )
 
     description = StreamField(
         [("description", SessionDescriptionBlock())],
-        verbose_name=("description"),
+        verbose_name="description",
         blank=True,
         null=True,
         min_num=1,
     )
 
     curriculum_connection_description = RichTextField(
-        verbose_name=("curriculum connection description"),
+        verbose_name="curriculum connection description",
         help_text=(
             "A description of how the session connects to the curriculum. This is optional but can help teachers understand the relevance of the session to their teaching."
         ),
@@ -312,7 +312,7 @@ class EducationSessionPage(
     highlights = StreamField(
         [("highlights", ImageGalleryBlock())],
         blank=True,
-        help_text=("Optional image gallery to show what to expect from the session."),
+        help_text="Optional image gallery to show what to expect from the session.",
         max_num=1,
     )
 
@@ -353,7 +353,7 @@ class EducationSessionPage(
             ),
             InlinePanel(
                 "related_education_sessions",
-                heading=("More education sessions"),
+                heading="More education sessions",
                 help_text=(
                     "Education sessions that are selected to be shown in the related education sessions section"
                 ),
@@ -371,12 +371,12 @@ class EducationSessionPage(
                         FieldPanel("price"),
                         FieldPanel("price_detail"),
                     ],
-                    heading=("Session price"),
+                    heading="Session price",
                 ),
                 InlinePanel(
                     "session_locations",
-                    label=("Location"),
-                    heading=("Session locations"),
+                    label="Location",
+                    heading="Session locations",
                     min_num=1,
                 ),
                 FieldPanel("booking_link"),

--- a/app/education/models/sessions.py
+++ b/app/education/models/sessions.py
@@ -1,7 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import (
     FieldPanel,
@@ -66,10 +65,10 @@ class EducationSessionPageThemeTag(BaseThemeTag):
 
 class SessionLocation(Orderable):
     class LocationType(models.TextChoices):
-        ONLINE = "online", _("Online")
-        NATIONAL_ARCHIVES = "national_archives", _("At The National Archives")
-        YOUR_SCHOOL = "your_school", _("At your school")
-        CUSTOM = "custom", _("Custom venue")
+        ONLINE = "online", ("Online")
+        NATIONAL_ARCHIVES = "national_archives", ("At The National Archives")
+        YOUR_SCHOOL = "your_school", ("At your school")
+        CUSTOM = "custom", ("Custom venue")
 
     class Regions(models.TextChoices):
         SOUTH_EAST = "south_east", "South East and London"
@@ -87,14 +86,14 @@ class SessionLocation(Orderable):
     location_type = models.CharField(
         max_length=32,
         choices=LocationType.choices,
-        verbose_name=_("location type"),
-        help_text=_("Choose a standard location or Custom venue."),
+        verbose_name=("location type"),
+        help_text=("Choose a standard location or Custom venue."),
         null=True,
     )
 
     duration = models.CharField(
-        verbose_name=_("duration"),
-        help_text=_(
+        verbose_name=("duration"),
+        help_text=(
             "A clear description of the session duration for this location, e.g. 1 hour, 1 to 2 hours."
         ),
         blank=True,
@@ -105,8 +104,8 @@ class SessionLocation(Orderable):
     region = models.CharField(
         max_length=32,
         choices=Regions.choices,
-        verbose_name=_("region"),
-        help_text=_(
+        verbose_name=("region"),
+        help_text=(
             "The region where the session is offered. Required for schools and custom venues."
         ),
         null=True,
@@ -117,32 +116,32 @@ class SessionLocation(Orderable):
         blank=True,
         null=True,
         max_length=255,
-        verbose_name=_("Venue name"),
-        help_text=_("Required only when location type is Custom venue."),
+        verbose_name=("Venue name"),
+        help_text=("Required only when location type is Custom venue."),
     )
 
     address_line_1 = models.CharField(
         blank=True,
         null=True,
         max_length=255,
-        verbose_name=_("Address line 1"),
-        help_text=_("Required only when location type is Custom venue."),
+        verbose_name=("Address line 1"),
+        help_text=("Required only when location type is Custom venue."),
     )
 
     address_line_2 = models.CharField(
         blank=True,
         null=True,
         max_length=255,
-        verbose_name=_("Address line 2"),
-        help_text=_("Required only when location type is Custom venue."),
+        verbose_name=("Address line 2"),
+        help_text=("Required only when location type is Custom venue."),
     )
 
     postcode = models.CharField(
         blank=True,
         null=True,
         max_length=20,
-        verbose_name=_("Postcode"),
-        help_text=_("Required only when location type is Custom venue."),
+        verbose_name=("Postcode"),
+        help_text=("Required only when location type is Custom venue."),
     )
 
     panels = [
@@ -156,13 +155,13 @@ class SessionLocation(Orderable):
                 FieldPanel("address_line_2"),
                 FieldPanel("postcode"),
             ],
-            heading=_("Custom venue address details"),
+            heading=("Custom venue address details"),
         ),
     ]
 
     class Meta:
-        verbose_name = _("session location")
-        verbose_name_plural = _("session locations")
+        verbose_name = "session location"
+        verbose_name_plural = "session locations"
         ordering = ["sort_order"]
 
     def clean(self):
@@ -183,24 +182,24 @@ class SessionLocation(Orderable):
 
         if self.location_type == self.LocationType.CUSTOM:
             if not venue_name:
-                errors["venue_name"] = _("Venue name is required for custom venue.")
+                errors["venue_name"] = "Venue name is required for custom venue."
             if not address_line_1:
-                errors["address_line_1"] = _(
+                errors["address_line_1"] = (
                     "Address line 1 is required for custom venue."
                 )
             if not postcode:
-                errors["postcode"] = _("Postcode is required for custom venue.")
+                errors["postcode"] = "Postcode is required for custom venue."
         elif has_venue_details:
-            errors["venue_name"] = _(
+            errors["venue_name"] = (
                 "Venue details should only be provided for custom venue location type."
             )
 
         if location_requires_region and not region:
-            errors["region"] = _(
+            errors["region"] = (
                 "Region is required for school or custom venue location types."
             )
         elif region and not location_requires_region:
-            errors["region"] = _(
+            errors["region"] = (
                 "Region should only be provided for school or custom venue location types."
             )
 
@@ -234,11 +233,11 @@ class RelatedEducationSessions(Orderable):
         "education.EducationSessionPage",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("selected page"),
+        verbose_name=("selected page"),
     )
 
     class Meta:
-        verbose_name = _("related education session")
+        verbose_name = "related education session"
         ordering = ["sort_order"]
 
 
@@ -259,28 +258,28 @@ class EducationSessionPage(
     ]
 
     start_date = models.DateField(
-        verbose_name=_("start date"),
+        verbose_name=("start date"),
         null=True,
         blank=True,
-        help_text=_(
+        help_text=(
             "If neither start nor end date is added this will default to 'All Year'"
         ),
     )
 
     end_date = models.DateField(
-        verbose_name=_("end date"),
+        verbose_name=("end date"),
         null=True,
         blank=True,
-        help_text=_(
+        help_text=(
             "If neither start nor end date is added this will default to 'All Year'"
         ),
     )
 
-    price = models.FloatField(null=True, blank=True, verbose_name=_("price"))
+    price = models.FloatField(null=True, blank=True, verbose_name=("price"))
 
     price_detail = models.CharField(
-        verbose_name=_("price detail"),
-        help_text=_("An explanation of the price. Required if price is filled in."),
+        verbose_name=("price detail"),
+        help_text=("An explanation of the price. Required if price is filled in."),
         blank=True,
         null=True,
         max_length=160,
@@ -289,21 +288,21 @@ class EducationSessionPage(
     booking_link = models.URLField(
         null=True,
         blank=True,
-        help_text=_("Link to booking page"),
-        verbose_name=_("Booking link"),
+        help_text=("Link to booking page"),
+        verbose_name=("Booking link"),
     )
 
     description = StreamField(
         [("description", SessionDescriptionBlock())],
-        verbose_name=_("description"),
+        verbose_name=("description"),
         blank=True,
         null=True,
         min_num=1,
     )
 
     curriculum_connection_description = RichTextField(
-        verbose_name=_("curriculum connection description"),
-        help_text=_(
+        verbose_name=("curriculum connection description"),
+        help_text=(
             "A description of how the session connects to the curriculum. This is optional but can help teachers understand the relevance of the session to their teaching."
         ),
         blank=True,
@@ -313,7 +312,7 @@ class EducationSessionPage(
     highlights = StreamField(
         [("highlights", ImageGalleryBlock())],
         blank=True,
-        help_text=_("Optional image gallery to show what to expect from the session."),
+        help_text=("Optional image gallery to show what to expect from the session."),
         max_num=1,
     )
 
@@ -323,14 +322,14 @@ class EducationSessionPage(
         if self.price is not None and not self.price_detail:
             raise ValidationError(
                 {
-                    "price_detail": _(
+                    "price_detail": (
                         "Price detail is required when a session price is specified."
                     )
                 }
             )
         if self.price is None and self.price_detail:
             raise ValidationError(
-                {"price": _("Price is required when price detail is specified.")}
+                {"price": ("Price is required when price detail is specified.")}
             )
         if (
             self.start_date is not None
@@ -338,7 +337,7 @@ class EducationSessionPage(
             and self.start_date >= self.end_date
         ):
             raise ValidationError(
-                {"end_date": _("End date must be later than start date.")}
+                {"end_date": ("End date must be later than start date.")}
             )
 
     content_panels = (
@@ -354,8 +353,8 @@ class EducationSessionPage(
             ),
             InlinePanel(
                 "related_education_sessions",
-                heading=_("More education sessions"),
-                help_text=_(
+                heading=("More education sessions"),
+                help_text=(
                     "Education sessions that are selected to be shown in the related education sessions section"
                 ),
             ),
@@ -372,12 +371,12 @@ class EducationSessionPage(
                         FieldPanel("price"),
                         FieldPanel("price_detail"),
                     ],
-                    heading=_("Session price"),
+                    heading=("Session price"),
                 ),
                 InlinePanel(
                     "session_locations",
-                    label=_("Location"),
-                    heading=_("Session locations"),
+                    label=("Location"),
+                    heading=("Session locations"),
                     min_num=1,
                 ),
                 FieldPanel("booking_link"),

--- a/app/education/models/sessions.py
+++ b/app/education/models/sessions.py
@@ -93,9 +93,7 @@ class SessionLocation(Orderable):
 
     duration = models.CharField(
         verbose_name="duration",
-        help_text=(
-            "A clear description of the session duration for this location, e.g. 1 hour, 1 to 2 hours."
-        ),
+        help_text="A clear description of the session duration for this location, e.g. 1 hour, 1 to 2 hours.",
         blank=True,
         null=True,
         max_length=160,
@@ -105,9 +103,7 @@ class SessionLocation(Orderable):
         max_length=32,
         choices=Regions.choices,
         verbose_name="region",
-        help_text=(
-            "The region where the session is offered. Required for schools and custom venues."
-        ),
+        help_text="The region where the session is offered. Required for schools and custom venues.",
         null=True,
         blank=True,
     )
@@ -261,18 +257,14 @@ class EducationSessionPage(
         verbose_name="start date",
         null=True,
         blank=True,
-        help_text=(
-            "If neither start nor end date is added this will default to 'All Year'"
-        ),
+        help_text="If neither start nor end date is added this will default to 'All Year'",
     )
 
     end_date = models.DateField(
         verbose_name="end date",
         null=True,
         blank=True,
-        help_text=(
-            "If neither start nor end date is added this will default to 'All Year'"
-        ),
+        help_text="If neither start nor end date is added this will default to 'All Year'",
     )
 
     price = models.FloatField(null=True, blank=True, verbose_name="price")
@@ -302,9 +294,7 @@ class EducationSessionPage(
 
     curriculum_connection_description = RichTextField(
         verbose_name="curriculum connection description",
-        help_text=(
-            "A description of how the session connects to the curriculum. This is optional but can help teachers understand the relevance of the session to their teaching."
-        ),
+        help_text="A description of how the session connects to the curriculum. This is optional but can help teachers understand the relevance of the session to their teaching.",
         blank=True,
         null=True,
     )
@@ -354,9 +344,7 @@ class EducationSessionPage(
             InlinePanel(
                 "related_education_sessions",
                 heading="More education sessions",
-                help_text=(
-                    "Education sessions that are selected to be shown in the related education sessions section"
-                ),
+                help_text="Education sessions that are selected to be shown in the related education sessions section",
             ),
         ]
     )

--- a/app/generic_pages/models.py
+++ b/app/generic_pages/models.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from rest_framework import serializers
 from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
@@ -123,7 +122,7 @@ class HubPage(HeroImageMixin, BasePageWithIntro):
 
     plain_cards_list = models.BooleanField(
         default=False,
-        help_text=_(
+        help_text=(
             "If checked, the links will be displayed as a list of plain cards, without images."
         ),
     )

--- a/app/generic_pages/models.py
+++ b/app/generic_pages/models.py
@@ -122,9 +122,7 @@ class HubPage(HeroImageMixin, BasePageWithIntro):
 
     plain_cards_list = models.BooleanField(
         default=False,
-        help_text=(
-            "If checked, the links will be displayed as a list of plain cards, without images."
-        ),
+        help_text="If checked, the links will be displayed as a list of plain cards, without images.",
     )
 
     content_panels = (

--- a/app/images/models.py
+++ b/app/images/models.py
@@ -12,13 +12,13 @@ from app.core.serializers import RichTextSerializer
 
 
 class TranscriptionHeadingChoices(models.TextChoices):
-    TRANSCRIPT = "transcript", ("Transcript")
-    PARTIAL_TRANSCRIPTION = "partial-transcript", ("Partial transcript")
+    TRANSCRIPT = "transcript", "Transcript"
+    PARTIAL_TRANSCRIPTION = "partial-transcript", "Partial transcript"
 
 
 class TranslationHeadingChoices(models.TextChoices):
-    TRANSLATION = "translation", ("Translation")
-    MODERN_ENGLISH = "modern-english", ("Modern English")
+    TRANSLATION = "translation", "Translation"
+    MODERN_ENGLISH = "modern-english", "Modern English"
 
 
 class CustomImage(ClusterableModel, AbstractImage):

--- a/app/images/models.py
+++ b/app/images/models.py
@@ -2,7 +2,6 @@ import uuid
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
 from wagtail.api import APIField
 from wagtail.fields import RichTextField
@@ -13,13 +12,13 @@ from app.core.serializers import RichTextSerializer
 
 
 class TranscriptionHeadingChoices(models.TextChoices):
-    TRANSCRIPT = "transcript", _("Transcript")
-    PARTIAL_TRANSCRIPTION = "partial-transcript", _("Partial transcript")
+    TRANSCRIPT = "transcript", ("Transcript")
+    PARTIAL_TRANSCRIPTION = "partial-transcript", ("Partial transcript")
 
 
 class TranslationHeadingChoices(models.TextChoices):
-    TRANSLATION = "translation", _("Translation")
-    MODERN_ENGLISH = "modern-english", _("Modern English")
+    TRANSLATION = "translation", ("Translation")
+    MODERN_ENGLISH = "modern-english", ("Modern English")
 
 
 class CustomImage(ClusterableModel, AbstractImage):
@@ -32,8 +31,8 @@ class CustomImage(ClusterableModel, AbstractImage):
 
     title = models.CharField(
         max_length=255,
-        verbose_name=_("title"),
-        help_text=_(
+        verbose_name=("title"),
+        help_text=(
             "The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page."
         ),
     )
@@ -41,51 +40,51 @@ class CustomImage(ClusterableModel, AbstractImage):
     description = models.CharField(
         blank=True,
         max_length=255,
-        verbose_name=_("alt text"),
+        verbose_name=("alt text"),
         default="",
     )
 
     copyright = RichTextField(
-        verbose_name=_("copyright"),
+        verbose_name=("copyright"),
         blank=True,
         max_length=200,
-        help_text=_(
+        help_text=(
             "Credit for images not owned by TNA. Do not include the copyright symbol."
         ),
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
     transcription_heading = models.CharField(
-        verbose_name=_("transcript heading"),
+        verbose_name=("transcript heading"),
         max_length=30,
         choices=TranscriptionHeadingChoices.choices,
         default=TranscriptionHeadingChoices.TRANSCRIPT,
     )
 
     transcription = RichTextField(
-        verbose_name=_("transcript"),
+        verbose_name=("transcript"),
         features=["bold", "italic", "ol", "ul"],
         blank=True,
         max_length=1500,
-        help_text=_("If the image contains text consider adding a transcript."),
+        help_text=("If the image contains text consider adding a transcript."),
     )
 
     translation_heading = models.CharField(
-        verbose_name=_("translation heading"),
+        verbose_name=("translation heading"),
         max_length=30,
         choices=TranslationHeadingChoices.choices,
         default=TranslationHeadingChoices.TRANSLATION,
-        help_text=_(
+        help_text=(
             'If the original transcription language is some earlier form of English, choose "Modern English". If not, choose “Translation”.'
         ),
     )
 
     translation = RichTextField(
-        verbose_name=_("translation"),
+        verbose_name=("translation"),
         features=["bold", "italic", "ol", "ul"],
         blank=True,
         max_length=1500,
-        help_text=_(
+        help_text=(
             "An optional English / Modern English translation of the transcription."
         ),
     )

--- a/app/images/models.py
+++ b/app/images/models.py
@@ -31,7 +31,7 @@ class CustomImage(ClusterableModel, AbstractImage):
 
     title = models.CharField(
         max_length=255,
-        verbose_name=("title"),
+        verbose_name="title",
         help_text=(
             "The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page."
         ),
@@ -40,12 +40,12 @@ class CustomImage(ClusterableModel, AbstractImage):
     description = models.CharField(
         blank=True,
         max_length=255,
-        verbose_name=("alt text"),
+        verbose_name="alt text",
         default="",
     )
 
     copyright = RichTextField(
-        verbose_name=("copyright"),
+        verbose_name="copyright",
         blank=True,
         max_length=200,
         help_text=(
@@ -55,22 +55,22 @@ class CustomImage(ClusterableModel, AbstractImage):
     )
 
     transcription_heading = models.CharField(
-        verbose_name=("transcript heading"),
+        verbose_name="transcript heading",
         max_length=30,
         choices=TranscriptionHeadingChoices.choices,
         default=TranscriptionHeadingChoices.TRANSCRIPT,
     )
 
     transcription = RichTextField(
-        verbose_name=("transcript"),
+        verbose_name="transcript",
         features=["bold", "italic", "ol", "ul"],
         blank=True,
         max_length=1500,
-        help_text=("If the image contains text consider adding a transcript."),
+        help_text="If the image contains text consider adding a transcript.",
     )
 
     translation_heading = models.CharField(
-        verbose_name=("translation heading"),
+        verbose_name="translation heading",
         max_length=30,
         choices=TranslationHeadingChoices.choices,
         default=TranslationHeadingChoices.TRANSLATION,
@@ -80,7 +80,7 @@ class CustomImage(ClusterableModel, AbstractImage):
     )
 
     translation = RichTextField(
-        verbose_name=("translation"),
+        verbose_name="translation",
         features=["bold", "italic", "ol", "ul"],
         blank=True,
         max_length=1500,

--- a/app/images/models.py
+++ b/app/images/models.py
@@ -32,9 +32,7 @@ class CustomImage(ClusterableModel, AbstractImage):
     title = models.CharField(
         max_length=255,
         verbose_name="title",
-        help_text=(
-            "The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page."
-        ),
+        help_text="The descriptive name of the image. If this image features in a highlights gallery, this title will be visible on the page.",
     )
 
     description = models.CharField(
@@ -48,9 +46,7 @@ class CustomImage(ClusterableModel, AbstractImage):
         verbose_name="copyright",
         blank=True,
         max_length=200,
-        help_text=(
-            "Credit for images not owned by TNA. Do not include the copyright symbol."
-        ),
+        help_text="Credit for images not owned by TNA. Do not include the copyright symbol.",
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -74,9 +70,7 @@ class CustomImage(ClusterableModel, AbstractImage):
         max_length=30,
         choices=TranslationHeadingChoices.choices,
         default=TranslationHeadingChoices.TRANSLATION,
-        help_text=(
-            'If the original transcription language is some earlier form of English, choose "Modern English". If not, choose “Translation”.'
-        ),
+        help_text='If the original transcription language is some earlier form of English, choose "Modern English". If not, choose “Translation”.',
     )
 
     translation = RichTextField(
@@ -84,9 +78,7 @@ class CustomImage(ClusterableModel, AbstractImage):
         features=["bold", "italic", "ol", "ul"],
         blank=True,
         max_length=1500,
-        help_text=(
-            "An optional English / Modern English translation of the transcription."
-        ),
+        help_text="An optional English / Modern English translation of the transcription.",
     )
 
     def usage_count(self):

--- a/app/ukgwa/mixins.py
+++ b/app/ukgwa/mixins.py
@@ -33,10 +33,8 @@ class FeaturedLinksMixin(models.Model):
         blank=True,
         max_num=3,
         use_json_field=True,
-        help_text=(
-            "Exactly three links, or leave empty to hide this section. "
-            "Each link can be to an internal page or an external URL."
-        ),
+        help_text="Exactly three links, or leave empty to hide this section. "
+        "Each link can be to an internal page or an external URL.",
     )
 
     api_fields = [
@@ -134,10 +132,8 @@ class SidebarNavigationMixin(models.Model):
 
     show_sidebar_navigation = models.BooleanField(
         default=True,
-        help_text=(
-            "Show a navigation sidebar of sibling pages within this section. "
-            "Only applies to direct children of a section index."
-        ),
+        help_text="Show a navigation sidebar of sibling pages within this section. "
+        "Only applies to direct children of a section index.",
     )
 
     @property

--- a/app/ukgwa/mixins.py
+++ b/app/ukgwa/mixins.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.api import APIField
 from wagtail.fields import StreamField
@@ -23,18 +22,18 @@ class FeaturedLinksMixin(models.Model):
     """
 
     featured_links_heading = models.CharField(
-        verbose_name=_("featured links heading text"),
+        verbose_name=("featured links heading text"),
         max_length=100,
         blank=True,
         help_text="A short heading for the featured links section",
     )
     featured_links = StreamField(
         [("link", LinkBlock())],
-        verbose_name=_("featured links"),
+        verbose_name=("featured links"),
         blank=True,
         max_num=3,
         use_json_field=True,
-        help_text=_(
+        help_text=(
             "Exactly three links, or leave empty to hide this section. "
             "Each link can be to an internal page or an external URL."
         ),
@@ -54,15 +53,13 @@ class FeaturedLinksMixin(models.Model):
         has_links = bool(self.featured_links)
         errors = {}
         if has_links and not has_heading:
-            errors["featured_links_heading"] = _(
+            errors["featured_links_heading"] = (
                 "A heading is required when featured links are added."
             )
         if has_heading and not has_links:
-            errors["featured_links"] = _(
-                "Links are required when a heading is provided."
-            )
+            errors["featured_links"] = "Links are required when a heading is provided."
         if has_links and len(self.featured_links) < 3:
-            errors["featured_links"] = _("Please add exactly 3 links.")
+            errors["featured_links"] = "Please add exactly 3 links."
         if errors:
             raise ValidationError(errors)
 
@@ -92,7 +89,7 @@ class BookmarkletMixin(models.Model):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text=_("Select a bookmarklet CTA snippet to display on this page"),
+        help_text=("Select a bookmarklet CTA snippet to display on this page"),
     )
 
     api_fields = [
@@ -119,7 +116,7 @@ class SearchMixin(models.Model):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text=_("Select an archive search component to display on this page"),
+        help_text=("Select an archive search component to display on this page"),
     )
 
     api_fields = [
@@ -137,7 +134,7 @@ class SidebarNavigationMixin(models.Model):
 
     show_sidebar_navigation = models.BooleanField(
         default=True,
-        help_text=_(
+        help_text=(
             "Show a navigation sidebar of sibling pages within this section. "
             "Only applies to direct children of a section index."
         ),

--- a/app/ukgwa/mixins.py
+++ b/app/ukgwa/mixins.py
@@ -22,14 +22,14 @@ class FeaturedLinksMixin(models.Model):
     """
 
     featured_links_heading = models.CharField(
-        verbose_name=("featured links heading text"),
+        verbose_name="featured links heading text",
         max_length=100,
         blank=True,
         help_text="A short heading for the featured links section",
     )
     featured_links = StreamField(
         [("link", LinkBlock())],
-        verbose_name=("featured links"),
+        verbose_name="featured links",
         blank=True,
         max_num=3,
         use_json_field=True,
@@ -89,7 +89,7 @@ class BookmarkletMixin(models.Model):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text=("Select a bookmarklet CTA snippet to display on this page"),
+        help_text="Select a bookmarklet CTA snippet to display on this page",
     )
 
     api_fields = [
@@ -116,7 +116,7 @@ class SearchMixin(models.Model):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        help_text=("Select an archive search component to display on this page"),
+        help_text="Select an archive search component to display on this page",
     )
 
     api_fields = [

--- a/app/ukgwa/models.py
+++ b/app/ukgwa/models.py
@@ -52,9 +52,7 @@ class FeaturedLinksSection(models.Model):
         min_num=3,
         max_num=3,
         use_json_field=True,
-        help_text=(
-            "Contains exactly three links. Each link can be to an internal page or an external URL."
-        ),
+        help_text="Contains exactly three links. Each link can be to an internal page or an external URL.",
     )
 
     panels = [
@@ -183,10 +181,8 @@ class SectionIndexPage(SearchMixin, UKGWABasePage):
         [("link", LinkWithDescriptionBlock())],
         blank=True,
         use_json_field=True,
-        help_text=(
-            "Optional links appended to the list of child pages. "
-            "Each link can be to an internal page or an external URL."
-        ),
+        help_text="Optional links appended to the list of child pages. "
+        "Each link can be to an internal page or an external URL.",
     )
 
     @property
@@ -308,23 +304,17 @@ class ArchiveSearchComponent(models.Model):
     name = models.CharField(
         verbose_name="name",
         max_length=255,
-        help_text=(
-            "Internal name to identify this search component (not shown to users)"
-        ),
+        help_text="Internal name to identify this search component (not shown to users)",
     )
     heading = models.CharField(
         verbose_name="heading",
         max_length=255,
-        help_text=(
-            "The heading text displayed above the search bar (e.g. 'Web Archive Search')"
-        ),
+        help_text="The heading text displayed above the search bar (e.g. 'Web Archive Search')",
     )
     help_text = models.TextField(
         verbose_name="help text",
         blank=True,
-        help_text=(
-            "Optional guidance text displayed below the search box to help users understand what they can search for"
-        ),
+        help_text="Optional guidance text displayed below the search box to help users understand what they can search for",
     )
     button_text = models.CharField(
         verbose_name="button text",
@@ -336,9 +326,7 @@ class ArchiveSearchComponent(models.Model):
         verbose_name="archive type",
         max_length=20,
         choices=ArchiveTypes.choices,
-        help_text=(
-            "Select whether this component searches the Web Archive or Social Media Archive"
-        ),
+        help_text="Select whether this component searches the Web Archive or Social Media Archive",
     )
 
     panels = [
@@ -375,9 +363,7 @@ class BookmarkletCTASnippet(models.Model):
     name = models.CharField(
         verbose_name="name",
         max_length=255,
-        help_text=(
-            "Internal name to identify this bookmarklet snippet (not shown to users)"
-        ),
+        help_text="Internal name to identify this bookmarklet snippet (not shown to users)",
     )
     heading = models.CharField(
         verbose_name="heading",

--- a/app/ukgwa/models.py
+++ b/app/ukgwa/models.py
@@ -42,13 +42,13 @@ class FeaturedLinksSection(models.Model):
         related_name="featured_links_sections",
     )
     heading = models.CharField(
-        verbose_name=("featured links heading text"),
+        verbose_name="featured links heading text",
         max_length=100,
-        help_text=("A short heading for the featured links section"),
+        help_text="A short heading for the featured links section",
     )
     links = StreamField(
         [("link", LinkBlock())],
-        verbose_name=("featured links"),
+        verbose_name="featured links",
         min_num=3,
         max_num=3,
         use_json_field=True,
@@ -144,10 +144,10 @@ class UKGWAHomePage(HeroImageMixin, SearchMixin, UKGWABasePage):
         + [
             InlinePanel(
                 "featured_links_sections",
-                label=("Featured links section"),
+                label="Featured links section",
                 min_num=2,
                 max_num=2,
-                help_text=("Add exactly 2 featured links sections to the homepage"),
+                help_text="Add exactly 2 featured links sections to the homepage",
             )
         ]
     )
@@ -306,34 +306,34 @@ class ArchiveSearchComponent(models.Model):
         SOCIAL = "social", "Social Media Archive"
 
     name = models.CharField(
-        verbose_name=("name"),
+        verbose_name="name",
         max_length=255,
         help_text=(
             "Internal name to identify this search component (not shown to users)"
         ),
     )
     heading = models.CharField(
-        verbose_name=("heading"),
+        verbose_name="heading",
         max_length=255,
         help_text=(
             "The heading text displayed above the search bar (e.g. 'Web Archive Search')"
         ),
     )
     help_text = models.TextField(
-        verbose_name=("help text"),
+        verbose_name="help text",
         blank=True,
         help_text=(
             "Optional guidance text displayed below the search box to help users understand what they can search for"
         ),
     )
     button_text = models.CharField(
-        verbose_name=("button text"),
+        verbose_name="button text",
         max_length=50,
         default="Search",
-        help_text=("The text displayed on the search button"),
+        help_text="The text displayed on the search button",
     )
     archive_type = models.CharField(
-        verbose_name=("archive type"),
+        verbose_name="archive type",
         max_length=20,
         choices=ArchiveTypes.choices,
         help_text=(
@@ -373,32 +373,32 @@ class BookmarkletCTASnippet(models.Model):
     """
 
     name = models.CharField(
-        verbose_name=("name"),
+        verbose_name="name",
         max_length=255,
         help_text=(
             "Internal name to identify this bookmarklet snippet (not shown to users)"
         ),
     )
     heading = models.CharField(
-        verbose_name=("heading"),
+        verbose_name="heading",
         max_length=255,
-        help_text=("The heading text displayed at the top of the component"),
+        help_text="The heading text displayed at the top of the component",
     )
     body = models.TextField(
-        verbose_name=("body"),
-        help_text=("Description text displayed below the heading"),
+        verbose_name="body",
+        help_text="Description text displayed below the heading",
     )
     button_text = models.CharField(
-        verbose_name=("button text"),
+        verbose_name="button text",
         max_length=50,
         default="Check UKGWA",
-        help_text=("The text displayed on the CTA button"),
+        help_text="The text displayed on the CTA button",
     )
     button_link = models.ForeignKey(
         "wagtailcore.Page",
         on_delete=models.PROTECT,
         related_name="+",
-        help_text=("The internal page the button will take users to"),
+        help_text="The internal page the button will take users to",
     )
 
     panels = [

--- a/app/ukgwa/models.py
+++ b/app/ukgwa/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import (
     FieldPanel,
@@ -43,17 +42,17 @@ class FeaturedLinksSection(models.Model):
         related_name="featured_links_sections",
     )
     heading = models.CharField(
-        verbose_name=_("featured links heading text"),
+        verbose_name=("featured links heading text"),
         max_length=100,
-        help_text=_("A short heading for the featured links section"),
+        help_text=("A short heading for the featured links section"),
     )
     links = StreamField(
         [("link", LinkBlock())],
-        verbose_name=_("featured links"),
+        verbose_name=("featured links"),
         min_num=3,
         max_num=3,
         use_json_field=True,
-        help_text=_(
+        help_text=(
             "Contains exactly three links. Each link can be to an internal page or an external URL."
         ),
     )
@@ -145,10 +144,10 @@ class UKGWAHomePage(HeroImageMixin, SearchMixin, UKGWABasePage):
         + [
             InlinePanel(
                 "featured_links_sections",
-                label=_("Featured links section"),
+                label=("Featured links section"),
                 min_num=2,
                 max_num=2,
-                help_text=_("Add exactly 2 featured links sections to the homepage"),
+                help_text=("Add exactly 2 featured links sections to the homepage"),
             )
         ]
     )
@@ -184,7 +183,7 @@ class SectionIndexPage(SearchMixin, UKGWABasePage):
         [("link", LinkWithDescriptionBlock())],
         blank=True,
         use_json_field=True,
-        help_text=_(
+        help_text=(
             "Optional links appended to the list of child pages. "
             "Each link can be to an internal page or an external URL."
         ),
@@ -307,37 +306,37 @@ class ArchiveSearchComponent(models.Model):
         SOCIAL = "social", "Social Media Archive"
 
     name = models.CharField(
-        verbose_name=_("name"),
+        verbose_name=("name"),
         max_length=255,
-        help_text=_(
+        help_text=(
             "Internal name to identify this search component (not shown to users)"
         ),
     )
     heading = models.CharField(
-        verbose_name=_("heading"),
+        verbose_name=("heading"),
         max_length=255,
-        help_text=_(
+        help_text=(
             "The heading text displayed above the search bar (e.g. 'Web Archive Search')"
         ),
     )
     help_text = models.TextField(
-        verbose_name=_("help text"),
+        verbose_name=("help text"),
         blank=True,
-        help_text=_(
+        help_text=(
             "Optional guidance text displayed below the search box to help users understand what they can search for"
         ),
     )
     button_text = models.CharField(
-        verbose_name=_("button text"),
+        verbose_name=("button text"),
         max_length=50,
         default="Search",
-        help_text=_("The text displayed on the search button"),
+        help_text=("The text displayed on the search button"),
     )
     archive_type = models.CharField(
-        verbose_name=_("archive type"),
+        verbose_name=("archive type"),
         max_length=20,
         choices=ArchiveTypes.choices,
-        help_text=_(
+        help_text=(
             "Select whether this component searches the Web Archive or Social Media Archive"
         ),
     )
@@ -361,8 +360,8 @@ class ArchiveSearchComponent(models.Model):
         return self.name
 
     class Meta:
-        verbose_name = _("Archive Search Component")
-        verbose_name_plural = _("Archive Search Components")
+        verbose_name = "Archive Search Component"
+        verbose_name_plural = "Archive Search Components"
 
 
 @register_snippet
@@ -374,32 +373,32 @@ class BookmarkletCTASnippet(models.Model):
     """
 
     name = models.CharField(
-        verbose_name=_("name"),
+        verbose_name=("name"),
         max_length=255,
-        help_text=_(
+        help_text=(
             "Internal name to identify this bookmarklet snippet (not shown to users)"
         ),
     )
     heading = models.CharField(
-        verbose_name=_("heading"),
+        verbose_name=("heading"),
         max_length=255,
-        help_text=_("The heading text displayed at the top of the component"),
+        help_text=("The heading text displayed at the top of the component"),
     )
     body = models.TextField(
-        verbose_name=_("body"),
-        help_text=_("Description text displayed below the heading"),
+        verbose_name=("body"),
+        help_text=("Description text displayed below the heading"),
     )
     button_text = models.CharField(
-        verbose_name=_("button text"),
+        verbose_name=("button text"),
         max_length=50,
         default="Check UKGWA",
-        help_text=_("The text displayed on the CTA button"),
+        help_text=("The text displayed on the CTA button"),
     )
     button_link = models.ForeignKey(
         "wagtailcore.Page",
         on_delete=models.PROTECT,
         related_name="+",
-        help_text=_("The internal page the button will take users to"),
+        help_text=("The internal page the button will take users to"),
     )
 
     panels = [
@@ -414,5 +413,5 @@ class BookmarkletCTASnippet(models.Model):
         return self.name
 
     class Meta:
-        verbose_name = _("Bookmarklet CTA")
-        verbose_name_plural = _("Bookmarklet CTA")
+        verbose_name = "Bookmarklet CTA"
+        verbose_name_plural = "Bookmarklet CTA"

--- a/app/whatson/models/details.py
+++ b/app/whatson/models/details.py
@@ -67,8 +67,8 @@ class SeriesTag(Orderable):
         "whatson.WhatsOnSeriesPage",
         on_delete=models.CASCADE,
         related_name="series_pages",
-        verbose_name=("series"),
-        help_text=("The series to include the page in."),
+        verbose_name="series",
+        help_text="The series to include the page in.",
         null=False,
         blank=False,
     )
@@ -91,12 +91,12 @@ class EventType(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=("name"),
+        verbose_name="name",
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=("slug"),
+        verbose_name="slug",
         unique=True,
     )
 
@@ -129,21 +129,21 @@ class EventSpeaker(Orderable):
 
     name = models.CharField(
         max_length=100,
-        verbose_name=("name"),
-        help_text=("The name of the speaker."),
+        verbose_name="name",
+        help_text="The name of the speaker.",
         blank=True,
     )
 
     role = models.CharField(
         max_length=200,
-        verbose_name=("role"),
-        help_text=("The role of the speaker."),
+        verbose_name="role",
+        help_text="The role of the speaker.",
         blank=True,
     )
 
     biography = RichTextField(
-        verbose_name=("biography"),
-        help_text=("A short biography of the speaker."),
+        verbose_name="biography",
+        help_text="A short biography of the speaker.",
         blank=True,
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
@@ -197,17 +197,17 @@ class EventSession(models.Model):
     )
 
     start = models.DateTimeField(
-        verbose_name=("starts at"),
+        verbose_name="starts at",
     )
 
     end = models.DateTimeField(
-        verbose_name=("ends at"),
+        verbose_name="ends at",
     )
 
     sold_out = models.BooleanField(
-        verbose_name=("sold out"),
+        verbose_name="sold out",
         default=False,
-        help_text=("Check this box if the session is sold out."),
+        help_text="Check this box if the session is sold out.",
     )
 
     def clean(self):
@@ -255,7 +255,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     )
 
     various_dates = models.BooleanField(
-        verbose_name=("various dates and times"),
+        verbose_name="various dates and times",
         default=False,
         help_text=(
             "Check this box if the event has multiple sessions with different dates and times."
@@ -263,13 +263,13 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     )
 
     start_date = models.DateTimeField(
-        verbose_name=("start date"),
+        verbose_name="start date",
         null=True,
         editable=False,
     )
 
     end_date = models.DateTimeField(
-        verbose_name=("end date"),
+        verbose_name="end date",
         null=True,
         editable=False,
     )
@@ -278,33 +278,33 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
         EventPageStreamBlock(),
         blank=True,
         null=True,
-        verbose_name=("description"),
-        help_text=("The description of the event."),
+        verbose_name="description",
+        help_text="The description of the event.",
     )
 
     age_detail = models.CharField(
         max_length=40,
-        verbose_name=("age detail"),
+        verbose_name="age detail",
         blank=True,
-        help_text=("The text for the age detail section."),
+        help_text="The text for the age detail section.",
     )
 
     booking_details = RichTextField(
         max_length=40,
         null=True,
         blank=True,
-        verbose_name=("booking details"),
-        help_text=("Information about how to book tickets for the event."),
+        verbose_name="booking details",
+        help_text="Information about how to book tickets for the event.",
         features=["link"],
     )
 
     min_price = models.FloatField(
-        verbose_name=("minimum price"),
+        verbose_name="minimum price",
         default=0,
     )
 
     max_price = models.FloatField(
-        verbose_name=("maximum price"),
+        verbose_name="maximum price",
         default=0,
     )
 
@@ -314,8 +314,8 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("location"),
-        help_text=("The location of the event."),
+        verbose_name="location",
+        help_text="The location of the event.",
     )
 
     booking_link = models.URLField(
@@ -327,9 +327,9 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
 
     event_highlights_title = models.CharField(
         max_length=100,
-        verbose_name=("event highlights title"),
+        verbose_name="event highlights title",
         blank=True,
-        help_text=("Leave blank to default to 'Event highlights'."),
+        help_text="Leave blank to default to 'Event highlights'.",
     )
 
     event_highlights = StreamField(
@@ -350,14 +350,14 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                 [
                     FieldPanel("description"),
                 ],
-                heading=("Event information"),
+                heading="Event information",
             ),
             MultiFieldPanel(
                 [
                     FieldPanel("event_highlights_title"),
                     FieldPanel("event_highlights"),
                 ],
-                heading=("Event highlights"),
+                heading="Event highlights",
             ),
         ]
     )
@@ -375,7 +375,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                     ],
                 ),
             ],
-            heading=("Price details"),
+            heading="Price details",
         ),
         MultiFieldPanel(
             [
@@ -391,17 +391,17 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                 FieldPanel("various_dates"),
                 InlinePanel(
                     "sessions",
-                    heading=("Sessions"),
+                    heading="Sessions",
                     min_num=1,
                 ),
             ],
-            heading=("Date details"),
+            heading="Date details",
         ),
         FieldPanel("location"),
         FieldPanel("age_detail"),
         InlinePanel(
             "speakers",
-            heading=("Speaker information"),
+            heading="Speaker information",
             help_text=(
                 "If the event has more than one speaker, please add these in order of relevance from most to least."
             ),
@@ -411,7 +411,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     promote_panels = BasePageWithRequiredIntro.promote_panels + [
         InlinePanel(
             "page_series_tags",
-            heading=("Series"),
+            heading="Series",
             max_num=3,
         ),
     ]
@@ -558,54 +558,54 @@ class DisplayPage(
 
     # Key details section
     start_date = models.DateField(
-        verbose_name=("start date"),
+        verbose_name="start date",
         null=True,
         blank=True,
     )
 
     end_date = models.DateField(
-        verbose_name=("end date"),
+        verbose_name="end date",
         null=True,
         blank=True,
     )
 
     all_year = models.BooleanField(
-        verbose_name=("all year"),
+        verbose_name="all year",
         default=False,
-        help_text=("Check this box if the display is available all year round."),
+        help_text="Check this box if the display is available all year round.",
     )
 
     exclude_days = models.BooleanField(
-        verbose_name=("exclude days"),
+        verbose_name="exclude days",
         default=False,
-        help_text=("Check this box to show only the month and year on the display."),
+        help_text="Check this box to show only the month and year on the display.",
     )
 
     price = models.FloatField(
-        verbose_name=("price"),
+        verbose_name="price",
         default=0,
     )
 
     booking_details = RichTextField(
         max_length=40,
         null=True,
-        verbose_name=("booking details"),
-        help_text=("Information about how to book tickets for the display."),
+        verbose_name="booking details",
+        help_text="Information about how to book tickets for the display.",
         features=["link"],
     )
 
     open_days = models.CharField(
         max_length=255,
-        verbose_name=("open days"),
+        verbose_name="open days",
         blank=True,
-        help_text=("The days the display is open, e.g. Tuesday to Sunday."),
+        help_text="The days the display is open, e.g. Tuesday to Sunday.",
     )
 
     age_detail = models.CharField(
         max_length=40,
-        verbose_name=("age detail"),
+        verbose_name="age detail",
         blank=True,
-        help_text=("The text for the age detail section."),
+        help_text="The text for the age detail section.",
     )
 
     location = models.ForeignKey(
@@ -614,8 +614,8 @@ class DisplayPage(
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("location"),
-        help_text=("The location of the display."),
+        verbose_name="location",
+        help_text="The location of the display.",
     )
 
     # Body section
@@ -623,9 +623,9 @@ class DisplayPage(
 
     display_highlights_title = models.CharField(
         max_length=100,
-        verbose_name=("display highlights title"),
+        verbose_name="display highlights title",
         blank=True,
-        help_text=("Leave blank to default to 'Display highlights'."),
+        help_text="Leave blank to default to 'Display highlights'.",
     )
 
     display_highlights = StreamField(
@@ -638,12 +638,12 @@ class DisplayPage(
     related_pages_title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=("The title to display for the related content section."),
+        help_text="The title to display for the related content section.",
     )
 
     related_pages_description = RichTextField(
         blank=True,
-        help_text=("The description to display for the related content section."),
+        help_text="The description to display for the related content section.",
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -713,7 +713,7 @@ class DisplayPage(
                     FieldPanel("display_highlights_title"),
                     FieldPanel("display_highlights"),
                 ],
-                heading=("Content"),
+                heading="Content",
             ),
             MultiFieldPanel(
                 [
@@ -723,7 +723,7 @@ class DisplayPage(
                     FieldPanel("related_pages"),
                     FieldPanel("shop"),
                 ],
-                heading=("Related content"),
+                heading="Related content",
             ),
         ]
     )
@@ -740,14 +740,14 @@ class DisplayPage(
                 FieldPanel("all_year"),
                 FieldPanel("exclude_days"),
             ],
-            heading=("Date details"),
+            heading="Date details",
         ),
         MultiFieldPanel(
             [
                 FieldPanel("price"),
                 FieldPanel("booking_details"),
             ],
-            heading=("Price details"),
+            heading="Price details",
         ),
         FieldPanel("open_days"),
         FieldPanel("age_detail"),
@@ -755,14 +755,14 @@ class DisplayPage(
             [
                 FieldPanel("location"),
             ],
-            heading=("Location details"),
+            heading="Location details",
         ),
     ]
 
     promote_panels = BasePageWithRequiredIntro.promote_panels + [
         InlinePanel(
             "page_series_tags",
-            heading=("Series"),
+            heading="Series",
             max_num=3,
         ),
     ]
@@ -848,54 +848,54 @@ class ExhibitionPage(
     # Hero section
     subtitle = models.CharField(
         max_length=120,
-        verbose_name=("subtitle"),
-        help_text=("A subtitle for the event."),
+        verbose_name="subtitle",
+        help_text="A subtitle for the event.",
     )
 
     # Key details section
     start_date = models.DateField(
-        verbose_name=("start date"),
+        verbose_name="start date",
         null=True,
         blank=True,
     )
 
     end_date = models.DateField(
-        verbose_name=("end date"),
+        verbose_name="end date",
         null=True,
         blank=True,
     )
 
     exclude_days = models.BooleanField(
-        verbose_name=("exclude days"),
+        verbose_name="exclude days",
         default=False,
-        help_text=("Check this box to show only the month and year on the exhibition."),
+        help_text="Check this box to show only the month and year on the exhibition.",
     )
 
     price = models.FloatField(
-        verbose_name=("price"),
+        verbose_name="price",
         default=0,
     )
 
     booking_details = RichTextField(
         max_length=40,
         null=True,
-        verbose_name=("booking details"),
-        help_text=("Information about how to book tickets for the exhibition."),
+        verbose_name="booking details",
+        help_text="Information about how to book tickets for the exhibition.",
         features=["link"],
     )
 
     open_days = models.CharField(
         max_length=255,
-        verbose_name=("open days"),
+        verbose_name="open days",
         blank=True,
-        help_text=("The days the exhibition is open, e.g. Tuesday to Sunday."),
+        help_text="The days the exhibition is open, e.g. Tuesday to Sunday.",
     )
 
     age_detail = models.CharField(
         max_length=40,
-        verbose_name=("age detail"),
+        verbose_name="age detail",
         blank=True,
-        help_text=("The text for the age detail section."),
+        help_text="The text for the age detail section.",
     )
 
     location = models.ForeignKey(
@@ -904,13 +904,13 @@ class ExhibitionPage(
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("location"),
-        help_text=("The location of the exhibition."),
+        verbose_name="location",
+        help_text="The location of the exhibition.",
     )
 
     partnership_lead_text = models.CharField(
         max_length=40,
-        verbose_name=("partnership lead text"),
+        verbose_name="partnership lead text",
         blank=True,
         help_text=(
             "Optional override for the partner logos section lead text. Will display a default if not provided."
@@ -921,14 +921,14 @@ class ExhibitionPage(
         null=True,
         blank=True,
         related_name="+",
-        verbose_name=("partnership"),
-        help_text=("The partnership logo for the exhibition."),
+        verbose_name="partnership",
+        help_text="The partnership logo for the exhibition.",
     )
 
     # Body section
     intro_title = models.CharField(
         max_length=100,
-        verbose_name=("intro title"),
+        verbose_name="intro title",
         blank=True,
         help_text=(
             "Only used in jump links. Does not appear on page. Leave blank to default to 'About [Page title]'."
@@ -939,9 +939,9 @@ class ExhibitionPage(
 
     exhibition_highlights_title = models.CharField(
         max_length=100,
-        verbose_name=("exhibition highlights title"),
+        verbose_name="exhibition highlights title",
         blank=True,
-        help_text=("Leave blank to default to 'Exhibition highlights'."),
+        help_text="Leave blank to default to 'Exhibition highlights'.",
     )
 
     exhibition_highlights = StreamField(
@@ -958,9 +958,9 @@ class ExhibitionPage(
 
     video_title = models.CharField(
         max_length=100,
-        verbose_name=("video title"),
+        verbose_name="video title",
         blank=True,
-        help_text=("The title of the video section."),
+        help_text="The title of the video section.",
     )
 
     video = StreamField(
@@ -975,12 +975,12 @@ class ExhibitionPage(
     related_pages_title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=("The title to display for the related content section."),
+        help_text="The title to display for the related content section.",
     )
 
     related_pages_description = RichTextField(
         blank=True,
-        help_text=("The description to display for the related content section."),
+        help_text="The description to display for the related content section.",
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -996,8 +996,8 @@ class ExhibitionPage(
 
     event_title = models.CharField(
         max_length=100,
-        verbose_name=("event title"),
-        help_text=("The title of the events section."),
+        verbose_name="event title",
+        help_text="The title of the events section.",
         default="Exhibition events",
         blank=True,
         null=True,
@@ -1005,7 +1005,7 @@ class ExhibitionPage(
 
     event_description = RichTextField(
         blank=True,
-        help_text=("The description to display for the events section."),
+        help_text="The description to display for the events section.",
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -1080,7 +1080,7 @@ class ExhibitionPage(
                 FieldPanel("hero_style"),
                 FieldPanel("hero_layout"),
             ],
-            heading=("Hero section"),
+            heading="Hero section",
         ),
         MultiFieldPanel(
             [
@@ -1093,7 +1093,7 @@ class ExhibitionPage(
                 FieldPanel("video_title"),
                 FieldPanel("video"),
             ],
-            heading=("Content"),
+            heading="Content",
         ),
         MultiFieldPanel(
             [
@@ -1106,7 +1106,7 @@ class ExhibitionPage(
                 FieldPanel("event_links"),
                 FieldPanel("shop"),
             ],
-            heading=("Related content"),
+            heading="Related content",
         ),
     ]
 
@@ -1121,14 +1121,14 @@ class ExhibitionPage(
                 ),
                 FieldPanel("exclude_days"),
             ],
-            heading=("Date details"),
+            heading="Date details",
         ),
         MultiFieldPanel(
             [
                 FieldPanel("price"),
                 FieldPanel("booking_details"),
             ],
-            heading=("Price details"),
+            heading="Price details",
         ),
         FieldPanel("open_days"),
         FieldPanel("age_detail"),
@@ -1138,7 +1138,7 @@ class ExhibitionPage(
                 FieldPanel("partnership_lead_text"),
                 FieldPanel("partnership"),
             ],
-            heading=("Partnership details"),
+            heading="Partnership details",
         ),
     ]
 
@@ -1149,7 +1149,7 @@ class ExhibitionPage(
     promote_panels = BasePageWithRequiredIntro.promote_panels + [
         InlinePanel(
             "page_series_tags",
-            heading=("Series"),
+            heading="Series",
             max_num=3,
         ),
     ]

--- a/app/whatson/models/details.py
+++ b/app/whatson/models/details.py
@@ -3,7 +3,6 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail import blocks
 from wagtail.admin.panels import (
@@ -68,15 +67,15 @@ class SeriesTag(Orderable):
         "whatson.WhatsOnSeriesPage",
         on_delete=models.CASCADE,
         related_name="series_pages",
-        verbose_name=_("series"),
-        help_text=_("The series to include the page in."),
+        verbose_name=("series"),
+        help_text=("The series to include the page in."),
         null=False,
         blank=False,
     )
 
     class Meta:
-        verbose_name = _("series")
-        verbose_name_plural = _("series")
+        verbose_name = "series"
+        verbose_name_plural = "series"
 
     def __str__(self):
         return f"{self.page.title}: {self.series.title}"
@@ -92,18 +91,18 @@ class EventType(models.Model):
 
     name = models.CharField(
         max_length=255,
-        verbose_name=_("name"),
+        verbose_name=("name"),
     )
 
     slug = models.SlugField(
         max_length=255,
-        verbose_name=_("slug"),
+        verbose_name=("slug"),
         unique=True,
     )
 
     class Meta:
-        verbose_name = _("event type")
-        verbose_name_plural = _("event types")
+        verbose_name = "event type"
+        verbose_name_plural = "event types"
 
     def __str__(self):
         return self.name
@@ -130,21 +129,21 @@ class EventSpeaker(Orderable):
 
     name = models.CharField(
         max_length=100,
-        verbose_name=_("name"),
-        help_text=_("The name of the speaker."),
+        verbose_name=("name"),
+        help_text=("The name of the speaker."),
         blank=True,
     )
 
     role = models.CharField(
         max_length=200,
-        verbose_name=_("role"),
-        help_text=_("The role of the speaker."),
+        verbose_name=("role"),
+        help_text=("The role of the speaker."),
         blank=True,
     )
 
     biography = RichTextField(
-        verbose_name=_("biography"),
-        help_text=_("A short biography of the speaker."),
+        verbose_name=("biography"),
+        help_text=("A short biography of the speaker."),
         blank=True,
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
@@ -168,7 +167,7 @@ class EventSpeaker(Orderable):
     def clean(self):
         if not (self.name and self.role) and not self.person_page:
             raise ValidationError(
-                _(
+                (
                     "You must provide either a person's name and role or a person page for the speaker."
                 )
             )
@@ -178,7 +177,7 @@ class EventSpeaker(Orderable):
             or (self.person_page and self.image)
         ):
             raise ValidationError(
-                _(
+                (
                     "You cannot provide both a person's details and a person page for the speaker."
                 )
             )
@@ -198,32 +197,32 @@ class EventSession(models.Model):
     )
 
     start = models.DateTimeField(
-        verbose_name=_("starts at"),
+        verbose_name=("starts at"),
     )
 
     end = models.DateTimeField(
-        verbose_name=_("ends at"),
+        verbose_name=("ends at"),
     )
 
     sold_out = models.BooleanField(
-        verbose_name=_("sold out"),
+        verbose_name=("sold out"),
         default=False,
-        help_text=_("Check this box if the session is sold out."),
+        help_text=("Check this box if the session is sold out."),
     )
 
     def clean(self):
         if self.start and self.end and self.start >= self.end:
             raise ValidationError(
                 {
-                    "start": _("The start time must be before the end time."),
-                    "end": _("The end time must be after the start time."),
+                    "start": ("The start time must be before the end time."),
+                    "end": ("The end time must be after the start time."),
                 }
             )
         if self.start and self.end and self.start.date() != self.end.date():
             raise ValidationError(
                 {
-                    "start": _("The start and end times must be on the same day."),
-                    "end": _("The start and end times must be on the same day."),
+                    "start": ("The start and end times must be on the same day."),
+                    "end": ("The start and end times must be on the same day."),
                 }
             )
         return super().clean()
@@ -235,8 +234,8 @@ class EventSession(models.Model):
     ]
 
     class Meta:
-        verbose_name = _("session")
-        verbose_name_plural = _("sessions")
+        verbose_name = "session"
+        verbose_name_plural = "sessions"
         ordering = ["start"]
 
 
@@ -256,21 +255,21 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     )
 
     various_dates = models.BooleanField(
-        verbose_name=_("various dates and times"),
+        verbose_name=("various dates and times"),
         default=False,
-        help_text=_(
+        help_text=(
             "Check this box if the event has multiple sessions with different dates and times."
         ),
     )
 
     start_date = models.DateTimeField(
-        verbose_name=_("start date"),
+        verbose_name=("start date"),
         null=True,
         editable=False,
     )
 
     end_date = models.DateTimeField(
-        verbose_name=_("end date"),
+        verbose_name=("end date"),
         null=True,
         editable=False,
     )
@@ -279,33 +278,33 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
         EventPageStreamBlock(),
         blank=True,
         null=True,
-        verbose_name=_("description"),
-        help_text=_("The description of the event."),
+        verbose_name=("description"),
+        help_text=("The description of the event."),
     )
 
     age_detail = models.CharField(
         max_length=40,
-        verbose_name=_("age detail"),
+        verbose_name=("age detail"),
         blank=True,
-        help_text=_("The text for the age detail section."),
+        help_text=("The text for the age detail section."),
     )
 
     booking_details = RichTextField(
         max_length=40,
         null=True,
         blank=True,
-        verbose_name=_("booking details"),
-        help_text=_("Information about how to book tickets for the event."),
+        verbose_name=("booking details"),
+        help_text=("Information about how to book tickets for the event."),
         features=["link"],
     )
 
     min_price = models.FloatField(
-        verbose_name=_("minimum price"),
+        verbose_name=("minimum price"),
         default=0,
     )
 
     max_price = models.FloatField(
-        verbose_name=_("maximum price"),
+        verbose_name=("maximum price"),
         default=0,
     )
 
@@ -315,8 +314,8 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("location"),
-        help_text=_("The location of the event."),
+        verbose_name=("location"),
+        help_text=("The location of the event."),
     )
 
     booking_link = models.URLField(
@@ -328,9 +327,9 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
 
     event_highlights_title = models.CharField(
         max_length=100,
-        verbose_name=_("event highlights title"),
+        verbose_name=("event highlights title"),
         blank=True,
-        help_text=_("Leave blank to default to 'Event highlights'."),
+        help_text=("Leave blank to default to 'Event highlights'."),
     )
 
     event_highlights = StreamField(
@@ -340,7 +339,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     )
 
     class Meta:
-        verbose_name = _("event page")
+        verbose_name = "event page"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels
@@ -351,14 +350,14 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                 [
                     FieldPanel("description"),
                 ],
-                heading=_("Event information"),
+                heading=("Event information"),
             ),
             MultiFieldPanel(
                 [
                     FieldPanel("event_highlights_title"),
                     FieldPanel("event_highlights"),
                 ],
-                heading=_("Event highlights"),
+                heading=("Event highlights"),
             ),
         ]
     )
@@ -376,7 +375,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                     ],
                 ),
             ],
-            heading=_("Price details"),
+            heading=("Price details"),
         ),
         MultiFieldPanel(
             [
@@ -385,25 +384,25 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                         FieldPanel("start_date", read_only=True),
                         FieldPanel("end_date", read_only=True),
                     ],
-                    help_text=_(
+                    help_text=(
                         "These dates are automatically set based on the sessions added."
                     ),
                 ),
                 FieldPanel("various_dates"),
                 InlinePanel(
                     "sessions",
-                    heading=_("Sessions"),
+                    heading=("Sessions"),
                     min_num=1,
                 ),
             ],
-            heading=_("Date details"),
+            heading=("Date details"),
         ),
         FieldPanel("location"),
         FieldPanel("age_detail"),
         InlinePanel(
             "speakers",
-            heading=_("Speaker information"),
-            help_text=_(
+            heading=("Speaker information"),
+            help_text=(
                 "If the event has more than one speaker, please add these in order of relevance from most to least."
             ),
         ),
@@ -412,7 +411,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     promote_panels = BasePageWithRequiredIntro.promote_panels + [
         InlinePanel(
             "page_series_tags",
-            heading=_("Series"),
+            heading=("Series"),
             max_num=3,
         ),
     ]
@@ -559,54 +558,54 @@ class DisplayPage(
 
     # Key details section
     start_date = models.DateField(
-        verbose_name=_("start date"),
+        verbose_name=("start date"),
         null=True,
         blank=True,
     )
 
     end_date = models.DateField(
-        verbose_name=_("end date"),
+        verbose_name=("end date"),
         null=True,
         blank=True,
     )
 
     all_year = models.BooleanField(
-        verbose_name=_("all year"),
+        verbose_name=("all year"),
         default=False,
-        help_text=_("Check this box if the display is available all year round."),
+        help_text=("Check this box if the display is available all year round."),
     )
 
     exclude_days = models.BooleanField(
-        verbose_name=_("exclude days"),
+        verbose_name=("exclude days"),
         default=False,
-        help_text=_("Check this box to show only the month and year on the display."),
+        help_text=("Check this box to show only the month and year on the display."),
     )
 
     price = models.FloatField(
-        verbose_name=_("price"),
+        verbose_name=("price"),
         default=0,
     )
 
     booking_details = RichTextField(
         max_length=40,
         null=True,
-        verbose_name=_("booking details"),
-        help_text=_("Information about how to book tickets for the display."),
+        verbose_name=("booking details"),
+        help_text=("Information about how to book tickets for the display."),
         features=["link"],
     )
 
     open_days = models.CharField(
         max_length=255,
-        verbose_name=_("open days"),
+        verbose_name=("open days"),
         blank=True,
-        help_text=_("The days the display is open, e.g. Tuesday to Sunday."),
+        help_text=("The days the display is open, e.g. Tuesday to Sunday."),
     )
 
     age_detail = models.CharField(
         max_length=40,
-        verbose_name=_("age detail"),
+        verbose_name=("age detail"),
         blank=True,
-        help_text=_("The text for the age detail section."),
+        help_text=("The text for the age detail section."),
     )
 
     location = models.ForeignKey(
@@ -615,8 +614,8 @@ class DisplayPage(
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("location"),
-        help_text=_("The location of the display."),
+        verbose_name=("location"),
+        help_text=("The location of the display."),
     )
 
     # Body section
@@ -624,9 +623,9 @@ class DisplayPage(
 
     display_highlights_title = models.CharField(
         max_length=100,
-        verbose_name=_("display highlights title"),
+        verbose_name=("display highlights title"),
         blank=True,
-        help_text=_("Leave blank to default to 'Display highlights'."),
+        help_text=("Leave blank to default to 'Display highlights'."),
     )
 
     display_highlights = StreamField(
@@ -639,12 +638,12 @@ class DisplayPage(
     related_pages_title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_("The title to display for the related content section."),
+        help_text=("The title to display for the related content section."),
     )
 
     related_pages_description = RichTextField(
         blank=True,
-        help_text=_("The description to display for the related content section."),
+        help_text=("The description to display for the related content section."),
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -699,9 +698,9 @@ class DisplayPage(
             return location.address_line_1 or location.space_name or "In-person"
 
     class Meta:
-        verbose_name = _("display page")
-        verbose_name_plural = _("display pages")
-        verbose_name_public = _("display")
+        verbose_name = "display page"
+        verbose_name_plural = "display pages"
+        verbose_name_public = "display"
 
     content_panels = (
         BasePageWithRequiredIntro.content_panels
@@ -714,7 +713,7 @@ class DisplayPage(
                     FieldPanel("display_highlights_title"),
                     FieldPanel("display_highlights"),
                 ],
-                heading=_("Content"),
+                heading=("Content"),
             ),
             MultiFieldPanel(
                 [
@@ -724,7 +723,7 @@ class DisplayPage(
                     FieldPanel("related_pages"),
                     FieldPanel("shop"),
                 ],
-                heading=_("Related content"),
+                heading=("Related content"),
             ),
         ]
     )
@@ -741,14 +740,14 @@ class DisplayPage(
                 FieldPanel("all_year"),
                 FieldPanel("exclude_days"),
             ],
-            heading=_("Date details"),
+            heading=("Date details"),
         ),
         MultiFieldPanel(
             [
                 FieldPanel("price"),
                 FieldPanel("booking_details"),
             ],
-            heading=_("Price details"),
+            heading=("Price details"),
         ),
         FieldPanel("open_days"),
         FieldPanel("age_detail"),
@@ -756,14 +755,14 @@ class DisplayPage(
             [
                 FieldPanel("location"),
             ],
-            heading=_("Location details"),
+            heading=("Location details"),
         ),
     ]
 
     promote_panels = BasePageWithRequiredIntro.promote_panels + [
         InlinePanel(
             "page_series_tags",
-            heading=_("Series"),
+            heading=("Series"),
             max_num=3,
         ),
     ]
@@ -826,8 +825,8 @@ class DisplayPage(
             if self.start_date > self.end_date:
                 raise ValidationError(
                     {
-                        "start_date": _("The start date must be before the end date."),
-                        "end_date": _("The end date must be after the start date."),
+                        "start_date": ("The start date must be before the end date."),
+                        "end_date": ("The end date must be after the start date."),
                     }
                 )
 
@@ -849,56 +848,54 @@ class ExhibitionPage(
     # Hero section
     subtitle = models.CharField(
         max_length=120,
-        verbose_name=_("subtitle"),
-        help_text=_("A subtitle for the event."),
+        verbose_name=("subtitle"),
+        help_text=("A subtitle for the event."),
     )
 
     # Key details section
     start_date = models.DateField(
-        verbose_name=_("start date"),
+        verbose_name=("start date"),
         null=True,
         blank=True,
     )
 
     end_date = models.DateField(
-        verbose_name=_("end date"),
+        verbose_name=("end date"),
         null=True,
         blank=True,
     )
 
     exclude_days = models.BooleanField(
-        verbose_name=_("exclude days"),
+        verbose_name=("exclude days"),
         default=False,
-        help_text=_(
-            "Check this box to show only the month and year on the exhibition."
-        ),
+        help_text=("Check this box to show only the month and year on the exhibition."),
     )
 
     price = models.FloatField(
-        verbose_name=_("price"),
+        verbose_name=("price"),
         default=0,
     )
 
     booking_details = RichTextField(
         max_length=40,
         null=True,
-        verbose_name=_("booking details"),
-        help_text=_("Information about how to book tickets for the exhibition."),
+        verbose_name=("booking details"),
+        help_text=("Information about how to book tickets for the exhibition."),
         features=["link"],
     )
 
     open_days = models.CharField(
         max_length=255,
-        verbose_name=_("open days"),
+        verbose_name=("open days"),
         blank=True,
-        help_text=_("The days the exhibition is open, e.g. Tuesday to Sunday."),
+        help_text=("The days the exhibition is open, e.g. Tuesday to Sunday."),
     )
 
     age_detail = models.CharField(
         max_length=40,
-        verbose_name=_("age detail"),
+        verbose_name=("age detail"),
         blank=True,
-        help_text=_("The text for the age detail section."),
+        help_text=("The text for the age detail section."),
     )
 
     location = models.ForeignKey(
@@ -907,15 +904,15 @@ class ExhibitionPage(
         blank=False,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("location"),
-        help_text=_("The location of the exhibition."),
+        verbose_name=("location"),
+        help_text=("The location of the exhibition."),
     )
 
     partnership_lead_text = models.CharField(
         max_length=40,
-        verbose_name=_("partnership lead text"),
+        verbose_name=("partnership lead text"),
         blank=True,
-        help_text=_(
+        help_text=(
             "Optional override for the partner logos section lead text. Will display a default if not provided."
         ),
     )
@@ -924,16 +921,16 @@ class ExhibitionPage(
         null=True,
         blank=True,
         related_name="+",
-        verbose_name=_("partnership"),
-        help_text=_("The partnership logo for the exhibition."),
+        verbose_name=("partnership"),
+        help_text=("The partnership logo for the exhibition."),
     )
 
     # Body section
     intro_title = models.CharField(
         max_length=100,
-        verbose_name=_("intro title"),
+        verbose_name=("intro title"),
         blank=True,
-        help_text=_(
+        help_text=(
             "Only used in jump links. Does not appear on page. Leave blank to default to 'About [Page title]'."
         ),
     )
@@ -942,9 +939,9 @@ class ExhibitionPage(
 
     exhibition_highlights_title = models.CharField(
         max_length=100,
-        verbose_name=_("exhibition highlights title"),
+        verbose_name=("exhibition highlights title"),
         blank=True,
-        help_text=_("Leave blank to default to 'Exhibition highlights'."),
+        help_text=("Leave blank to default to 'Exhibition highlights'."),
     )
 
     exhibition_highlights = StreamField(
@@ -961,9 +958,9 @@ class ExhibitionPage(
 
     video_title = models.CharField(
         max_length=100,
-        verbose_name=_("video title"),
+        verbose_name=("video title"),
         blank=True,
-        help_text=_("The title of the video section."),
+        help_text=("The title of the video section."),
     )
 
     video = StreamField(
@@ -978,12 +975,12 @@ class ExhibitionPage(
     related_pages_title = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_("The title to display for the related content section."),
+        help_text=("The title to display for the related content section."),
     )
 
     related_pages_description = RichTextField(
         blank=True,
-        help_text=_("The description to display for the related content section."),
+        help_text=("The description to display for the related content section."),
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -999,8 +996,8 @@ class ExhibitionPage(
 
     event_title = models.CharField(
         max_length=100,
-        verbose_name=_("event title"),
-        help_text=_("The title of the events section."),
+        verbose_name=("event title"),
+        help_text=("The title of the events section."),
         default="Exhibition events",
         blank=True,
         null=True,
@@ -1008,7 +1005,7 @@ class ExhibitionPage(
 
     event_description = RichTextField(
         blank=True,
-        help_text=_("The description to display for the events section."),
+        help_text=("The description to display for the events section."),
         features=settings.INLINE_RICH_TEXT_FEATURES,
     )
 
@@ -1068,9 +1065,9 @@ class ExhibitionPage(
             return location.address_line_1 or location.space_name or "In-person"
 
     class Meta:
-        verbose_name = _("exhibition page")
-        verbose_name_plural = _("exhibition pages")
-        verbose_name_public = _("exhibition")
+        verbose_name = "exhibition page"
+        verbose_name_plural = "exhibition pages"
+        verbose_name_public = "exhibition"
 
     content_panels = [
         TitleFieldPanel("title"),
@@ -1083,7 +1080,7 @@ class ExhibitionPage(
                 FieldPanel("hero_style"),
                 FieldPanel("hero_layout"),
             ],
-            heading=_("Hero section"),
+            heading=("Hero section"),
         ),
         MultiFieldPanel(
             [
@@ -1096,7 +1093,7 @@ class ExhibitionPage(
                 FieldPanel("video_title"),
                 FieldPanel("video"),
             ],
-            heading=_("Content"),
+            heading=("Content"),
         ),
         MultiFieldPanel(
             [
@@ -1109,7 +1106,7 @@ class ExhibitionPage(
                 FieldPanel("event_links"),
                 FieldPanel("shop"),
             ],
-            heading=_("Related content"),
+            heading=("Related content"),
         ),
     ]
 
@@ -1124,14 +1121,14 @@ class ExhibitionPage(
                 ),
                 FieldPanel("exclude_days"),
             ],
-            heading=_("Date details"),
+            heading=("Date details"),
         ),
         MultiFieldPanel(
             [
                 FieldPanel("price"),
                 FieldPanel("booking_details"),
             ],
-            heading=_("Price details"),
+            heading=("Price details"),
         ),
         FieldPanel("open_days"),
         FieldPanel("age_detail"),
@@ -1141,7 +1138,7 @@ class ExhibitionPage(
                 FieldPanel("partnership_lead_text"),
                 FieldPanel("partnership"),
             ],
-            heading=_("Partnership details"),
+            heading=("Partnership details"),
         ),
     ]
 
@@ -1152,7 +1149,7 @@ class ExhibitionPage(
     promote_panels = BasePageWithRequiredIntro.promote_panels + [
         InlinePanel(
             "page_series_tags",
-            heading=_("Series"),
+            heading=("Series"),
             max_num=3,
         ),
     ]
@@ -1228,16 +1225,14 @@ class ExhibitionPage(
             if self.start_date > self.end_date:
                 raise ValidationError(
                     {
-                        "start_date": _("The start date must be before the end date."),
-                        "end_date": _("The end date must be after the start date."),
+                        "start_date": ("The start date must be before the end date."),
+                        "end_date": ("The end date must be after the start date."),
                     }
                 )
         if self.video and not self.video_title:
             raise ValidationError(
                 {
-                    "video_title": _(
-                        "The video title is required if a video is added."
-                    ),
+                    "video_title": ("The video title is required if a video is added."),
                 }
             )
         return super().clean()

--- a/app/whatson/models/details.py
+++ b/app/whatson/models/details.py
@@ -167,9 +167,7 @@ class EventSpeaker(Orderable):
     def clean(self):
         if not (self.name and self.role) and not self.person_page:
             raise ValidationError(
-                (
-                    "You must provide either a person's name and role or a person page for the speaker."
-                )
+                "You must provide either a person's name and role or a person page for the speaker."
             )
         if (
             (self.person_page and self.name)
@@ -177,9 +175,7 @@ class EventSpeaker(Orderable):
             or (self.person_page and self.image)
         ):
             raise ValidationError(
-                (
-                    "You cannot provide both a person's details and a person page for the speaker."
-                )
+                "You cannot provide both a person's details and a person page for the speaker."
             )
         return super().clean()
 
@@ -214,15 +210,15 @@ class EventSession(models.Model):
         if self.start and self.end and self.start >= self.end:
             raise ValidationError(
                 {
-                    "start": ("The start time must be before the end time."),
-                    "end": ("The end time must be after the start time."),
+                    "start": "The start time must be before the end time.",
+                    "end": "The end time must be after the start time.",
                 }
             )
         if self.start and self.end and self.start.date() != self.end.date():
             raise ValidationError(
                 {
-                    "start": ("The start and end times must be on the same day."),
-                    "end": ("The start and end times must be on the same day."),
+                    "start": "The start and end times must be on the same day.",
+                    "end": "The start and end times must be on the same day.",
                 }
             )
         return super().clean()
@@ -819,8 +815,8 @@ class DisplayPage(
             if self.start_date > self.end_date:
                 raise ValidationError(
                     {
-                        "start_date": ("The start date must be before the end date."),
-                        "end_date": ("The end date must be after the start date."),
+                        "start_date": "The start date must be before the end date.",
+                        "end_date": "The end date must be after the start date.",
                     }
                 )
 
@@ -1215,14 +1211,14 @@ class ExhibitionPage(
             if self.start_date > self.end_date:
                 raise ValidationError(
                     {
-                        "start_date": ("The start date must be before the end date."),
-                        "end_date": ("The end date must be after the start date."),
+                        "start_date": "The start date must be before the end date.",
+                        "end_date": "The end date must be after the start date.",
                     }
                 )
         if self.video and not self.video_title:
             raise ValidationError(
                 {
-                    "video_title": ("The video title is required if a video is added."),
+                    "video_title": "The video title is required if a video is added.",
                 }
             )
         return super().clean()

--- a/app/whatson/models/details.py
+++ b/app/whatson/models/details.py
@@ -257,9 +257,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
     various_dates = models.BooleanField(
         verbose_name="various dates and times",
         default=False,
-        help_text=(
-            "Check this box if the event has multiple sessions with different dates and times."
-        ),
+        help_text="Check this box if the event has multiple sessions with different dates and times.",
     )
 
     start_date = models.DateTimeField(
@@ -384,9 +382,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
                         FieldPanel("start_date", read_only=True),
                         FieldPanel("end_date", read_only=True),
                     ],
-                    help_text=(
-                        "These dates are automatically set based on the sessions added."
-                    ),
+                    help_text="These dates are automatically set based on the sessions added.",
                 ),
                 FieldPanel("various_dates"),
                 InlinePanel(
@@ -402,9 +398,7 @@ class EventPage(RequiredHeroImageMixin, ContentWarningMixin, BasePageWithRequire
         InlinePanel(
             "speakers",
             heading="Speaker information",
-            help_text=(
-                "If the event has more than one speaker, please add these in order of relevance from most to least."
-            ),
+            help_text="If the event has more than one speaker, please add these in order of relevance from most to least.",
         ),
     ]
 
@@ -912,9 +906,7 @@ class ExhibitionPage(
         max_length=40,
         verbose_name="partnership lead text",
         blank=True,
-        help_text=(
-            "Optional override for the partner logos section lead text. Will display a default if not provided."
-        ),
+        help_text="Optional override for the partner logos section lead text. Will display a default if not provided.",
     )
 
     partnership = PartnerLogoField(
@@ -930,9 +922,7 @@ class ExhibitionPage(
         max_length=100,
         verbose_name="intro title",
         blank=True,
-        help_text=(
-            "Only used in jump links. Does not appear on page. Leave blank to default to 'About [Page title]'."
-        ),
+        help_text="Only used in jump links. Does not appear on page. Leave blank to default to 'About [Page title]'.",
     )
 
     body = StreamField(ExhibitionPageStreamBlock, blank=True, null=True)

--- a/app/whatson/models/landing.py
+++ b/app/whatson/models/landing.py
@@ -32,8 +32,8 @@ class WhatsOnPageSelection(Orderable):
         "wagtailcore.Page",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=("selected page"),
-        help_text=("The page to display on the What's On page."),
+        verbose_name="selected page",
+        help_text="The page to display on the What's On page.",
     )
 
     panels = [
@@ -82,8 +82,8 @@ class WhatsOnPage(BasePageWithRequiredIntro):
     content_panels = BasePageWithRequiredIntro.content_panels + [
         InlinePanel(
             "whats_on_page_selections",
-            heading=("Page selections"),
-            help_text=("Select pages to display on the What's On page."),
+            heading="Page selections",
+            help_text="Select pages to display on the What's On page.",
         ),
     ]
 

--- a/app/whatson/models/landing.py
+++ b/app/whatson/models/landing.py
@@ -1,6 +1,5 @@
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import (
     InlinePanel,
@@ -33,8 +32,8 @@ class WhatsOnPageSelection(Orderable):
         "wagtailcore.Page",
         on_delete=models.CASCADE,
         related_name="+",
-        verbose_name=_("selected page"),
-        help_text=_("The page to display on the What's On page."),
+        verbose_name=("selected page"),
+        help_text=("The page to display on the What's On page."),
     )
 
     panels = [
@@ -50,7 +49,7 @@ class WhatsOnPageSelection(Orderable):
     ]
 
     class Meta:
-        verbose_name = _("selection")
+        verbose_name = "selection"
         ordering = ["sort_order"]
 
 
@@ -64,7 +63,7 @@ class WhatsOnPage(BasePageWithRequiredIntro):
         return "What's On"
 
     class Meta:
-        verbose_name = _("What's On page")
+        verbose_name = "What's On page"
 
     parent_page_types = [
         "home.HomePage",
@@ -83,8 +82,8 @@ class WhatsOnPage(BasePageWithRequiredIntro):
     content_panels = BasePageWithRequiredIntro.content_panels + [
         InlinePanel(
             "whats_on_page_selections",
-            heading=_("Page selections"),
-            help_text=_("Select pages to display on the What's On page."),
+            heading=("Page selections"),
+            help_text=("Select pages to display on the What's On page."),
         ),
     ]
 

--- a/app/whatson/models/listings.py
+++ b/app/whatson/models/listings.py
@@ -74,8 +74,8 @@ class WhatsOnSeriesPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured page"),
-        help_text=("The page to feature on the series page."),
+        verbose_name="featured page",
+        help_text="The page to feature on the series page.",
     )
 
     parent_page_types = [
@@ -156,8 +156,8 @@ class CategorySelection(models.Model):
         "whatson.EventType",
         on_delete=models.CASCADE,
         related_name="selected_category",
-        verbose_name=("category"),
-        help_text=("The category of events to display on the Category page."),
+        verbose_name="category",
+        help_text="The category of events to display on the Category page.",
         null=False,
         blank=False,
     )
@@ -174,8 +174,8 @@ class WhatsOnCategoryPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured page"),
-        help_text=("The page to feature on the category page."),
+        verbose_name="featured page",
+        help_text="The page to feature on the category page.",
     )
 
     parent_page_types = [
@@ -187,7 +187,7 @@ class WhatsOnCategoryPage(BasePageWithRequiredIntro):
     content_panels = BasePageWithRequiredIntro.content_panels + [
         InlinePanel(
             "category_pages",
-            heading=("Category selection"),
+            heading="Category selection",
         ),
         PageChooserPanel(
             "featured_page",
@@ -254,14 +254,14 @@ class WhatsOnLocationListingPage(BasePageWithRequiredIntro):
 
     at_tna = models.BooleanField(
         default=False,
-        verbose_name=("at The National Archives"),
-        help_text=("Check this box to display events at The National Archives."),
+        verbose_name="at The National Archives",
+        help_text="Check this box to display events at The National Archives.",
     )
 
     online = models.BooleanField(
         default=False,
-        verbose_name=("online"),
-        help_text=("Check this box to display online events."),
+        verbose_name="online",
+        help_text="Check this box to display online events.",
     )
 
     @cached_property
@@ -340,8 +340,8 @@ class WhatsOnDateListingPage(BasePageWithRequiredIntro):
 
     days = models.PositiveIntegerField(
         default=1,
-        verbose_name=("number of days"),
-        help_text=("The number of days in the future to list events/exhibitions."),
+        verbose_name="number of days",
+        help_text="The number of days in the future to list events/exhibitions.",
     )
 
     @cached_property
@@ -449,8 +449,8 @@ class EventsListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured page"),
-        help_text=("The page to feature at the top of the Events page."),
+        verbose_name="featured page",
+        help_text="The page to feature at the top of the Events page.",
     )
 
     max_count = 1
@@ -510,8 +510,8 @@ class ExhibitionsListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=("featured page"),
-        help_text=("The page to feature at the top of the Exhibitions page."),
+        verbose_name="featured page",
+        help_text="The page to feature at the top of the Exhibitions page.",
     )
 
     @cached_property

--- a/app/whatson/models/listings.py
+++ b/app/whatson/models/listings.py
@@ -4,7 +4,6 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import (
     FieldPanel,
@@ -75,8 +74,8 @@ class WhatsOnSeriesPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured page"),
-        help_text=_("The page to feature on the series page."),
+        verbose_name=("featured page"),
+        help_text=("The page to feature on the series page."),
     )
 
     parent_page_types = [
@@ -143,8 +142,8 @@ class WhatsOnSeriesPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Series listing page")
-        verbose_name_plural = _("Series listing pages")
+        verbose_name = "Series listing page"
+        verbose_name_plural = "Series listing pages"
 
 
 class CategorySelection(models.Model):
@@ -157,8 +156,8 @@ class CategorySelection(models.Model):
         "whatson.EventType",
         on_delete=models.CASCADE,
         related_name="selected_category",
-        verbose_name=_("category"),
-        help_text=_("The category of events to display on the Category page."),
+        verbose_name=("category"),
+        help_text=("The category of events to display on the Category page."),
         null=False,
         blank=False,
     )
@@ -175,8 +174,8 @@ class WhatsOnCategoryPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured page"),
-        help_text=_("The page to feature on the category page."),
+        verbose_name=("featured page"),
+        help_text=("The page to feature on the category page."),
     )
 
     parent_page_types = [
@@ -188,7 +187,7 @@ class WhatsOnCategoryPage(BasePageWithRequiredIntro):
     content_panels = BasePageWithRequiredIntro.content_panels + [
         InlinePanel(
             "category_pages",
-            heading=_("Category selection"),
+            heading=("Category selection"),
         ),
         PageChooserPanel(
             "featured_page",
@@ -244,8 +243,8 @@ class WhatsOnCategoryPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Category listing page")
-        verbose_name_plural = _("Category listing pages")
+        verbose_name = "Category listing page"
+        verbose_name_plural = "Category listing pages"
 
 
 class WhatsOnLocationListingPage(BasePageWithRequiredIntro):
@@ -255,14 +254,14 @@ class WhatsOnLocationListingPage(BasePageWithRequiredIntro):
 
     at_tna = models.BooleanField(
         default=False,
-        verbose_name=_("at The National Archives"),
-        help_text=_("Check this box to display events at The National Archives."),
+        verbose_name=("at The National Archives"),
+        help_text=("Check this box to display events at The National Archives."),
     )
 
     online = models.BooleanField(
         default=False,
-        verbose_name=_("online"),
-        help_text=_("Check this box to display online events."),
+        verbose_name=("online"),
+        help_text=("Check this box to display online events."),
     )
 
     @cached_property
@@ -330,8 +329,8 @@ class WhatsOnLocationListingPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Location listing page")
-        verbose_name_plural = _("Location listing pages")
+        verbose_name = "Location listing page"
+        verbose_name_plural = "Location listing pages"
 
 
 class WhatsOnDateListingPage(BasePageWithRequiredIntro):
@@ -341,8 +340,8 @@ class WhatsOnDateListingPage(BasePageWithRequiredIntro):
 
     days = models.PositiveIntegerField(
         default=1,
-        verbose_name=_("number of days"),
-        help_text=_("The number of days in the future to list events/exhibitions."),
+        verbose_name=("number of days"),
+        help_text=("The number of days in the future to list events/exhibitions."),
     )
 
     @cached_property
@@ -435,8 +434,8 @@ class WhatsOnDateListingPage(BasePageWithRequiredIntro):
     ]
 
     class Meta:
-        verbose_name = _("Date listing page")
-        verbose_name_plural = _("Date listing pages")
+        verbose_name = "Date listing page"
+        verbose_name_plural = "Date listing pages"
 
 
 class EventsListingPage(BasePageWithRequiredIntro):
@@ -450,8 +449,8 @@ class EventsListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured page"),
-        help_text=_("The page to feature at the top of the Events page."),
+        verbose_name=("featured page"),
+        help_text=("The page to feature at the top of the Events page."),
     )
 
     max_count = 1
@@ -511,8 +510,8 @@ class ExhibitionsListingPage(BasePageWithRequiredIntro):
         blank=True,
         on_delete=models.SET_NULL,
         related_name="+",
-        verbose_name=_("featured page"),
-        help_text=_("The page to feature at the top of the Exhibitions page."),
+        verbose_name=("featured page"),
+        help_text=("The page to feature at the top of the Exhibitions page."),
     )
 
     @cached_property


### PR DESCRIPTION
Fix for: https://the-national-archives.sentry.io/issues/7513606707/?alert_rule_id=11003752&alert_type=issue&notification_uuid=e92a674d-17fa-4be8-a0b8-c4a7d86f69e7&project=6377027

We don't actually need `gettext_lazy` as it's only used internally. Translation isn't really a need, and to be honest, in-browser translation will do the trick if it's _really_ needed...

I think I'll still raise this with Wagtail as I feel this is breaking at Wagtail level. But this fix works for us