### PR TITLE
Fix CIIMClient initialisation headers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - feature/*
+      - fix/*
 
 concurrency:
   group: cd-${{ github.ref }}

--- a/app/ciim/client.py
+++ b/app/ciim/client.py
@@ -26,8 +26,8 @@ class CIIMClient(SimpleJsonApiClient):
             )
         if default_params is None:
             default_params = {}
-        super().__init__(api_url, default_params=default_params)
-        self.add_default_parameter("filter", "@datatype.base:record")
+        default_params.update({"filter": "@datatype.base:record"})
+        super().__init__(api_url, default_params=default_params, default_headers={})
 
     def get(self, path: str = "/", headers: dict = None) -> dict:
         try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - WAGTAILAPI_BASE_URL=http://host.docker.internal:8000
       - WAGTAILAPI_MEDIA_BASE_URL=https://localhost
       - REDIS_URL=redis://redis:6379/0
+      - ROSETTA_API_URL=${ROSETTA_API_URL}
       - WAGTAIL_2FA_REQUIRED=False
       - EMAIL_HOST
       - EMAIL_HOST_USER


### PR DESCRIPTION
CIIM errors when you pass the `Accept` header which is what `SimpleJsonApiClient` adds as default