### PR TITLE
DescriptionListSettingsBlock `null` values

### DIFF
--- a/app/core/blocks/lists.py
+++ b/app/core/blocks/lists.py
@@ -69,6 +69,15 @@ class DescriptionListSettingsBlock(blocks.StructBlock):
         help_text="If enabled, the term and detail will be stacked vertically instead of displayed side by side.",
     )
 
+    def get_api_representation(self, value, context=None):
+        representation = super().get_api_representation(value, context=context)
+
+        for field in ("style", "column_balancing"):
+            if representation.get(field) == "none":
+                representation[field] = None
+
+        return representation
+
     class Meta:
         label = "Style Options"
         label_format = ""

--- a/app/core/tests/test_description_list_settings_block.py
+++ b/app/core/tests/test_description_list_settings_block.py
@@ -1,0 +1,43 @@
+from django.test import SimpleTestCase
+
+from app.core.blocks.lists import DescriptionListSettingsBlock
+
+
+class DescriptionListSettingsBlockTests(SimpleTestCase):
+    def test_empty_choice_values_are_serialized_as_none(self):
+        block = DescriptionListSettingsBlock()
+        value = block.to_python(
+            {
+                "style": "none",
+                "column_balancing": "none",
+                "stacked": False,
+            }
+        )
+
+        self.assertEqual(
+            block.get_api_representation(value),
+            {
+                "style": None,
+                "column_balancing": None,
+                "stacked": False,
+            },
+        )
+
+    def test_non_empty_choice_values_are_preserved(self):
+        block = DescriptionListSettingsBlock()
+        value = block.to_python(
+            {
+                "style": "lined",
+                "column_balancing": "even",
+                "stacked": True,
+            }
+        )
+
+        self.assertEqual(
+            block.get_api_representation(value),
+            {
+                "style": "lined",
+                "column_balancing": "even",
+                "stacked": True,
+            },
+        )


### PR DESCRIPTION
When a user selects "none" - return `null/None` in the API.