### PR TITLE
Media page URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,47 @@ Log in to the Wagtail Admin on [localhost:8000/admin](http://localhost:8000/admi
 This project contains technical documentation written in Markdown in the `/docs` folder. The latest build from the working branch can be viewed online at [nationalarchives.github.io/ds-wagtail](https://nationalarchives.github.io/ds-wagtail/).
 
 You can also view it locally on http://localhost:8001/ which is served from the `docs` container.
+
+## Environment variables
+
+In addition to the [base Docker image variables](https://github.com/nationalarchives/docker/blob/main/docker/tna-python/README.md#environment-variables), this application has support for:
+
+| Variable                             | Purpose                                                            | Default                                                 |
+| ------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------- |
+| `ALLOWED_HOSTS`                      | Comma-separated list of allowed Django hosts                       | `""`                                                    |
+| `BUILD_VERSION`                      | Build/version identifier surfaced in the app                       | `""`                                                    |
+| `CACHE_DEFAULT_TIMEOUT`              | Default cache timeout (only when `REDIS_URL` is set)               | production: `900`, staging: `60`, develop: `1`          |
+| `CSRF_TRUSTED_ORIGINS`               | Comma-separated CSRF trusted origins                               | `https://www.nationalarchives.gov.uk`                   |
+| `DATABASE_ENGINE`                    | Django database backend engine                                     | `django.db.backends.postgresql`                         |
+| `DATABASE_HOST`                      | Database host                                                      | _none_                                                  |
+| `DATABASE_NAME`                      | Database name                                                      | _none_                                                  |
+| `DATABASE_PASSWORD`                  | Database password                                                  | _none_                                                  |
+| `DATABASE_PORT`                      | Database port                                                      | `5432`                                                  |
+| `DATABASE_USER`                      | Database user                                                      | _none_                                                  |
+| `DEBUG`                              | Enable Django debug mode                                           | production: `False`, staging: `False`, develop: `False` |
+| `DEFAULT_FROM_EMAIL`                 | Default sender address for outgoing email                          | `wagtail@nationalarchives.gov.uk`                       |
+| `EMAIL_HOST`                         | SMTP host                                                          | _none_                                                  |
+| `EMAIL_HOST_PASSWORD`                | SMTP password                                                      | _none_                                                  |
+| `EMAIL_HOST_USER`                    | SMTP username                                                      | _none_                                                  |
+| `EMAIL_PORT`                         | SMTP port                                                          | `587`                                                   |
+| `EMAIL_USE_TLS`                      | Use TLS for SMTP                                                   | `True`                                                  |
+| `ENVIRONMENT_NAME`                   | Environment label used in UI/email text                            | `production`                                            |
+| `FRONTEND_CACHE_AWS_DISTRIBUTION_ID` | CloudFront distribution id for Wagtail frontend cache invalidation | `""`                                                    |
+| `LOG_LEVEL`                          | Root logger level                                                  | `warning`                                               |
+| `MEDIA_PAGE_URL`                     | Base URL used for live media page links                            | `WAGTAILAPI_MEDIA_BASE_URL`                             |
+| `NEW_LABEL_DISPLAY_FOR_DAYS`         | Number of days to show "new" labels                                | `21`                                                    |
+| `RECORD_DETAILS_CACHE_TIMEOUT`       | Record details cache timeout (seconds)                             | `2592000`                                               |
+| `REDIS_URL`                          | Redis connection URL to enable caching                             | _none_                                                  |
+| `ROSETTA_API_URL`                    | Base URL for the CIIM/Rosetta API client                           | _none_                                                  |
+| `SECRET_KEY`                         | Django secret key (required)                                       | _none_                                                  |
+| `SENTRY_DSN`                         | Sentry DSN                                                         | `""`                                                    |
+| `SENTRY_SAMPLE_RATE`                 | Trace/profile sampling rate                                        | production: `0.1`, staging: `0.25`, develop: `1.0`      |
+| `USE_X_FORWARDED_HOST`               | Trust `X-Forwarded-Host` header                                    | `False`                                                 |
+| `WAGTAILADMIN_BASE_URL`              | Public base URL for Wagtail admin                                  | `""`                                                    |
+| `WAGTAILAPI_AUTHENTICATION`          | Enable authentication on Wagtail API                               | `True`                                                  |
+| `WAGTAILAPI_BASE_URL`                | Public base URL for Wagtail API                                    | `WAGTAILADMIN_BASE_URL`                                 |
+| `WAGTAILAPI_LIMIT_MAX`               | Max API page size (`0` means unlimited/`None`)                     | `0`                                                     |
+| `WAGTAILAPI_MEDIA_BASE_URL`          | Public base URL for media URLs                                     | `""`                                                    |
+| `WAGTAIL_2FA_REQUIRED`               | Require 2FA for Wagtail admin users                                | `True`                                                  |
+| `WAGTAIL_AUTOSAVE_INTERVAL`          | Wagtail editor autosave interval in ms (`0` disables autosave)     | `0`                                                     |
+| `WAGTAIL_HEADLESS_PREVIEW_URL`       | Headless preview URL template                                      | `{SITE_ROOT_URL}/preview/`                              |

--- a/README.md
+++ b/README.md
@@ -30,42 +30,42 @@ You can also view it locally on http://localhost:8001/ which is served from the 
 
 In addition to the [base Docker image variables](https://github.com/nationalarchives/docker/blob/main/docker/tna-python/README.md#environment-variables), this application has support for:
 
-| Variable                             | Purpose                                                            | Default                                                 |
-| ------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------- |
-| `ALLOWED_HOSTS`                      | Comma-separated list of allowed Django hosts                       | `""`                                                    |
-| `BUILD_VERSION`                      | Build/version identifier surfaced in the app                       | `""`                                                    |
-| `CACHE_DEFAULT_TIMEOUT`              | Default cache timeout (only when `REDIS_URL` is set)               | production: `900`, staging: `60`, develop: `1`          |
-| `CSRF_TRUSTED_ORIGINS`               | Comma-separated CSRF trusted origins                               | `https://www.nationalarchives.gov.uk`                   |
-| `DATABASE_ENGINE`                    | Django database backend engine                                     | `django.db.backends.postgresql`                         |
-| `DATABASE_HOST`                      | Database host                                                      | _none_                                                  |
-| `DATABASE_NAME`                      | Database name                                                      | _none_                                                  |
-| `DATABASE_PASSWORD`                  | Database password                                                  | _none_                                                  |
-| `DATABASE_PORT`                      | Database port                                                      | `5432`                                                  |
-| `DATABASE_USER`                      | Database user                                                      | _none_                                                  |
-| `DEBUG`                              | Enable Django debug mode                                           | production: `False`, staging: `False`, develop: `False` |
-| `DEFAULT_FROM_EMAIL`                 | Default sender address for outgoing email                          | `wagtail@nationalarchives.gov.uk`                       |
-| `EMAIL_HOST`                         | SMTP host                                                          | _none_                                                  |
-| `EMAIL_HOST_PASSWORD`                | SMTP password                                                      | _none_                                                  |
-| `EMAIL_HOST_USER`                    | SMTP username                                                      | _none_                                                  |
-| `EMAIL_PORT`                         | SMTP port                                                          | `587`                                                   |
-| `EMAIL_USE_TLS`                      | Use TLS for SMTP                                                   | `True`                                                  |
-| `ENVIRONMENT_NAME`                   | Environment label used in UI/email text                            | `production`                                            |
-| `FRONTEND_CACHE_AWS_DISTRIBUTION_ID` | CloudFront distribution id for Wagtail frontend cache invalidation | `""`                                                    |
-| `LOG_LEVEL`                          | Root logger level                                                  | `warning`                                               |
-| `MEDIA_PAGE_URL`                     | Base URL used for live media page links                            | `WAGTAILAPI_MEDIA_BASE_URL`                             |
-| `NEW_LABEL_DISPLAY_FOR_DAYS`         | Number of days to show "new" labels                                | `21`                                                    |
-| `RECORD_DETAILS_CACHE_TIMEOUT`       | Record details cache timeout (seconds)                             | `2592000`                                               |
-| `REDIS_URL`                          | Redis connection URL to enable caching                             | _none_                                                  |
-| `ROSETTA_API_URL`                    | Base URL for the CIIM/Rosetta API client                           | _none_                                                  |
-| `SECRET_KEY`                         | Django secret key (required)                                       | _none_                                                  |
-| `SENTRY_DSN`                         | Sentry DSN                                                         | `""`                                                    |
-| `SENTRY_SAMPLE_RATE`                 | Trace/profile sampling rate                                        | production: `0.1`, staging: `0.25`, develop: `1.0`      |
-| `USE_X_FORWARDED_HOST`               | Trust `X-Forwarded-Host` header                                    | `False`                                                 |
-| `WAGTAILADMIN_BASE_URL`              | Public base URL for Wagtail admin                                  | `""`                                                    |
-| `WAGTAILAPI_AUTHENTICATION`          | Enable authentication on Wagtail API                               | `True`                                                  |
-| `WAGTAILAPI_BASE_URL`                | Public base URL for Wagtail API                                    | `WAGTAILADMIN_BASE_URL`                                 |
-| `WAGTAILAPI_LIMIT_MAX`               | Max API page size (`0` means unlimited/`None`)                     | `0`                                                     |
-| `WAGTAILAPI_MEDIA_BASE_URL`          | Public base URL for media URLs                                     | `""`                                                    |
-| `WAGTAIL_2FA_REQUIRED`               | Require 2FA for Wagtail admin users                                | `True`                                                  |
-| `WAGTAIL_AUTOSAVE_INTERVAL`          | Wagtail editor autosave interval in ms (`0` disables autosave)     | `0`                                                     |
-| `WAGTAIL_HEADLESS_PREVIEW_URL`       | Headless preview URL template                                      | `{SITE_ROOT_URL}/preview/`                              |
+| Variable                             | Purpose                                                                   | Default                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `ALLOWED_HOSTS`                      | Comma-separated list of allowed Django hosts                              | `""`                                                    |
+| `BUILD_VERSION`                      | Build/version identifier surfaced in the app                              | `""`                                                    |
+| `CACHE_DEFAULT_TIMEOUT`              | Default cache timeout (only when `REDIS_URL` is set)                      | production: `900`, staging: `60`, develop: `1`          |
+| `CSRF_TRUSTED_ORIGINS`               | Comma-separated CSRF trusted origins                                      | `https://www.nationalarchives.gov.uk`                   |
+| `DATABASE_ENGINE`                    | Django database backend engine                                            | `django.db.backends.postgresql`                         |
+| `DATABASE_HOST`                      | Database host                                                             | _none_                                                  |
+| `DATABASE_NAME`                      | Database name                                                             | _none_                                                  |
+| `DATABASE_PASSWORD`                  | Database password                                                         | _none_                                                  |
+| `DATABASE_PORT`                      | Database port                                                             | `5432`                                                  |
+| `DATABASE_USER`                      | Database user                                                             | _none_                                                  |
+| `DEBUG`                              | Enable Django debug mode                                                  | production: `False`, staging: `False`, develop: `False` |
+| `DEFAULT_FROM_EMAIL`                 | Default sender address for outgoing email                                 | `wagtail@nationalarchives.gov.uk`                       |
+| `EMAIL_HOST`                         | SMTP host                                                                 | _none_                                                  |
+| `EMAIL_HOST_PASSWORD`                | SMTP password                                                             | _none_                                                  |
+| `EMAIL_HOST_USER`                    | SMTP username                                                             | _none_                                                  |
+| `EMAIL_PORT`                         | SMTP port                                                                 | `587`                                                   |
+| `EMAIL_USE_TLS`                      | Use TLS for SMTP                                                          | `True`                                                  |
+| `ENVIRONMENT_NAME`                   | Environment label used in UI/email text                                   | `production`                                            |
+| `FRONTEND_CACHE_AWS_DISTRIBUTION_ID` | CloudFront distribution id for Wagtail frontend cache invalidation        | `""`                                                    |
+| `LOG_LEVEL`                          | Root logger level                                                         | `warning`                                               |
+| `MEDIA_PAGE_URL`                     | Base URL used for live media page links                                   | `WAGTAILAPI_MEDIA_BASE_URL`                             |
+| `NEW_LABEL_DISPLAY_FOR_DAYS`         | Number of days to show "new" labels                                       | `21`                                                    |
+| `RECORD_DETAILS_CACHE_TIMEOUT`       | Record details cache timeout (seconds)                                    | `2592000`                                               |
+| `REDIS_URL`                          | Redis connection URL to enable caching                                    | _none_                                                  |
+| `ROSETTA_API_URL`                    | Base URL for the CIIM/Rosetta API client                                  | _none_                                                  |
+| `SECRET_KEY`                         | Django secret key (required)                                              | _none_                                                  |
+| `SENTRY_DSN`                         | Sentry DSN                                                                | `""`                                                    |
+| `SENTRY_SAMPLE_RATE`                 | Trace/profile sampling rate                                               | production: `0.1`, staging: `0.25`, develop: `1.0`      |
+| `USE_X_FORWARDED_HOST`               | Trust `X-Forwarded-Host` header                                           | `False`                                                 |
+| `WAGTAILADMIN_BASE_URL`              | Public base URL for Wagtail admin                                         | `""`                                                    |
+| `WAGTAILAPI_AUTHENTICATION`          | Enable authentication on Wagtail API                                      | `True`                                                  |
+| `WAGTAILAPI_BASE_URL`                | Public base URL for Wagtail API                                           | `WAGTAILADMIN_BASE_URL`                                 |
+| `WAGTAILAPI_LIMIT_MAX`               | Max results allowed in Wagtail API response via `?limit=` (0 = unlimited) | `0`                                                     |
+| `WAGTAILAPI_MEDIA_BASE_URL`          | Public base URL for media URLs                                            | `""`                                                    |
+| `WAGTAIL_2FA_REQUIRED`               | Require 2FA for Wagtail admin users                                       | `True`                                                  |
+| `WAGTAIL_AUTOSAVE_INTERVAL`          | Wagtail editor autosave interval in ms (`0` disables autosave)            | `0`                                                     |
+| `WAGTAIL_HEADLESS_PREVIEW_URL`       | Headless preview URL template                                             | `{SITE_ROOT_URL}/preview/`                              |

--- a/app/core/context_processors.py
+++ b/app/core/context_processors.py
@@ -8,5 +8,6 @@ def settings_vars(request):
         "BUILD_VERSION": getattr(settings, "BUILD_VERSION", ""),
         "IMAGE_PAGE_URL": MEDIA_PAGE_URL + "/image/",
         "VIDEO_PAGE_URL": MEDIA_PAGE_URL + "/video/",
-        "AUDIO_PAGE_URL": MEDIA_PAGE_URL + "/video/", # TODO: Update to /audio/ when implemented in frontend
+        "AUDIO_PAGE_URL": MEDIA_PAGE_URL
+        + "/video/",  # TODO: Update to /audio/ when implemented in frontend
     }

--- a/app/core/context_processors.py
+++ b/app/core/context_processors.py
@@ -2,7 +2,11 @@ from django.conf import settings
 
 
 def settings_vars(request):
+    MEDIA_PAGE_URL = getattr(settings, "MEDIA_PAGE_URL", "")
     return {
-        "ENVIRONMENT_NAME": settings.ENVIRONMENT_NAME,
-        "BUILD_VERSION": settings.BUILD_VERSION,
+        "ENVIRONMENT_NAME": getattr(settings, "ENVIRONMENT_NAME", ""),
+        "BUILD_VERSION": getattr(settings, "BUILD_VERSION", ""),
+        "IMAGE_PAGE_URL": MEDIA_PAGE_URL + "/image/",
+        "VIDEO_PAGE_URL": MEDIA_PAGE_URL + "/video/",
+        "AUDIO_PAGE_URL": MEDIA_PAGE_URL + "/video/", # TODO: Update to /audio/ when implemented in frontend
     }

--- a/app/core/templates/wagtailimages/images/edit.html
+++ b/app/core/templates/wagtailimages/images/edit.html
@@ -1,0 +1,11 @@
+{% extends "wagtailimages/images/edit.html" %}
+
+{% block form_content %}
+<div class="w-grid w-grid-cols-1 sm:w-grid-cols-2 w-gap-8">
+    <p>
+        View live image page at: <a href="{{ IMAGE_PAGE_URL }}{{ image.uuid }}" target="_blank" rel="noreferrer">{{ IMAGE_PAGE_URL }}{{ image.uuid }}</a>
+    </p>
+</div>
+{{ block.super }}
+
+{% endblock %}

--- a/app/core/templates/wagtailmedia/media/edit.html
+++ b/app/core/templates/wagtailmedia/media/edit.html
@@ -1,0 +1,18 @@
+{% extends "wagtailmedia/media/edit.html" %}
+
+{% block form_row %}
+    <div class="row row-flush nice-padding">
+        <div class="col10">
+            {% if media.type == "video" %}
+                <p>
+                    View live video page at: <a href="{{ VIDEO_PAGE_URL }}{{ media.uuid }}" target="_blank" rel="noreferrer">{{ VIDEO_PAGE_URL }}{{ media.uuid }}</a>
+                </p>
+            {% else %}
+                <p>
+                    View live audio page at: <a href="{{ AUDIO_PAGE_URL }}{{ media.uuid }}" target="_blank" rel="noreferrer">{{ AUDIO_PAGE_URL }}{{ media.uuid }}</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+    {{ block.super }}
+{% endblock %}

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -241,6 +241,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 MEDIA_ROOT = "/media"
 MEDIA_URL = "media/"
+MEDIA_PAGE_URL = os.getenv("MEDIA_PAGE_URL", WAGTAILADMIN_BASE_URL)
 
 WAGTAILMEDIA = {
     "MEDIA_MODEL": "media.EtnaMedia",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -241,7 +241,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 MEDIA_ROOT = "/media"
 MEDIA_URL = "media/"
-MEDIA_PAGE_URL = os.getenv("MEDIA_PAGE_URL", WAGTAILADMIN_BASE_URL)
+MEDIA_PAGE_URL = os.getenv("MEDIA_PAGE_URL", WAGTAILAPI_MEDIA_BASE_URL)
 
 WAGTAILMEDIA = {
     "MEDIA_MODEL": "media.EtnaMedia",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - WAGTAILADMIN_BASE_URL=http://localhost:8000
       - WAGTAILAPI_BASE_URL=http://host.docker.internal:8000
       - WAGTAILAPI_MEDIA_BASE_URL=https://localhost
+      - MEDIA_PAGE_URL=https://localhost
       - REDIS_URL=redis://redis:6379/0
       - ROSETTA_API_URL=${ROSETTA_API_URL}
       - WAGTAIL_2FA_REQUIRED=False

--- a/templates/wagtailimages/images/add.html
+++ b/templates/wagtailimages/images/add.html
@@ -1,7 +1,0 @@
-{% extends "wagtailimages/images/add.html" %}
-{% load wagtailadmin_tags %}
-
-{% block extra_js %}
-    {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-{% endblock %}

--- a/templates/wagtailimages/images/edit.html
+++ b/templates/wagtailimages/images/edit.html
@@ -1,7 +1,0 @@
-{% extends "wagtailimages/images/edit.html" %}
-{% load wagtailadmin_tags %}
-
-{% block extra_js %}
-    {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-{% endblock %}

--- a/templates/wagtailimages/multiple/add.html
+++ b/templates/wagtailimages/multiple/add.html
@@ -1,7 +1,0 @@
-{% extends "wagtailimages/multiple/add.html" %}
-{% load wagtailadmin_tags %}
-
-{% block extra_js %}
-    {{ block.super }}
-    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-{% endblock %}


### PR DESCRIPTION
This PR adds links in the image and media editing pages to the "live" media pages.

The base URL is set by `MEDIA_PAGE_URL`, and the individual routes are set in `context_processors.py`. TODO added for when audio is correctly displayed under `url.com/audio/` - it is currently `url.com/video/`

<img width="1481" height="745" alt="image" src="https://github.com/user-attachments/assets/2922383e-8d3b-4706-a220-6f8e8b4993d4" />

<img width="1250" height="523" alt="image" src="https://github.com/user-attachments/assets/2859f4bb-cbe1-4641-8c26-b9248b396ea1" />

<img width="1432" height="491" alt="image" src="https://github.com/user-attachments/assets/32d6abc4-2147-4db7-b275-b446015e0d67" />
