### PR TITLE
Feature/education api regions

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -360,7 +360,12 @@ def location_query(location_type, regions=None):
 
 class SessionLocationFilter(BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
-        valid_location_types = {v for v, _ in SessionLocation.LocationType.choices}
+        LT = SessionLocation.LocationType
+        valid_location_types = {
+            LT.NATIONAL_ARCHIVES,
+            LT.ONLINE,
+            LT.YOUR_SCHOOL,
+        }
         valid_regions = {v for v, _ in SessionLocation.Regions.choices}
 
         locations = get_validated_values(request, "location", valid_location_types)
@@ -371,7 +376,6 @@ class SessionLocationFilter(BaseFilterBackend):
         if not locations and not regions:
             return queryset
 
-        LT = SessionLocation.LocationType
         query = Q()
 
         if LT.ONLINE in locations:
@@ -387,7 +391,11 @@ class SessionLocationFilter(BaseFilterBackend):
         if LT.YOUR_SCHOOL in locations:
             query |= location_query(LT.YOUR_SCHOOL, regions)
 
-        return queryset.filter(query).distinct()
+        matching_ids = list(
+            queryset.model.objects.filter(query).values_list("id", flat=True).distinct()
+        )
+
+        return queryset.filter(id__in=matching_ids).distinct()
 
 
 class CurrentOrFutureSessionFilter(BaseFilterBackend):

--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -372,10 +372,13 @@ class SessionLocationFilter(BaseFilterBackend):
             return queryset
 
         LT = SessionLocation.LocationType
-        query = location_query(LT.NATIONAL_ARCHIVES)
+        query = Q()
 
         if LT.ONLINE in locations:
             query |= location_query(LT.ONLINE)
+
+        if LT.NATIONAL_ARCHIVES in locations:
+            query |= location_query(LT.NATIONAL_ARCHIVES)
 
         if regions and not locations:
             query |= location_query(LT.CUSTOM, regions)

--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -381,12 +381,12 @@ class SessionLocationFilter(BaseFilterBackend):
         if LT.NATIONAL_ARCHIVES in locations:
             query |= location_query(LT.NATIONAL_ARCHIVES)
 
-        if regions and not locations:
-            query |= location_query(LT.CUSTOM, regions)
-            query |= location_query(LT.YOUR_SCHOOL, regions)
-
-        if LT.YOUR_SCHOOL in locations:
-            query |= location_query(LT.YOUR_SCHOOL, regions)
+        if regions:
+            if LT.YOUR_SCHOOL in locations:
+                query |= location_query(LT.YOUR_SCHOOL, regions)
+            else:
+                query |= location_query(LT.CUSTOM, regions)
+                query |= location_query(LT.YOUR_SCHOOL, regions)
 
         matching_ids = list(
             queryset.model.objects.filter(query).values_list("id", flat=True).distinct()

--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -381,12 +381,11 @@ class SessionLocationFilter(BaseFilterBackend):
         if LT.NATIONAL_ARCHIVES in locations:
             query |= location_query(LT.NATIONAL_ARCHIVES)
 
-        if regions:
-            if LT.YOUR_SCHOOL in locations:
-                query |= location_query(LT.YOUR_SCHOOL, regions)
-            else:
-                query |= location_query(LT.CUSTOM, regions)
-                query |= location_query(LT.YOUR_SCHOOL, regions)
+        if LT.YOUR_SCHOOL in locations:
+            query |= location_query(LT.YOUR_SCHOOL, regions)
+        elif regions:
+            query |= location_query(LT.CUSTOM, regions)
+            query |= location_query(LT.YOUR_SCHOOL, regions)
 
         matching_ids = list(
             queryset.model.objects.filter(query).values_list("id", flat=True).distinct()

--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -338,19 +338,6 @@ class EducationTaxonomyFilter(BaseFilterBackend):
         return queryset.distinct()
 
 
-def get_validated_values(request, param_name, valid_values, normalize=None):
-    values = get_multivalue_tags_from_name(request, param_name) or []
-    if not values:
-        return set()
-    normalized = {normalize(v) if normalize else v for v in values}
-    invalid = normalized - valid_values
-    if invalid:
-        raise BadRequestError(
-            f"{param_name} must be one or more of: {', '.join(sorted(valid_values))}"
-        )
-    return normalized
-
-
 def location_query(location_type, regions=None):
     q = Q(session_locations__location_type=location_type)
     if regions:
@@ -368,10 +355,20 @@ class SessionLocationFilter(BaseFilterBackend):
         }
         valid_regions = {v for v, _ in SessionLocation.Regions.choices}
 
-        locations = get_validated_values(request, "location", valid_location_types)
-        regions = get_validated_values(
-            request, "region", valid_regions, normalize=lambda v: v.replace("-", "_")
-        )
+        locations = set(get_multivalue_tags_from_name(request, "location") or [])
+        invalid_locations = locations - valid_location_types
+        if invalid_locations:
+            raise BadRequestError(
+                "location must be one or more of: "
+                f"{', '.join(sorted(valid_location_types))}"
+            )
+
+        regions = set(get_multivalue_tags_from_name(request, "region") or [])
+        invalid_regions = regions - valid_regions
+        if invalid_regions:
+            raise BadRequestError(
+                f"region must be one or more of: {', '.join(sorted(valid_regions))}"
+            )
 
         if not locations and not regions:
             return queryset

--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -338,32 +338,53 @@ class EducationTaxonomyFilter(BaseFilterBackend):
         return queryset.distinct()
 
 
+def get_validated_values(request, param_name, valid_values, normalize=None):
+    values = get_multivalue_tags_from_name(request, param_name) or []
+    if not values:
+        return set()
+    normalized = {normalize(v) if normalize else v for v in values}
+    invalid = normalized - valid_values
+    if invalid:
+        raise BadRequestError(
+            f"{param_name} must be one or more of: {', '.join(sorted(valid_values))}"
+        )
+    return normalized
+
+
+def location_query(location_type, regions=None):
+    q = Q(session_locations__location_type=location_type)
+    if regions:
+        q &= Q(session_locations__region__in=regions)
+    return q
+
+
 class SessionLocationFilter(BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
+        valid_location_types = {v for v, _ in SessionLocation.LocationType.choices}
+        valid_regions = {v for v, _ in SessionLocation.Regions.choices}
 
-        locations = get_multivalue_tags_from_name(request, "location")
-        if not locations:
-            return queryset
-
-        valid_location_types = {
-            value for value, _ in SessionLocation.LocationType.choices
-        }
-
-        invalid = set(locations) - set(valid_location_types)
-        if invalid:
-            raise BadRequestError(
-                f"location must be one or more of: {', '.join(sorted(valid_location_types))}"
-            )
-
-        matching_ids = list(
-            queryset.model.objects.filter(
-                session_locations__location_type__in=locations
-            )
-            .values_list("id", flat=True)
-            .distinct()
+        locations = get_validated_values(request, "location", valid_location_types)
+        regions = get_validated_values(
+            request, "region", valid_regions, normalize=lambda v: v.replace("-", "_")
         )
 
-        return queryset.filter(id__in=matching_ids).distinct()
+        if not locations and not regions:
+            return queryset
+
+        LT = SessionLocation.LocationType
+        query = location_query(LT.NATIONAL_ARCHIVES)
+
+        if LT.ONLINE in locations:
+            query |= location_query(LT.ONLINE)
+
+        if regions and not locations:
+            query |= location_query(LT.CUSTOM, regions)
+            query |= location_query(LT.YOUR_SCHOOL, regions)
+
+        if LT.YOUR_SCHOOL in locations:
+            query |= location_query(LT.YOUR_SCHOOL, regions)
+
+        return queryset.filter(query).distinct()
 
 
 class CurrentOrFutureSessionFilter(BaseFilterBackend):

--- a/app/api/tests/test_education_listings.py
+++ b/app/api/tests/test_education_listings.py
@@ -174,6 +174,7 @@ class EducationListingsAPITest(WagtailPageTestCase):
         location_types,
         start_date=None,
         end_date=None,
+        region=None,
     ):
         page = EducationSessionPage(
             title=title,
@@ -203,8 +204,11 @@ class EducationListingsAPITest(WagtailPageTestCase):
                 "location_type": location_type,
                 "duration": "1 hour",
             }
-            if location_type == SessionLocation.LocationType.YOUR_SCHOOL:
-                kwargs["region"] = SessionLocation.Regions.NORTH_WEST
+            if location_type in {
+                SessionLocation.LocationType.YOUR_SCHOOL,
+                SessionLocation.LocationType.CUSTOM,
+            }:
+                kwargs["region"] = region or SessionLocation.Regions.NORTH_WEST
             location_objects.append(SessionLocation(**kwargs))
         page.session_locations = location_objects
 
@@ -367,6 +371,7 @@ class EducationListingsAPITest(WagtailPageTestCase):
             themes=[self.medicine_welfare],
             location_types=[SessionLocation.LocationType.YOUR_SCHOOL],
             start_date=future_date,
+            region=SessionLocation.Regions.NORTH_EAST,
         )
         self.create_session_page(
             slug="mouse-custom-south-west",
@@ -376,6 +381,7 @@ class EducationListingsAPITest(WagtailPageTestCase):
             themes=[self.medicine_welfare],
             location_types=[SessionLocation.LocationType.CUSTOM],
             start_date=future_date,
+            region=SessionLocation.Regions.SOUTH_WEST,
         )
         self.create_session_page(
             slug="mouse-at-tna",

--- a/app/api/tests/test_education_listings.py
+++ b/app/api/tests/test_education_listings.py
@@ -394,7 +394,7 @@ class EducationListingsAPITest(WagtailPageTestCase):
         )
 
         response = self.request_api(
-            "/api/v2/education/sessions/?region=north-east&region=south-west"
+            "/api/v2/education/sessions/?region=north_east&region=south_west"
         )
 
         self.assertEqual(response.status_code, 200, response.content.decode())

--- a/app/api/tests/test_education_listings.py
+++ b/app/api/tests/test_education_listings.py
@@ -354,6 +354,52 @@ class EducationListingsAPITest(WagtailPageTestCase):
         )
         self.assertEqual(past_session_response.json()["meta"]["total_count"], 0)
 
+    def test_sessions_endpoint_region_filter_does_not_default_to_national_archives(
+        self,
+    ):
+        future_date = localdate() + timedelta(days=7)
+
+        self.create_session_page(
+            slug="mouse-school-north-east",
+            title="Mouse school north east",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.YOUR_SCHOOL],
+            start_date=future_date,
+        )
+        self.create_session_page(
+            slug="mouse-custom-south-west",
+            title="Mouse custom south west",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.CUSTOM],
+            start_date=future_date,
+        )
+        self.create_session_page(
+            slug="mouse-at-tna",
+            title="Mouse at TNA",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.NATIONAL_ARCHIVES],
+            start_date=future_date,
+        )
+
+        response = self.request_api(
+            "/api/v2/education/sessions/?region=north-east&region=south-west"
+        )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        response_data = response.json()
+
+        self.assertEqual(response_data["meta"]["total_count"], 2)
+        self.assertEqual(
+            {item["title"] for item in response_data["items"]},
+            {"Mouse school north east", "Mouse custom south west"},
+        )
+
     def test_teaching_resources_listing_page_returns_ordered_search_filters(self):
         self.create_resource_page(
             slug="resources-order-one",

--- a/app/api/tests/test_education_listings.py
+++ b/app/api/tests/test_education_listings.py
@@ -406,6 +406,57 @@ class EducationListingsAPITest(WagtailPageTestCase):
             {"Mouse school north east", "Mouse custom south west"},
         )
 
+    def test_sessions_endpoint_region_filter_combines_with_national_archives(self):
+        future_date = localdate() + timedelta(days=7)
+
+        self.create_session_page(
+            slug="mouse-school-south-east",
+            title="Mouse school south east",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.YOUR_SCHOOL],
+            start_date=future_date,
+            region=SessionLocation.Regions.SOUTH_EAST,
+        )
+        self.create_session_page(
+            slug="mouse-custom-south-west",
+            title="Mouse custom south west",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.CUSTOM],
+            start_date=future_date,
+            region=SessionLocation.Regions.SOUTH_WEST,
+        )
+        self.create_session_page(
+            slug="mouse-at-tna",
+            title="Mouse at TNA",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.NATIONAL_ARCHIVES],
+            start_date=future_date,
+        )
+
+        response = self.request_api(
+            "/api/v2/education/sessions/?region=south_east&region=south_west"
+            "&location=national_archives"
+        )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        response_data = response.json()
+
+        self.assertEqual(response_data["meta"]["total_count"], 3)
+        self.assertEqual(
+            {item["title"] for item in response_data["items"]},
+            {
+                "Mouse school south east",
+                "Mouse custom south west",
+                "Mouse at TNA",
+            },
+        )
+
     def test_teaching_resources_listing_page_returns_ordered_search_filters(self):
         self.create_resource_page(
             slug="resources-order-one",

--- a/app/api/tests/test_education_listings.py
+++ b/app/api/tests/test_education_listings.py
@@ -406,6 +406,44 @@ class EducationListingsAPITest(WagtailPageTestCase):
             {"Mouse school north east", "Mouse custom south west"},
         )
 
+    def test_sessions_endpoint_region_filter_with_your_school_excludes_custom(self):
+        future_date = localdate() + timedelta(days=7)
+
+        self.create_session_page(
+            slug="mouse-school-north-east",
+            title="Mouse school north east",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.YOUR_SCHOOL],
+            start_date=future_date,
+            region=SessionLocation.Regions.NORTH_EAST,
+        )
+        self.create_session_page(
+            slug="mouse-custom-south-west",
+            title="Mouse custom south west",
+            key_stages=[self.ks1],
+            time_periods=[self.early_modern],
+            themes=[self.medicine_welfare],
+            location_types=[SessionLocation.LocationType.CUSTOM],
+            start_date=future_date,
+            region=SessionLocation.Regions.SOUTH_WEST,
+        )
+
+        response = self.request_api(
+            "/api/v2/education/sessions/?region=north_east&region=south_west"
+            "&location=your_school"
+        )
+
+        self.assertEqual(response.status_code, 200, response.content.decode())
+        response_data = response.json()
+
+        self.assertEqual(response_data["meta"]["total_count"], 1)
+        self.assertEqual(
+            {item["title"] for item in response_data["items"]},
+            {"Mouse school north east"},
+        )
+
     def test_sessions_endpoint_region_filter_combines_with_national_archives(self):
         future_date = localdate() + timedelta(days=7)
 

--- a/app/api/urls/education.py
+++ b/app/api/urls/education.py
@@ -29,7 +29,7 @@ class EducationResourcesAPIViewSet(CustomPagesAPIViewSet):
 class EducationSessionsAPIViewSet(CustomPagesAPIViewSet):
     model = EducationSessionPage
     known_query_parameters = CustomPagesAPIViewSet.known_query_parameters.union(
-        ["key_stage", "time_period", "theme", "location"]
+        ["key_stage", "time_period", "theme", "location", "region"]
     )
 
     filter_backends = [

--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -191,6 +191,14 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
             .distinct()
         )
 
+        available_regions = set(
+            SessionLocation.objects.filter(page__in=current_or_future_session_pages)
+            .exclude(region__isnull=True)
+            .exclude(region="")
+            .values_list("region", flat=True)
+            .distinct()
+        )
+
         return {
             "key_stage": KeyStageSerializer(
                 KeyStage.objects.filter(id__in=key_stages).order_by("stage", "name"),
@@ -213,6 +221,14 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
                 }
                 for value, label in SessionLocation.LocationType.choices
                 if value in available_location_types
+            ],
+            "regions": [
+                {
+                    "name": label,
+                    "slug": value.replace("_", "-"),
+                }
+                for value, label in SessionLocation.Regions.choices
+                if value in available_regions
             ],
         }
 

--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -225,7 +225,7 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
             "regions": [
                 {
                     "name": label,
-                    "slug": value.replace("_", "-"),
+                    "slug": value,
                 }
                 for value, label in SessionLocation.Regions.choices
                 if value in available_regions

--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -186,6 +186,7 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
         available_location_types = set(
             SessionLocation.objects.filter(page__in=current_or_future_session_pages)
             .exclude(location_type__isnull=True)
+            .exclude(location_type=SessionLocation.LocationType.CUSTOM)
             .values_list("location_type", flat=True)
             .distinct()
         )


### PR DESCRIPTION


https://ds-education-prototype-9a0169fe9b4e.herokuapp.com/locations

- Remove custom from the list of the search_filters location in http://localhost:8000/api/v2/pages/695/
- Add another entry into search_filters of regions which returns all the regions used on published, future and current sessions
- Allow me to pass a query string of ?region=south-west&region=north-east etc.
- Follow the logic from the linked prototype at the top of this message chain

https://national-archives.atlassian.net/wiki/spaces/WM/pages/1942323242/Listing+API+and+filters