### PR TITLE
Remove extra validation for keystage to allow drafts to work

### DIFF
--- a/app/education/models/mixins.py
+++ b/app/education/models/mixins.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
 from wagtail.admin.panels import InlinePanel
 
@@ -34,11 +33,6 @@ class EducationTaxonomyMixin:
                 "theme__name"
             )
         ]
-
-    def clean(self):
-        super().clean()
-        if not self.education_keystage_tags.exists():
-            raise ValidationError("At least one key stage is required.")
 
     @staticmethod
     def taxonomy_promote_panels():


### PR DESCRIPTION
I did think it was overkill, and forgot to test on drafts, only tested on publish, oops - can confirm it works for drafts now too.

<img width="511" height="118" alt="Screenshot 2026-07-14 at 15 48 51" src="https://github.com/user-attachments/assets/2af0c31a-2a41-4de4-84a7-f1eff4bc7556" />
