### PR TITLE
Education - consistency in naming re. region

### DIFF
--- a/app/education/models/listings.py
+++ b/app/education/models/listings.py
@@ -222,7 +222,7 @@ class EducationSessionsListingPage(BasePageWithRequiredIntro):
                 for value, label in SessionLocation.LocationType.choices
                 if value in available_location_types
             ],
-            "regions": [
+            "region": [
                 {
                     "name": label,
                     "slug": value,


### PR DESCRIPTION
Really small change request:

In http://localhost:8000/api/v2/pages/695/, under search_filters, could we change regions to region (singular) to match the others?