### PR TITLE
Add DATA_UPLOAD_MAX_NUMBER_FIELDS as an env var setting (default 10000)

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -158,6 +158,8 @@ WAGTAIL_AUTOSAVE_INTERVAL = int(
     os.getenv("WAGTAIL_AUTOSAVE_INTERVAL", "0")
 )  # Disabled (0) by default
 
+DATA_UPLOAD_MAX_NUMBER_FIELDS = int(os.getenv("DATA_UPLOAD_MAX_NUMBER_FIELDS", 10000))
+
 # django-allauth configuration
 ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]


### PR DESCRIPTION
Needed as there are pages that hit this limit, so we want to override this limit.